### PR TITLE
refactor: alternate Versions strategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,17 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${maven-jar-plugin.version}</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
+            </archive>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring-boot.version}</version>

--- a/rest/src/main/java/io/syndesis/rest/Version.java
+++ b/rest/src/main/java/io/syndesis/rest/Version.java
@@ -15,14 +15,17 @@
  */
 package io.syndesis.rest;
 
+import java.util.Optional;
+
 public final class Version {
 
     private Version() {
     }
 
     public static String getVersion() {
-        return "${project.version}";
-    }
+        final String packageVersion = Version.class.getPackage().getImplementationVersion();
 
+        return Optional.ofNullable(packageVersion).orElse("DEVELOPMENT");
+    }
 
 }


### PR DESCRIPTION
Instead of templating/resource filtering this changes the Version to
return package implementation version when packaged or fixed string
`DEVELOPMENT` when not.