### PR TITLE
Use basepom as parent instead of Sonatype OSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,8 @@ crashlytics-build.properties
 # OS X files
 .DS_Store
 
+# PMD and Checkstyle config files (auto generated)
+.pmd
+.pmdruleset.xml
+.checkstyle
 

--- a/connector-catalog/pom.xml
+++ b/connector-catalog/pom.xml
@@ -32,6 +32,10 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.camel</groupId>
+      <artifactId>camel-catalog</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
       <artifactId>camel-catalog-connector</artifactId>
     </dependency>
     <dependency>
@@ -39,8 +43,16 @@
       <artifactId>camel-catalog-maven</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/connector-catalog/src/main/java/io/syndesis/connector/catalog/ConnectorCatalog.java
+++ b/connector-catalog/src/main/java/io/syndesis/connector/catalog/ConnectorCatalog.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 public class ConnectorCatalog {
 
-    private final static Logger log = LoggerFactory.getLogger(ConnectorCatalog.class);
+    private static final Logger log = LoggerFactory.getLogger(ConnectorCatalog.class);
 
     private final CamelConnectorCatalog connectorCatalog;
     private final CamelCatalog camelCatalog;

--- a/controllers/pom.xml
+++ b/controllers/pom.xml
@@ -32,6 +32,16 @@
   <dependencies>
     <dependency>
       <groupId>io.syndesis</groupId>
+      <artifactId>core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
       <artifactId>dao</artifactId>
     </dependency>
 
@@ -48,6 +58,36 @@
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>project-generator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/controllers/src/main/java/io/syndesis/controllers/integration/DemoHandlerProvider.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/DemoHandlerProvider.java
@@ -15,9 +15,13 @@
  */
 package io.syndesis.controllers.integration;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import io.syndesis.model.integration.Integration;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -34,7 +38,7 @@ public class DemoHandlerProvider implements StatusChangeHandlerProvider {
                             );
     }
 
-    class DemoHandler implements StatusChangeHandler {
+    static class DemoHandler implements StatusChangeHandler {
         private final Integration.Status status;
         private final long waitMillis;
 

--- a/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
@@ -16,8 +16,15 @@
 package io.syndesis.controllers.integration;
 
 import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -28,6 +35,7 @@ import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.ChangeEvent;
 import io.syndesis.model.Kind;
 import io.syndesis.model.integration.Integration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +56,7 @@ public class IntegrationController {
     private ExecutorService executor;
     private ScheduledExecutorService scheduler;
 
-    private final static long SCHEDULE_INTERVAL_IN_SECONDS = 60;
+    private static final long SCHEDULE_INTERVAL_IN_SECONDS = 60;
 
     @Autowired
     public IntegrationController(DataManager dataManager, EventBus eventBus, StatusChangeHandlerProvider handlerFactory) {

--- a/controllers/src/main/java/io/syndesis/controllers/integration/NoopHandlerProvider.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/NoopHandlerProvider.java
@@ -15,9 +15,14 @@
  */
 package io.syndesis.controllers.integration;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import io.syndesis.model.integration.Integration;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
@@ -16,12 +16,20 @@
 package io.syndesis.controllers.integration.online;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
+import io.fabric8.funktion.model.StepKinds;
 import io.syndesis.controllers.integration.StatusChangeHandlerProvider;
-import io.syndesis.core.SyndesisServerException;
 import io.syndesis.core.Names;
+import io.syndesis.core.SyndesisServerException;
 import io.syndesis.core.Tokens;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.github.GitHubService;
@@ -34,7 +42,7 @@ import io.syndesis.openshift.OpenShiftService;
 import io.syndesis.project.converter.GenerateProjectRequest;
 import io.syndesis.project.converter.ImmutableGenerateProjectRequest;
 import io.syndesis.project.converter.ProjectGenerator;
-import io.fabric8.funktion.model.StepKinds;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +57,7 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
     private final GitHubService gitHubService;
     private final ProjectGenerator projectConverter;
 
-    private final static Logger log = LoggerFactory.getLogger(ActivateHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(ActivateHandler.class);
 
     ActivateHandler(DataManager dataManager, OpenShiftService openShiftService,
                     GitHubService gitHubService, ProjectGenerator projectConverter) {

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/DeactivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/DeactivateHandler.java
@@ -15,14 +15,17 @@
  */
 package io.syndesis.controllers.integration.online;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.syndesis.controllers.integration.StatusChangeHandlerProvider;
 import io.syndesis.core.Tokens;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.openshift.OpenShiftDeployment;
 import io.syndesis.openshift.OpenShiftService;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-
-import java.util.*;
 
 public class DeactivateHandler implements StatusChangeHandlerProvider.StatusChangeHandler {
 

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/DeleteHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/DeleteHandler.java
@@ -15,13 +15,14 @@
  */
 package io.syndesis.controllers.integration.online;
 
+import java.util.Collections;
+import java.util.Set;
+
 import io.syndesis.controllers.integration.StatusChangeHandlerProvider;
 import io.syndesis.core.Tokens;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.openshift.OpenShiftDeployment;
 import io.syndesis.openshift.OpenShiftService;
-
-import java.util.*;
 
 public class DeleteHandler implements StatusChangeHandlerProvider.StatusChangeHandler {
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,13 +35,43 @@
     <!-- ===================================================================================== -->
 
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-spring-security-adapter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-adapter-core</artifactId>
     </dependency>
 
     <!-- Testing -->

--- a/core/src/main/java/io/syndesis/core/EventBus.java
+++ b/core/src/main/java/io/syndesis/core/EventBus.java
@@ -41,24 +41,24 @@ public interface EventBus {
      * @param handler the callback that will receive the events.
      * @return the previously registered subscription with that id or null.
      */
-    public Subscription subscribe(String subscriberId, Subscription handler);
+    Subscription subscribe(String subscriberId, Subscription handler);
 
     /**
      * Removes a subscription from the event bus.
      * @param subscriberId unique id for the subscription.
      * @return the previously registered subscription with that id or null if not registered.
      */
-    public Subscription unsubscribe(String subscriberId);
+    Subscription unsubscribe(String subscriberId);
 
     /**
      * Send an event to all subscribers in a bus.  The event MAY get delivered to the subscriptions
      * after this call returns.
      */
-    public void broadcast(String event, String data);
+    void broadcast(String event, String data);
 
     /**
      * Send an event to a specific subscriber on the bus.  The event MAY get delivered to the subscriptions
      * after this call returns.
      */
-    public void send(String subscriberId, String event, String data);
+    void send(String subscriberId, String event, String data);
 }

--- a/core/src/main/java/io/syndesis/core/KeyGenerator.java
+++ b/core/src/main/java/io/syndesis/core/KeyGenerator.java
@@ -28,9 +28,9 @@ import java.util.Random;
  */
 public class KeyGenerator {
 
-    static private long lastTimestamp = System.currentTimeMillis();
-    static private final byte randomnessByte;
-    static private long randomnessLong;
+    private static long lastTimestamp = System.currentTimeMillis();
+    private static final byte randomnessByte;
+    private static long randomnessLong;
 
     private KeyGenerator() {}
 
@@ -40,7 +40,7 @@ public class KeyGenerator {
         randomnessLong = random.nextLong();
     }
 
-    static public String createKey() {
+    public static String createKey() {
         long now = System.currentTimeMillis();
 
         ByteBuffer buffer = ByteBuffer.wrap(new byte[8 + 1 + 8]);
@@ -55,7 +55,7 @@ public class KeyGenerator {
         }
     }
 
-    protected synchronized static long getRandomPart(long timeStamp) {
+    protected static synchronized long getRandomPart(long timeStamp) {
         if( timeStamp == lastTimestamp ) {
             // increment the randomness.
             randomnessLong ++;

--- a/core/src/main/java/io/syndesis/core/SyndesisServerException.java
+++ b/core/src/main/java/io/syndesis/core/SyndesisServerException.java
@@ -17,41 +17,41 @@ package io.syndesis.core;
 
 public class SyndesisServerException extends RuntimeException {
 
-	private static final long serialVersionUID = 3476018743129184217L;
+    private static final long serialVersionUID = 3476018743129184217L;
 
-	public SyndesisServerException() {
-		super();
-	}
+    public SyndesisServerException() {
+        super();
+    }
 
-	public SyndesisServerException(String message, Throwable cause, boolean enableSuppression,
+    public SyndesisServerException(String message, Throwable cause, boolean enableSuppression,
                                    boolean writableStackTrace) {
-		super(message, cause, enableSuppression, writableStackTrace);
-	}
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
 
-	public SyndesisServerException(String message, Throwable cause) {
-		super(message, cause);
-	}
+    public SyndesisServerException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
-	public SyndesisServerException(String message) {
-		super(message);
-	}
+    public SyndesisServerException(String message) {
+        super(message);
+    }
 
-	public SyndesisServerException(Throwable cause) {
-		super(cause);
-	}
+    public SyndesisServerException(Throwable cause) {
+        super(cause);
+    }
 
-	public static RuntimeException launderThrowable(Throwable cause) {
-	    return launderThrowable("An error has occurred.", cause);
-	  }
+    public static RuntimeException launderThrowable(Throwable cause) {
+        return launderThrowable("An error has occurred.", cause);
+      }
 
-	  public static RuntimeException launderThrowable(String message, Throwable cause) {
-	    if (cause instanceof RuntimeException) {
-	      return ((RuntimeException) cause);
-	    } else if (cause instanceof Error) {
-	      throw ((Error) cause);
-	    } else {
-	      throw new SyndesisServerException(message, cause);
-	    }
-	  }
+      public static RuntimeException launderThrowable(String message, Throwable cause) {
+        if (cause instanceof RuntimeException) {
+          return ((RuntimeException) cause);
+        } else if (cause instanceof Error) {
+          throw ((Error) cause);
+        } else {
+          throw new SyndesisServerException(message, cause);
+        }
+      }
 
 }

--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -48,13 +48,38 @@
     </dependency>
 
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>
@@ -77,6 +102,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -88,17 +119,18 @@
     </resources>
 
     <plugins>
+
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.2</version>
         <configuration>
           <delimiters>
             <delimiter>@</delimiter>
           </delimiters>
         </configuration>
       </plugin>
+
     </plugins>
+
   </build>
 
 </project>

--- a/dao/src/main/java/io/syndesis/dao/ConnectionDao.java
+++ b/dao/src/main/java/io/syndesis/dao/ConnectionDao.java
@@ -22,7 +22,7 @@ import io.syndesis.model.connection.Connection;
 public interface ConnectionDao extends DataAccessObject<Connection> {
 
     @Override
-    default public Class<Connection> getType() {
+    default Class<Connection> getType() {
         return Connection.class;
     }
 

--- a/dao/src/main/java/io/syndesis/dao/ConnectorDao.java
+++ b/dao/src/main/java/io/syndesis/dao/ConnectorDao.java
@@ -22,7 +22,7 @@ import io.syndesis.model.connection.Connector;
 public interface ConnectorDao extends DataAccessObject<Connector> {
 
     @Override
-    default public Class<Connector> getType() {
+    default Class<Connector> getType() {
         return Connector.class;
     }
 

--- a/dao/src/main/java/io/syndesis/dao/IntegrationDao.java
+++ b/dao/src/main/java/io/syndesis/dao/IntegrationDao.java
@@ -22,7 +22,7 @@ import io.syndesis.model.integration.Integration;
 public interface IntegrationDao extends DataAccessObject<Integration> {
 
     @Override
-    default public Class<Integration> getType() {
+    default Class<Integration> getType() {
         return Integration.class;
     }
 

--- a/dao/src/main/java/io/syndesis/dao/IntegrationPatternDao.java
+++ b/dao/src/main/java/io/syndesis/dao/IntegrationPatternDao.java
@@ -22,7 +22,7 @@ import io.syndesis.model.integration.IntegrationPattern;
 public interface IntegrationPatternDao extends DataAccessObject<IntegrationPattern> {
 
     @Override
-    default public Class<IntegrationPattern> getType() {
+    default Class<IntegrationPattern> getType() {
         return IntegrationPattern.class;
     }
 

--- a/dao/src/main/java/io/syndesis/dao/UserDao.java
+++ b/dao/src/main/java/io/syndesis/dao/UserDao.java
@@ -22,7 +22,7 @@ import io.syndesis.model.user.User;
 public interface UserDao extends DataAccessObject<User> {
 
     @Override
-    default public Class<User> getType() {
+    default Class<User> getType() {
         return User.class;
     }
 

--- a/dao/src/main/java/io/syndesis/dao/init/ReadApiClientData.java
+++ b/dao/src/main/java/io/syndesis/dao/init/ReadApiClientData.java
@@ -27,18 +27,20 @@ import io.syndesis.core.Json;
 
 public class ReadApiClientData {
 
-	/**
-	 *
-	 * @param fileName
-	 * @return
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws IOException
-	 */
-	public List<ModelData> readDataFromFile(String fileName) throws JsonParseException, JsonMappingException, IOException {
-		InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName);
-		if (is==null) throw new FileNotFoundException("Cannot find file " + fileName + " on classpath");
-		return Json.mapper().readValue(is, new TypeReference<List<ModelData>>(){});
-	}
+    /**
+     *
+     * @param fileName
+     * @return
+     * @throws JsonParseException
+     * @throws JsonMappingException
+     * @throws IOException
+     */
+    public List<ModelData> readDataFromFile(String fileName) throws JsonParseException, JsonMappingException, IOException {
+        InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName);
+        if (is==null) {
+            throw new FileNotFoundException("Cannot find file " + fileName + " on classpath");
+        }
+        return Json.mapper().readValue(is, new TypeReference<List<ModelData>>(){});
+    }
 
 }

--- a/dao/src/test/java/io/syndesis/dao/ReadApiClientDataTest.java
+++ b/dao/src/test/java/io/syndesis/dao/ReadApiClientDataTest.java
@@ -39,44 +39,44 @@ public class ReadApiClientDataTest {
 
     private final static ObjectMapper mapper = Json.mapper();
 
-	@Test
-	public void deserializeModelDataTest() throws IOException {
+    @Test
+    public void deserializeModelDataTest() throws IOException {
 
-	    Integration integrationIn = new Integration.Builder()
-	                .desiredStatus(Integration.Status.Activated)
-	                .tags(new TreeSet<String>(Arrays.asList("tag1", "tag2")))
-	                .createdDate(new Date())
-	                .build();
-	    String integrationJson = mapper.writeValueAsString(integrationIn);
-	    System.out.println(integrationJson);
-	    Integration integrationOut = mapper.readValue(integrationJson, Integration.class);
-	    Assert.assertEquals(integrationIn.getDesiredStatus(), integrationOut.getDesiredStatus());
+        Integration integrationIn = new Integration.Builder()
+                    .desiredStatus(Integration.Status.Activated)
+                    .tags(new TreeSet<String>(Arrays.asList("tag1", "tag2")))
+                    .createdDate(new Date())
+                    .build();
+        String integrationJson = mapper.writeValueAsString(integrationIn);
+        System.out.println(integrationJson);
+        Integration integrationOut = mapper.readValue(integrationJson, Integration.class);
+        Assert.assertEquals(integrationIn.getDesiredStatus(), integrationOut.getDesiredStatus());
 
-		//serialize
-		ConnectorGroup cg = new ConnectorGroup.Builder().id("label").name("label").build();
-		ModelData mdIn = new ModelData(Kind.ConnectorGroup, cg);
-		Assert.assertEquals("{\"id\":\"label\",\"name\":\"label\"}", mdIn.getDataAsJson());
+        //serialize
+        ConnectorGroup cg = new ConnectorGroup.Builder().id("label").name("label").build();
+        ModelData mdIn = new ModelData(Kind.ConnectorGroup, cg);
+        Assert.assertEquals("{\"id\":\"label\",\"name\":\"label\"}", mdIn.getDataAsJson());
 
-		//deserialize
-		String json = mapper.writeValueAsString(mdIn);
-		ModelData mdOut = mapper.readValue(json, ModelData.class);
-		Assert.assertEquals("{\"id\":\"label\",\"name\":\"label\"}", mdOut.getDataAsJson());
-	}
+        //deserialize
+        String json = mapper.writeValueAsString(mdIn);
+        ModelData mdOut = mapper.readValue(json, ModelData.class);
+        Assert.assertEquals("{\"id\":\"label\",\"name\":\"label\"}", mdOut.getDataAsJson());
+    }
 
-	@Test
-	public void loadApiClientDataTest() throws IOException {
-		List<ModelData> modelDataList = new ReadApiClientData().readDataFromFile("io/syndesis/dao/deployment.json");
-		System.out.println("Found " + modelDataList.size() + " entities.");
-		Assert.assertTrue("We should find some ModelData", 0 < modelDataList.size());
+    @Test
+    public void loadApiClientDataTest() throws IOException {
+        List<ModelData> modelDataList = new ReadApiClientData().readDataFromFile("io/syndesis/dao/deployment.json");
+        System.out.println("Found " + modelDataList.size() + " entities.");
+        Assert.assertTrue("We should find some ModelData", 0 < modelDataList.size());
         List<Connector> connectorList = new ArrayList<>();
-		for (ModelData md : modelDataList) {
-			if (md.getKind() == Kind.Connector) {
-				Connector cg = (Connector) md.getData();
-				connectorList.add(cg);
-			}
-		}
-		System.out.println("Found " + connectorList.size() + " Connectors");
-		Assert.assertTrue("We should find some Connectors", 0 < connectorList.size());
-	}
+        for (ModelData md : modelDataList) {
+            if (md.getKind() == Kind.Connector) {
+                Connector cg = (Connector) md.getData();
+                connectorList.add(cg);
+            }
+        }
+        System.out.println("Found " + connectorList.size() + " Connectors");
+        Assert.assertTrue("We should find some Connectors", 0 < connectorList.size());
+    }
 
 }

--- a/github/pom.xml
+++ b/github/pom.xml
@@ -44,6 +44,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
@@ -72,4 +82,22 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>org.keycloak:keycloak-spring-security-adapter</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
 </project>

--- a/github/src/main/java/io/syndesis/github/GitHubConfiguration.java
+++ b/github/src/main/java/io/syndesis/github/GitHubConfiguration.java
@@ -17,10 +17,13 @@ package io.syndesis.github;
 
 import io.syndesis.github.backend.ExtendedContentsService;
 import io.syndesis.github.backend.KeycloakTokenAwareGitHubClient;
+
 import org.eclipse.egit.github.core.service.RepositoryService;
 import org.eclipse.egit.github.core.service.UserService;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * Configured in spring.factories so that tis configuration is automatically picked

--- a/github/src/main/java/io/syndesis/github/GitHubService.java
+++ b/github/src/main/java/io/syndesis/github/GitHubService.java
@@ -46,6 +46,6 @@ public interface GitHubService {
      * @return the repositories clone URL or null if it does not exist
      * @throws IOException if interaction with GitHub fails.
      */
-    public String getCloneURL(String repoName) throws IOException;
+    String getCloneURL(String repoName) throws IOException;
 
 }

--- a/github/src/main/java/io/syndesis/github/GitHubServiceImpl.java
+++ b/github/src/main/java/io/syndesis/github/GitHubServiceImpl.java
@@ -21,7 +21,11 @@ import java.util.List;
 import java.util.Map;
 
 import io.syndesis.github.backend.ExtendedContentsService;
-import org.eclipse.egit.github.core.*;
+
+import org.eclipse.egit.github.core.Repository;
+import org.eclipse.egit.github.core.RepositoryContents;
+import org.eclipse.egit.github.core.RepositoryHook;
+import org.eclipse.egit.github.core.User;
 import org.eclipse.egit.github.core.client.RequestException;
 import org.eclipse.egit.github.core.service.RepositoryService;
 import org.eclipse.egit.github.core.service.UserService;

--- a/github/src/main/java/io/syndesis/github/backend/ExtendedContentsService.java
+++ b/github/src/main/java/io/syndesis/github/backend/ExtendedContentsService.java
@@ -21,7 +21,8 @@ import org.eclipse.egit.github.core.IRepositoryIdProvider;
 import org.eclipse.egit.github.core.client.GitHubClient;
 import org.eclipse.egit.github.core.service.ContentsService;
 
-import static org.eclipse.egit.github.core.client.IGitHubConstants.*;
+import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_CONTENTS;
+import static org.eclipse.egit.github.core.client.IGitHubConstants.SEGMENT_REPOS;
 
 /**
  * Extend ContentsService for creating and updating files
@@ -32,27 +33,28 @@ public class ExtendedContentsService extends ContentsService {
         super(client);
     }
 
-	public void createFile(IRepositoryIdProvider repository, String message, String path, byte[] content) throws IOException {
-		StringBuilder uri = createContentsUri(repository, path);
-		client.put(uri.toString(), new FileContent(path, message, content, null),null /* no response serialization */);
-	}
-
-	public void updateFile(IRepositoryIdProvider repository, String message, String path, String sha, byte[] content) throws IOException {
-		StringBuilder uri = createContentsUri(repository, path);
-		client.put(uri.toString(), new FileContent(path, message, content, sha),null /* no response serialization */);
+    public void createFile(IRepositoryIdProvider repository, String message, String path, byte[] content) throws IOException {
+        StringBuilder uri = createContentsUri(repository, path);
+        client.put(uri.toString(), new FileContent(path, message, content, null),null /* no response serialization */);
     }
 
-	private StringBuilder createContentsUri(IRepositoryIdProvider repository, String path) {
-		String id = getId(repository);
-		StringBuilder uri = new StringBuilder(SEGMENT_REPOS);
-		uri.append('/').append(id);
-		uri.append(SEGMENT_CONTENTS);
-		if (path != null && path.length() > 0) {
-			if (path.charAt(0) != '/')
-				uri.append('/');
-			uri.append(path);
-		}
-		return uri;
-	}
+    public void updateFile(IRepositoryIdProvider repository, String message, String path, String sha, byte[] content) throws IOException {
+        StringBuilder uri = createContentsUri(repository, path);
+        client.put(uri.toString(), new FileContent(path, message, content, sha),null /* no response serialization */);
+    }
+
+    private StringBuilder createContentsUri(IRepositoryIdProvider repository, String path) {
+        String id = getId(repository);
+        StringBuilder uri = new StringBuilder(SEGMENT_REPOS);
+        uri.append('/').append(id);
+        uri.append(SEGMENT_CONTENTS);
+        if (path != null && path.length() > 0) {
+            if (path.charAt(0) != '/') {
+                uri.append('/');
+            }
+            uri.append(path);
+        }
+        return uri;
+    }
 }
 

--- a/github/src/main/java/io/syndesis/github/backend/FileContent.java
+++ b/github/src/main/java/io/syndesis/github/backend/FileContent.java
@@ -48,7 +48,7 @@ class FileContent {
         if (content == null) {
             return null;
         }
-        return new String(Base64.getEncoder().encode(content));
+        return Base64.getEncoder().encodeToString(content);
     }
 
     public String getContent() {

--- a/github/src/main/java/io/syndesis/github/backend/KeycloakTokenAwareGitHubClient.java
+++ b/github/src/main/java/io/syndesis/github/backend/KeycloakTokenAwareGitHubClient.java
@@ -39,12 +39,12 @@ public class KeycloakTokenAwareGitHubClient extends GitHubClient {
     @Override
     protected String configureUri(final String uri) {
         return uri;
-	}
+    }
 
     @Override
     protected HttpURLConnection configureRequest(final HttpURLConnection request) {
         super.configureRequest(request);
         request.setRequestProperty(HEADER_AUTHORIZATION, "Bearer " + Tokens.getAuthenticationToken());
-		return request;
-	}
+        return request;
+    }
 }

--- a/jsondb/pom.xml
+++ b/jsondb/pom.xml
@@ -39,6 +39,11 @@
 
     <dependency>
       <groupId>io.syndesis</groupId>
+      <artifactId>model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
       <artifactId>dao</artifactId>
     </dependency>
 
@@ -59,16 +64,34 @@
       <artifactId>jdbi</artifactId>
     </dependency>
 
-    <!-- for the very handy Base64 that supports the ordered option -->
     <dependency>
-      <groupId>org.keycloak</groupId>
-      <artifactId>keycloak-common</artifactId>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
-      <optional>true</optional>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
 
     <!-- For test resource -->
@@ -81,7 +104,6 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.16.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/jsondb/src/main/java/io/syndesis/jsondb/JsonDB.java
+++ b/jsondb/src/main/java/io/syndesis/jsondb/JsonDB.java
@@ -15,7 +15,12 @@
  */
 package io.syndesis.jsondb;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.function.Consumer;
 
 /**

--- a/jsondb/src/main/java/io/syndesis/jsondb/dao/JsonDbDao.java
+++ b/jsondb/src/main/java/io/syndesis/jsondb/dao/JsonDbDao.java
@@ -33,7 +33,7 @@ import io.syndesis.model.WithId;
 /**
  * Implements a DataAccessObject using the {@see: JsonDB}.
  */
-abstract public class JsonDbDao<T extends WithId> implements DataAccessObject<T> {
+public abstract class JsonDbDao<T extends WithId> implements DataAccessObject<T> {
 
     private final JsonDB jsondb;
 

--- a/jsondb/src/main/java/io/syndesis/jsondb/impl/SqlJsonDB.java
+++ b/jsondb/src/main/java/io/syndesis/jsondb/impl/SqlJsonDB.java
@@ -15,20 +15,6 @@
  */
 package io.syndesis.jsondb.impl;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import io.syndesis.core.EventBus;
-import io.syndesis.core.KeyGenerator;
-import io.syndesis.jsondb.JsonDBException;
-import io.syndesis.jsondb.GetOptions;
-import io.syndesis.jsondb.JsonDB;
-
-import org.skife.jdbi.v2.*;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import org.skife.jdbi.v2.util.IntegerColumnMapper;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -39,6 +25,25 @@ import java.util.LinkedList;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+import io.syndesis.core.EventBus;
+import io.syndesis.core.KeyGenerator;
+import io.syndesis.jsondb.GetOptions;
+import io.syndesis.jsondb.JsonDB;
+import io.syndesis.jsondb.JsonDBException;
+
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.PreparedBatch;
+import org.skife.jdbi.v2.ResultIterator;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.skife.jdbi.v2.util.IntegerColumnMapper;
 
 /**
  * Implements the JsonDB via DBI/JDBC
@@ -192,7 +197,7 @@ public class SqlJsonDB implements JsonDB {
         private long batchSize;
         private PreparedBatch insertBatch;
 
-        public BatchManager(Handle dbi) {
+        private BatchManager(Handle dbi) {
             this.dbi = dbi;
         }
 
@@ -320,7 +325,7 @@ public class SqlJsonDB implements JsonDB {
         return dbi.update(sql, params.toArray());
     }
 
-    static private LinkedList<String> getAllParentPaths(String baseDBPath) {
+    private static LinkedList<String> getAllParentPaths(String baseDBPath) {
         LinkedList<String> params = new LinkedList<String>();
         Pattern compile = Pattern.compile("/[^/]*$");
         String current = Strings.trimSuffix(baseDBPath, "/");

--- a/jsondb/src/main/java/io/syndesis/jsondb/impl/Strings.java
+++ b/jsondb/src/main/java/io/syndesis/jsondb/impl/Strings.java
@@ -20,28 +20,28 @@ package io.syndesis.jsondb.impl;
  */
 public class Strings {
 
-    static public String prefix(String base, String prefix) {
+    public static String prefix(String base, String prefix) {
         if( !base.startsWith(prefix) ) {
             return prefix + base;
         }
         return base;
     }
 
-    static public String suffix(String base, String suffix) {
+    public static String suffix(String base, String suffix) {
         if( !base.endsWith(suffix) ) {
             return base+suffix;
         }
         return base;
     }
 
-    static public String trimPrefix(String value, String prefix) {
+    public static String trimPrefix(String value, String prefix) {
         if( value.startsWith(prefix) ) {
             return value.substring(prefix.length());
         }
         return value;
     }
 
-    static public String trimSuffix(String value, String suffix) {
+    public static String trimSuffix(String value, String suffix) {
         if( value.endsWith(suffix) ) {
             return value.substring(0, value.length()-suffix.length());
         }

--- a/jsondb/src/main/java/io/syndesis/jsondb/rest/JsonDBResource.java
+++ b/jsondb/src/main/java/io/syndesis/jsondb/rest/JsonDBResource.java
@@ -15,20 +15,28 @@
  */
 package io.syndesis.jsondb.rest;
 
-import io.syndesis.jsondb.GetOptions;
-import io.syndesis.jsondb.JsonDB;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
-
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.function.Consumer;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import io.syndesis.jsondb.GetOptions;
+import io.syndesis.jsondb.JsonDB;
 
 /**
  * Provides a REST API to read/update a Key/Value database presented to the user a

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -38,18 +38,18 @@
     <!-- ===================================================================================== -->
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-validator</artifactId>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8.funktion</groupId>
+      <artifactId>funktion-model</artifactId>
     </dependency>
 
     <dependency>
@@ -58,8 +58,18 @@
     </dependency>
 
     <dependency>
-      <groupId>io.fabric8.funktion</groupId>
-      <artifactId>funktion-model</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
     </dependency>
 
         <!-- === Test ============================================================================ -->
@@ -75,6 +85,23 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>io.fabric8.funktion:funktion-model</ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/model/src/main/java/io/syndesis/model/ImmutablesStyle.java
+++ b/model/src/main/java/io/syndesis/model/ImmutablesStyle.java
@@ -20,13 +20,12 @@ import org.immutables.value.Value;
 @Value.Style(
     jdkOnly = true,
     visibility = Value.Style.ImplementationVisibility.PACKAGE,
-    defaultAsDefault = true,
     headerComments = true,
     depluralize = true,
     typeAbstract = "*",
     allParameters = true,
     from = "createFrom",
     validationMethod = Value.Style.ValidationMethod.VALIDATION_API
-)
+    )
 public @interface ImmutablesStyle {
 }

--- a/model/src/main/java/io/syndesis/model/WithProperties.java
+++ b/model/src/main/java/io/syndesis/model/WithProperties.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.syndesis.model.connection.ConfigurationProperty;
 import io.syndesis.model.connection.Connector;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -26,6 +28,7 @@ import java.util.stream.Collectors;
 
 public interface WithProperties {
 
+    @SuppressFBWarnings("SE_BAD_FIELD")
     Map<String, ConfigurationProperty> getProperties();
 
     @JsonIgnore

--- a/model/src/main/java/io/syndesis/model/connection/Connector.java
+++ b/model/src/main/java/io/syndesis/model/connection/Connector.java
@@ -33,6 +33,7 @@ import org.immutables.value.Value;
 public interface Connector extends WithId<Connector>, WithName, WithProperties, Serializable {
 
     @Override
+    @Value.Default
     default Kind getKind() {
         return Kind.Connector;
     }

--- a/model/src/main/java/io/syndesis/model/connection/DataShape.java
+++ b/model/src/main/java/io/syndesis/model/connection/DataShape.java
@@ -17,13 +17,14 @@ package io.syndesis.model.connection;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.io.Serializable;
 import java.util.Optional;
 
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = DataShape.Builder.class)
-public interface DataShape {
+public interface DataShape extends Serializable {
 
     String getKind();
 

--- a/model2/pom.xml
+++ b/model2/pom.xml
@@ -31,21 +31,18 @@
 
   <dependencies>
     <!-- === Internal dependencies (don't touch without discussion) ========================== -->
-    <dependency>
-      <groupId>io.syndesis</groupId>
-      <artifactId>core</artifactId>
-    </dependency>
+
     <!-- ===================================================================================== -->
 
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>javax.persistence</artifactId>
-      <version>2.1.0</version>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
     </dependency>
 
     <dependency>

--- a/model2/src/main/java/io/syndesis/model2/Action.java
+++ b/model2/src/main/java/io/syndesis/model2/Action.java
@@ -34,7 +34,8 @@ import lombok.Data;
 
 @Entity(name = "Action")
 @Table(name = "syndesis_action")
-public @Data class Action implements Serializable {
+@Data
+public class Action implements Serializable {
 
     private static final long serialVersionUID = 1584777116521907130L;
     @Id

--- a/model2/src/main/java/io/syndesis/model2/ActionInstance.java
+++ b/model2/src/main/java/io/syndesis/model2/ActionInstance.java
@@ -32,7 +32,8 @@ import lombok.Data;
 
 @Entity(name = "ActionInstance")
 @Table(name = "syndesis_action_instance")
-public @Data class ActionInstance implements Serializable {
+@Data
+public class ActionInstance implements Serializable {
 
     private static final long serialVersionUID = 4151168555047111446L;
     @Id

--- a/model2/src/main/java/io/syndesis/model2/ActionInstanceProperty.java
+++ b/model2/src/main/java/io/syndesis/model2/ActionInstanceProperty.java
@@ -27,7 +27,8 @@ import lombok.Data;
 
 @Entity(name = "ActionInstanceProperty")
 @Table(name = "syndesis_action_instance_property")
-public @Data class ActionInstanceProperty implements Serializable {
+@Data
+public class ActionInstanceProperty implements Serializable {
 
     private static final long serialVersionUID = 3018522417242463576L;
     @Id

--- a/model2/src/main/java/io/syndesis/model2/ActionProperty.java
+++ b/model2/src/main/java/io/syndesis/model2/ActionProperty.java
@@ -28,7 +28,8 @@ import lombok.Data;
 
 @Entity(name = "ActionProperty")
 @Table(name = "syndesis_action_property")
-public @Data class ActionProperty implements Serializable {
+@Data
+public class ActionProperty implements Serializable {
 
     private static final long serialVersionUID = -5080309558521198599L;
     @Id

--- a/model2/src/main/java/io/syndesis/model2/ConfiguredConnector.java
+++ b/model2/src/main/java/io/syndesis/model2/ConfiguredConnector.java
@@ -32,7 +32,8 @@ import lombok.Data;
 
 @Entity(name = "ConfiguredConnector")
 @Table(name = "syndesis_configured_connector")
-public @Data class ConfiguredConnector implements Serializable {
+@Data
+public class ConfiguredConnector implements Serializable {
 
     private static final long serialVersionUID = -5012309870194352171L;
     @Id

--- a/model2/src/main/java/io/syndesis/model2/ConfiguredConnectorProperty.java
+++ b/model2/src/main/java/io/syndesis/model2/ConfiguredConnectorProperty.java
@@ -27,7 +27,8 @@ import lombok.Data;
 
 @Entity(name = "ConfiguredConnectionProperty")
 @Table(name = "syndesis_configured_connection_property")
-public @Data class ConfiguredConnectorProperty implements Serializable {
+@Data
+public class ConfiguredConnectorProperty implements Serializable {
 
     private static final long serialVersionUID = -6644977946278966373L;
     @Id

--- a/model2/src/main/java/io/syndesis/model2/Connector.java
+++ b/model2/src/main/java/io/syndesis/model2/Connector.java
@@ -32,7 +32,8 @@ import lombok.Data;
 
 @Entity(name = "Connector")
 @Table(name = "syndesis_connector")
-public @Data class Connector implements Serializable {
+@Data
+public class Connector implements Serializable {
 
     private static final long serialVersionUID = -7666292486786929721L;
     @Id

--- a/model2/src/main/java/io/syndesis/model2/ConnectorProperty.java
+++ b/model2/src/main/java/io/syndesis/model2/ConnectorProperty.java
@@ -28,7 +28,8 @@ import lombok.Data;
 
 @Entity(name = "ConnectorProperty")
 @Table(name = "syndesis_connector_property")
-public @Data class ConnectorProperty implements Serializable{
+@Data
+public class ConnectorProperty implements Serializable{
 
     private static final long serialVersionUID = 9055427838470721582L;
     @Id

--- a/model2/src/test/resources/META-INF/persistence.xml
+++ b/model2/src/test/resources/META-INF/persistence.xml
@@ -35,7 +35,7 @@
         <properties>
             <property name="hibernate.connection.release_mode" value="after_transaction"/>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
-            <property name="hibernate.connection.url" value="jdbc:h2:./target/h2-syndesis"/>
+            <property name="hibernate.connection.url" value="jdbc:h2:mem:"/>
             <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
             <property name="hibernate.connection.username" value="sa"/>
             <property name="hibernate.show_sql" value="false"/>

--- a/openshift/pom.xml
+++ b/openshift/pom.xml
@@ -46,12 +46,27 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>openshift-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
     </dependency>
 
     <dependency>
@@ -78,4 +93,32 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>org.keycloak:keycloak-spring-security-adapter</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <configuration>
+          <ignoredClassPatterns>
+            <ignoredClassPattern>io.fabric8.kubernetes.client.*</ignoredClassPattern>
+          </ignoredClassPatterns>
+        </configuration>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,13 @@
     limitations under the License.
 
 -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>9</version>
+    <groupId>org.basepom</groupId>
+    <artifactId>basepom-oss</artifactId>
+    <version>23</version>
   </parent>
 
   <groupId>io.syndesis</groupId>
@@ -96,22 +95,20 @@
   </pluginRepositories>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <syndesis-connectors.version>0.4.4</syndesis-connectors.version>
 
     <assertj-core.version>3.6.2</assertj-core.version>
+    <caffeine.version>2.4.0</caffeine.version>
     <camel.version>2.19.0</camel.version>
     <jdbi.version>2.78</jdbi.version>
     <funktion.version>1.1.55</funktion.version>
     <hibernate.validator.version>5.3.4.Final</hibernate.validator.version>
-    <immutables.version>2.4.0</immutables.version>
+    <immutables.version>2.5.1</immutables.version>
     <infinispan.version>9.0.0.Final</infinispan.version>
-    <jackson.version>2.8.6</jackson.version>
-    <javaee.api.version>7.0</javaee.api.version>
+    <jackson.version>2.8.8</jackson.version>
     <junit.version>4.12</junit.version>
     <keycloak.version>2.5.1.Final</keycloak.version>
     <kubernetes.client.version>2.2.13</kubernetes.client.version>
@@ -120,36 +117,28 @@
     <postgresql.version>9.1-901-1.jdbc4</postgresql.version>
     <resteasy-spring-boot-starter.version>2.3.0-RELEASE</resteasy-spring-boot-starter.version>
     <resteasy.version>3.1.1.Final</resteasy.version>
+    <spring.version>4.3.7.RELEASE</spring.version>
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
     <spring-cloud.version>Camden.SR5</spring-cloud.version>
     <spring-cloud-kubernetes.version>0.1.5</spring-cloud-kubernetes.version>
+    <spring-cloud-sleuth.version>1.1.2.RELEASE</spring-cloud-sleuth.version>
+    <spring-security.version>4.2.2.RELEASE</spring-security.version>
     <swagger.version>1.5.12</swagger.version>
+    <sqlite-jdbc.version>3.16.1</sqlite-jdbc.version>
+    <undertow.version>1.4.11.Final</undertow.version>
     <atlasmap.version>1.10.0</atlasmap.version>
 
     <!-- maven plugin version -->
-    <maven-dependency-plugin.version>3.0.0</maven-dependency-plugin.version>
-    <maven-enforcer-plugin.version>1.3.1</maven-enforcer-plugin.version>
-    <!-- Stick to 2.18.1 until 2.19.2 is out due to https://issues.apache.org/jira/browse/SUREFIRE-1198 -->
-    <maven-failsafe-plugin.version>2.18.1</maven-failsafe-plugin.version>
-    <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
-    <maven-jar-plugin.version>3.0.1</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-    <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
-    <maven-source-plugin.version>2.4</maven-source-plugin.version>
-    <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
+    <dep.plugin.dependency.version>3.0.0</dep.plugin.dependency.version>
 
     <!-- third party plugin version -->
     <asciidoctor-maven-plugin.version>1.5.3</asciidoctor-maven-plugin.version>
     <build-helper-maven-plugin.version>1.12</build-helper-maven-plugin.version>
     <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
     <fabric8-maven-plugin.version>3.3.0</fabric8-maven-plugin.version>
-    <git-commit-id-plugin.version>2.2.2</git-commit-id-plugin.version>
-    <jacoco-maven-plugin.version>0.7.8</jacoco-maven-plugin.version>
-    <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <process-exec-maven-plugin.version>0.8</process-exec-maven-plugin.version>
     <swagger-maven-plugin.version>1.0.0</swagger-maven-plugin.version>
     <swagger2markup-maven-plugin.version>1.1.0</swagger2markup-maven-plugin.version>
-    <templating-maven-plugin.version>1.0.0</templating-maven-plugin.version>
   </properties>
 
   <modules>
@@ -306,9 +295,10 @@
       </dependency>
 
       <dependency>
-        <groupId>javax</groupId>
-        <artifactId>javaee-api</artifactId>
-        <version>${javaee.api.version}</version>
+        <groupId>javax.ws.rs</groupId>
+        <artifactId>javax.ws.rs-api</artifactId>
+        <version>2.0.1</version>
+        <scope>provided</scope>
       </dependency>
 
       <dependency>
@@ -331,9 +321,152 @@
       </dependency>
 
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-core</artifactId>
+        <version>${spring.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aop</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>aopalliance</groupId>
+            <artifactId>aopalliance</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-core</artifactId>
+        <version>${spring-security.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>aopalliance</groupId>
+            <artifactId>aopalliance</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-config</artifactId>
+        <version>${spring-security.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>aopalliance</groupId>
+            <artifactId>aopalliance</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-web</artifactId>
+        <version>${spring-security.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>aopalliance</groupId>
+            <artifactId>aopalliance</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>${spring-boot.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-sleuth-core</artifactId>
+        <version>${spring-cloud-sleuth.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+        </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>spring-cloud-kubernetes-core</artifactId>
+        <version>${spring-cloud-kubernetes.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.undertow</groupId>
+        <artifactId>undertow-servlet</artifactId>
+        <version>${undertow.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.spec.javax.ws.rs</groupId>
+        <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+        <version>1.0.1.Beta1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.spec.javax.annotation</groupId>
+        <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        <version>1.0.0.Final</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>3.0.1</version>
+        <version>${dep.findbugs.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>findbugs-annotations</artifactId>
+        <version>${dep.findbugs.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy</artifactId>
+        <version>2.4.11</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeine.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.5</version>
       </dependency>
 
       <!-- Testing Dependencies -->
@@ -363,6 +496,12 @@
         <groupId>com.paypal.springboot</groupId>
         <artifactId>resteasy-spring-boot-starter</artifactId>
         <version>${resteasy-spring-boot-starter.version}</version>
+        <exclusions>
+          <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -374,12 +513,22 @@
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-client</artifactId>
+        <version>${resteasy.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jaxrs</artifactId>
         <version>${resteasy.version}</version>
       </dependency>
 
@@ -406,9 +555,25 @@
         <version>${keycloak.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-core</artifactId>
+        <version>${keycloak.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-adapter-core</artifactId>
+        <version>${keycloak.version}</version>
+      </dependency>
+      <dependency>
         <groupId>postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>${postgresql.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.xerial</groupId>
+        <artifactId>sqlite-jdbc</artifactId>
+        <version>${sqlite-jdbc.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jdbi</groupId>
@@ -437,17 +602,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>${maven-jar-plugin.version}</version>
-          <configuration>
-            <archive>
-              <manifest>
-                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-              </manifest>
-            </archive>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring-boot.version}</version>
@@ -473,39 +627,6 @@
           <version>${asciidoctor-maven-plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>build-helper-maven-plugin</artifactId>
-          <version>${build-helper-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${maven-failsafe-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>pl.project13.maven</groupId>
-          <artifactId>git-commit-id-plugin</artifactId>
-          <version>${git-commit-id-plugin.version}</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>revision</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <verbose>true</verbose>
-            <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
-            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>${maven-dependency-plugin.version}</version>
-        </plugin>
-        <plugin>
           <groupId>com.bazaarvoice.maven.plugins</groupId>
           <artifactId>process-exec-maven-plugin</artifactId>
           <version>${process-exec-maven-plugin.version}</version>
@@ -518,23 +639,10 @@
       </plugins>
     </pluginManagement>
     <plugins>
+
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>templating-maven-plugin</artifactId>
-        <version>${templating-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>filter-sources</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <inherited>true</inherited>
-        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <environmentVariables>
             <ENV_VAR_EXISTS>value</ENV_VAR_EXISTS>
@@ -542,36 +650,18 @@
           </environmentVariables>
         </configuration>
       </plugin>
+
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>${maven-gpg-plugin.version}</version>
         <configuration>
           <passphrase>${gpg.passphrase}</passphrase>
-          <useAgent>true</useAgent>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${jacoco-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-              <goal>prepare-agent-integration</goal>
-              <goal>report</goal>
-              <goal>report-integration</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>${license-maven-plugin.version}</version>
         <configuration>
-          <aggregate>true</aggregate>
           <header>header.txt</header>
           <properties>
             <owner>Red Hat, Inc.</owner>
@@ -579,7 +669,6 @@
           <excludes>
             <exclude>.editorconfig</exclude>
             <exclude>license.txt</exclude>
-            <exclude>**/*.adoc</exclude>
             <exclude>.mention-bot</exclude>
             <exclude>.mvn/wrapper/maven-wrapper.properties</exclude>
             <exclude>mvnw*</exclude>
@@ -588,6 +677,23 @@
           </excludes>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <configuration>
+          <ignoredClassPatterns>
+            <ignoredClassPattern>io.fabric8.kubernetes.client.*</ignoredClassPattern>
+            <ignoredClassPattern>org.infinispan.util.*</ignoredClassPattern>
+            <ignoredClassPattern>org.springframework.security.crypto.*</ignoredClassPattern>
+            <ignoredClassPattern>org.objectweb.asm.*</ignoredClassPattern>
+          </ignoredClassPatterns>
+          <ignoredResourcePatterns>
+            <ignoredResourcePattern>features.xml</ignoredResourcePattern>
+          </ignoredResourcePatterns>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 
@@ -597,22 +703,7 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>${maven-enforcer-plugin.version}</version>
             <executions>
               <execution>
                 <id>enforce-no-snapshots</id>
@@ -630,44 +721,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>${maven-javadoc-plugin.version}</version>
-            <configuration>
-              <includeDependencySources>${javadoc.include.deps}
-              </includeDependencySources>
-              <dependencySourceIncludes>
-                <dependencySourceInclude>${javadoc.source.includes}
-                </dependencySourceInclude>
-              </dependencySourceIncludes>
-              <excludePackageNames>${javadoc.package.excludes}</excludePackageNames>
-            </configuration>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-                <configuration>
-                  <additionalparam>${javadoc.opts}</additionalparam>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>${maven-source-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -681,4 +734,5 @@
       </properties>
     </profile>
   </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <basepom.test.timeout>300</basepom.test.timeout>
 
     <syndesis-connectors.version>0.4.4</syndesis-connectors.version>
 

--- a/project-generator/pom.xml
+++ b/project-generator/pom.xml
@@ -52,22 +52,55 @@
   </repositories>
 
   <dependencies>
+
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>model</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>connector-catalog</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.fabric8.funktion</groupId>
       <artifactId>funktion-model</artifactId>
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
 
     <dependency>
@@ -78,6 +111,16 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>
@@ -97,6 +140,13 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -114,16 +164,25 @@
     </testResources>
 
     <plugins>
+
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.2</version>
         <configuration>
           <delimiters>
             <delimiter>@</delimiter>
           </delimiters>
         </configuration>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
+import java.io.OutputStreamWriter;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -46,30 +46,32 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class DefaultProjectGenerator implements ProjectGenerator {
 
-    private final static String MAPPER = "mapper";
-    private final static ObjectMapper YAML_OBJECT_MAPPER = YamlHelper.createYamlMapper();
-    private final static String PLACEHOLDER_FORMAT = "{{%s}}";
+    private static final String MAPPER = "mapper";
+    private static final ObjectMapper YAML_OBJECT_MAPPER = YamlHelper.createYamlMapper();
+    private static final String PLACEHOLDER_FORMAT = "{{%s}}";
 
     private MustacheFactory mf = new DefaultMustacheFactory();
 
     private Mustache readmeMustache = mf.compile(
-        new InputStreamReader(getClass().getResourceAsStream("templates/README.md.mustache")),
+        new InputStreamReader(getClass().getResourceAsStream("templates/README.md.mustache"), UTF_8),
         "README.md"
     );
     private Mustache applicationJavaMustache = mf.compile(
-        new InputStreamReader(getClass().getResourceAsStream("templates/Application.java.mustache")),
+        new InputStreamReader(getClass().getResourceAsStream("templates/Application.java.mustache"), UTF_8),
         "Application.java"
     );
 
     private Mustache applicationYmlMustache = mf.compile(
-        new InputStreamReader(getClass().getResourceAsStream("templates/application.properties.mustache")),
+        new InputStreamReader(getClass().getResourceAsStream("templates/application.properties.mustache"), UTF_8),
         "application.properties"
     );
 
     private Mustache pomMustache = mf.compile(
-        new InputStreamReader(getClass().getResourceAsStream("templates/pom.xml.mustache")),
+        new InputStreamReader(getClass().getResourceAsStream("templates/pom.xml.mustache"), UTF_8),
         "pom.xml"
     );
 
@@ -201,7 +203,7 @@ public class DefaultProjectGenerator implements ProjectGenerator {
         return YAML_OBJECT_MAPPER.writeValueAsBytes(funktion);
     }
 
-    static private byte[] utf8(String value) {
+    private static byte[] utf8(String value) {
         if (value == null) {
             return null;
         }
@@ -238,7 +240,7 @@ public class DefaultProjectGenerator implements ProjectGenerator {
 
     private byte[] generate(Object obj, Mustache template) throws IOException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        template.execute(new PrintWriter(bos), obj).flush();
+        template.execute(new OutputStreamWriter(bos, UTF_8), obj).flush();
         return bos.toByteArray();
     }
 

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -16,9 +16,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>syndesis-rest-parent</artifactId>
     <groupId>io.syndesis</groupId>
@@ -37,6 +36,11 @@
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>model</artifactId>
     </dependency>
 
     <dependency>
@@ -77,6 +81,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
@@ -97,9 +106,38 @@
     </dependency>
 
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
-      <optional>true</optional>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- === Testing Dependencies ======================================================== -->
@@ -115,5 +153,49 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
+
+  <build>
+
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>io.syndesis:github</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>io.syndesis:controllers</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>io.syndesis:openshift</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+          <ignoredUsedUndeclaredDependencies>
+            <!-- if declared complains about being unused -->
+            <ignoredUnusedDeclaredDependency>com.google.code.findbugs:findbugs-annotations</ignoredUnusedDeclaredDependency>
+          </ignoredUsedUndeclaredDependencies>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.ning.maven.plugins</groupId>
+        <artifactId>maven-dependency-versions-check-plugin</artifactId>
+        <configuration>
+          <exceptions>
+            <exception>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <expectedVersion>2.8.4</expectedVersion>
+              <resolvedVersion>2.8.0</resolvedVersion>
+            </exception>
+          </exceptions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+
+  </build>
 </project>

--- a/rest/src/main/java/io/syndesis/rest/v1/CacheFor.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/CacheFor.java
@@ -15,7 +15,10 @@
  */
 package io.syndesis.rest.v1;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/rest/src/main/java/io/syndesis/rest/v1/CacheForFilter.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/CacheForFilter.java
@@ -17,7 +17,11 @@ package io.syndesis.rest.v1;
 
 import java.io.IOException;
 
-import javax.ws.rs.container.*;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.ext.Provider;

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
@@ -15,6 +15,17 @@
  */
 package io.syndesis.rest.v1.handler.connection;
 
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.swagger.annotations.Api;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.Kind;
 import io.syndesis.model.connection.Connector;
@@ -22,13 +33,6 @@ import io.syndesis.rest.v1.handler.BaseHandler;
 import io.syndesis.rest.v1.operations.Getter;
 import io.syndesis.rest.v1.operations.Lister;
 import io.syndesis.verifier.Verifier;
-import io.swagger.annotations.Api;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-
-import java.util.List;
-import java.util.Map;
 
 @Path("/connectors")
 @Api(value = "connectors")

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/EntityNotFoundExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/EntityNotFoundExceptionMapper.java
@@ -28,13 +28,13 @@ import org.springframework.stereotype.Component;
 @Provider
 public class EntityNotFoundExceptionMapper implements ExceptionMapper<EntityNotFoundException> {
 
-	private static final Logger LOG = LoggerFactory.getLogger(EntityNotFoundExceptionMapper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(EntityNotFoundExceptionMapper.class);
 
-	@Override
-	public Response toResponse(EntityNotFoundException e) {
-		LOG.error(e.getMessage(),e);
-		RestError error = new RestError("Entity Not Found Exception " + e.getMessage(), "Please check your request data", 404);
-		return Response.status(error.errorCode).entity(error).build();
-	}
+    @Override
+    public Response toResponse(EntityNotFoundException e) {
+        LOG.error(e.getMessage(),e);
+        RestError error = new RestError("Entity Not Found Exception " + e.getMessage(), "Please check your request data", 404);
+        return Response.status(error.errorCode).entity(error).build();
+    }
 
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/IllegalArgumentExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/IllegalArgumentExceptionMapper.java
@@ -27,13 +27,13 @@ import org.springframework.stereotype.Component;
 @Provider
 public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
 
-	private static final Logger LOG = LoggerFactory.getLogger(IllegalArgumentExceptionMapper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(IllegalArgumentExceptionMapper.class);
 
-	@Override
-	public Response toResponse(IllegalArgumentException e) {
-		LOG.error(e.getMessage(),e);
-		RestError error = new RestError("Illegal Argument on Call " + e.getMessage(), "Please check your sorting arguments", 400);
-		return Response.status(error.errorCode).entity(error).build();
-	}
+    @Override
+    public Response toResponse(IllegalArgumentException e) {
+        LOG.error(e.getMessage(),e);
+        RestError error = new RestError("Illegal Argument on Call " + e.getMessage(), "Please check your sorting arguments", 400);
+        return Response.status(error.errorCode).entity(error).build();
+    }
 
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/RestError.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/RestError.java
@@ -17,35 +17,35 @@ package io.syndesis.rest.v1.handler.exception;
 
 public class RestError {
 
-	String developerMsg;
-	String userMsg;
-	Integer errorCode;
+    String developerMsg;
+    String userMsg;
+    Integer errorCode;
 
-	public RestError() {
-	}
+    public RestError() {
+    }
 
-	public RestError(String developerMsg, String userMsg, Integer errorCode) {
-		this.developerMsg = developerMsg;
-		this.userMsg = userMsg;
-		this.errorCode = errorCode;
-	}
-	public String getDeveloperMsg() {
-		return developerMsg;
-	}
-	public void setDeveloperMsg(String developerMsg) {
-		this.developerMsg = developerMsg;
-	}
-	public String getUserMsg() {
-		return userMsg;
-	}
-	public void setUserMsg(String userMsg) {
-		this.userMsg = userMsg;
-	}
-	public Integer getErrorCode() {
-		return errorCode;
-	}
-	public void setErrorCode(Integer errorCode) {
-		this.errorCode = errorCode;
-	}
+    public RestError(String developerMsg, String userMsg, Integer errorCode) {
+        this.developerMsg = developerMsg;
+        this.userMsg = userMsg;
+        this.errorCode = errorCode;
+    }
+    public String getDeveloperMsg() {
+        return developerMsg;
+    }
+    public void setDeveloperMsg(String developerMsg) {
+        this.developerMsg = developerMsg;
+    }
+    public String getUserMsg() {
+        return userMsg;
+    }
+    public void setUserMsg(String userMsg) {
+        this.userMsg = userMsg;
+    }
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+    public void setErrorCode(Integer errorCode) {
+        this.errorCode = errorCode;
+    }
 }
 

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/SyndesisServerExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/SyndesisServerExceptionMapper.java
@@ -26,13 +26,13 @@ import org.springframework.stereotype.Component;
 @Provider
 public class SyndesisServerExceptionMapper implements javax.ws.rs.ext.ExceptionMapper<Exception> {
 
-	private static final Logger LOG = LoggerFactory.getLogger(SyndesisServerExceptionMapper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SyndesisServerExceptionMapper.class);
 
-	@Override
-	public Response toResponse(Exception e) {
-		LOG.error(e.getMessage(),e);
-		RestError error = new RestError("Internal Server Exception. " + e.getMessage(), "Please contact the administrator and file a bug report", 500);
-		return Response.status(error.errorCode).entity(error).build();
-	}
+    @Override
+    public Response toResponse(Exception e) {
+        LOG.error(e.getMessage(),e);
+        RestError error = new RestError("Internal Server Exception. " + e.getMessage(), "Please contact the administrator and file a bug report", 500);
+        return Response.status(error.errorCode).entity(error).build();
+    }
 
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
@@ -19,6 +19,7 @@ import io.syndesis.core.Tokens;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.Kind;
 import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.Integration.Status;
 import io.syndesis.rest.v1.handler.BaseHandler;
 import io.swagger.annotations.Api;
 import io.syndesis.rest.v1.operations.Creator;
@@ -54,7 +55,8 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
         Integration integration = Getter.super.get(id);
 
         //fudging the timesUsed for now
-        if (integration.getCurrentStatus().equals(Integration.Status.Activated)) {
+        Optional<Status> currentStatus = integration.getCurrentStatus();
+        if (currentStatus.isPresent() && currentStatus.get() == Integration.Status.Activated) {
             return new Integration.Builder()
                     .createFrom(integration)
                     .timesUsed(BigInteger.valueOf(new Date().getTime()/1000000))

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/tests/TestSupportHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/tests/TestSupportHandler.java
@@ -15,22 +15,28 @@
  */
 package io.syndesis.rest.v1.handler.tests;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
 import io.syndesis.dao.init.ModelData;
 import io.syndesis.dao.manager.DataAccessObject;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.ListResult;
 import io.syndesis.model.WithId;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Path("/test-support")
 @org.springframework.stereotype.Component

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Deleter.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Deleter.java
@@ -15,7 +15,10 @@
  */
 package io.syndesis.rest.v1.operations;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 
 import io.syndesis.dao.manager.WithDataManager;
 import io.syndesis.model.WithId;

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Getter.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Getter.java
@@ -16,12 +16,15 @@
 package io.syndesis.rest.v1.operations;
 
 import javax.persistence.EntityNotFoundException;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.ApiParam;
 import io.syndesis.dao.manager.WithDataManager;
 import io.syndesis.model.WithId;
-import io.swagger.annotations.ApiParam;
 
 public interface Getter<T extends WithId> extends Resource<T>, WithDataManager {
 

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Updater.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Updater.java
@@ -15,7 +15,10 @@
  */
 package io.syndesis.rest.v1.operations;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 
 import io.syndesis.dao.manager.WithDataManager;
 import io.syndesis.model.WithId;

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -229,6 +229,10 @@
               <goal>verify</goal>
             </goals>
             <configuration>
+              <additionalClasspathElements>
+                <!-- workaround suggested in https://github.com/spring-projects/spring-boot/issues/6254 -->
+                <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
+              </additionalClasspathElements>
               <systemProperties>
                 <keycloak.http.port>${keycloak.http.port}</keycloak.http.port>
               </systemProperties>
@@ -260,6 +264,88 @@
               <outputDirectory>${project.build.directory}/keycloak</outputDirectory>
             </artifactItem>
           </artifactItems>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>com.paypal.springboot:resteasy-spring-boot-starter</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>io.fabric8:spring-cloud-kubernetes-core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-actuator</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-jdbc</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-security</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-undertow</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-web</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-websocket</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.cloud:spring-cloud-starter-security</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.cloud:spring-cloud-starter-zipkin</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>postgresql:postgresql</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.ning.maven.plugins</groupId>
+        <artifactId>maven-dependency-versions-check-plugin</artifactId>
+        <configuration>
+          <exceptions>
+            <exception>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <resolvedVersion>2.8.0</resolvedVersion>
+              <expectedVersion>2.5.4</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <resolvedVersion>2.8.0</resolvedVersion>
+              <expectedVersion>2.6.0</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <resolvedVersion>2.8.0</resolvedVersion>
+              <expectedVersion>2.7.0</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <resolvedVersion>2.8.0</resolvedVersion>
+              <expectedVersion>2.8.3</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
+              <resolvedVersion>18.0</resolvedVersion>
+              <expectedVersion>15.0</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
+              <resolvedVersion>18.0</resolvedVersion>
+              <expectedVersion>19.0</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>org.bouncycastle</groupId>
+              <artifactId>bcpkix-jdk15on</artifactId>
+              <resolvedVersion>1.52</resolvedVersion>
+              <expectedVersion>1.47</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>org.bouncycastle</groupId>
+              <artifactId>bcpkix-jdk15on</artifactId>
+              <resolvedVersion>1.52</resolvedVersion>
+              <expectedVersion>1.55</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>org.bouncycastle</groupId>
+              <artifactId>bcprov-jdk15on</artifactId>
+              <resolvedVersion>1.52</resolvedVersion>
+              <expectedVersion>1.47</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>org.bouncycastle</groupId>
+              <artifactId>bcprov-jdk15on</artifactId>
+              <resolvedVersion>1.52</resolvedVersion>
+              <expectedVersion>1.55</expectedVersion>
+            </exception>
+          </exceptions>
         </configuration>
       </plugin>
 
@@ -316,6 +402,7 @@
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 
@@ -325,7 +412,27 @@
     <!-- Top most layer, entrypoint. It contains the deps to other modules -->
     <dependency>
       <groupId>io.syndesis</groupId>
+      <artifactId>model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>dao</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
       <artifactId>rest</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>verifier</artifactId>
     </dependency>
 
     <!-- DAO implementations: -->
@@ -334,18 +441,46 @@
       <artifactId>jsondb</artifactId>
     </dependency>
 
-
     <!-- ===================================================================================== -->
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-tomcat</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -359,10 +494,22 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
@@ -394,6 +541,41 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.annotation</groupId>
+      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.undertow</groupId>
+      <artifactId>undertow-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.undertow</groupId>
+      <artifactId>undertow-servlet</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
@@ -409,7 +591,6 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.16.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -420,6 +601,31 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>spring-cloud-kubernetes-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
     </dependency>
 
   </dependencies>

--- a/runtime/src/main/java/io/syndesis/runtime/EventBusToServerSentEvents.java
+++ b/runtime/src/main/java/io/syndesis/runtime/EventBusToServerSentEvents.java
@@ -100,16 +100,19 @@ public class EventBusToServerSentEvents implements UndertowDeploymentInfoCustomi
             responseHeaders.put(new HttpString(CorsHeaders.ACCESS_CONTROL_ALLOW_ORIGIN), origin);
 
             String value = requestHeaders.getFirst(CorsHeaders.ACCESS_CONTROL_REQUEST_HEADERS);
-            if (value != null)
+            if (value != null) {
                 responseHeaders.put(new HttpString(CorsHeaders.ACCESS_CONTROL_ALLOW_HEADERS), value);
+            }
 
             value = requestHeaders.getFirst(CorsHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS);
-            if (value != null)
+            if (value != null) {
                 responseHeaders.put(new HttpString(CorsHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS), value);
+            }
 
             value = requestHeaders.getFirst(CorsHeaders.ACCESS_CONTROL_REQUEST_METHOD);
-            if (value != null)
+            if (value != null) {
                 responseHeaders.put(new HttpString(CorsHeaders.ACCESS_CONTROL_ALLOW_METHODS), value);
+            }
         }
 
         String uri = exchange.getRequestURI();

--- a/runtime/src/main/java/io/syndesis/runtime/SchemaCheck.java
+++ b/runtime/src/main/java/io/syndesis/runtime/SchemaCheck.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  */
 @Service
 public class SchemaCheck {
-    static private final Logger LOG = LoggerFactory.getLogger(SchemaCheck.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaCheck.class);
 
     @Value("${dao.schema.version}")
     private String daoSchemaVersion;

--- a/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
@@ -15,27 +15,35 @@
  */
 package io.syndesis.runtime;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.file.Paths;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
 import io.syndesis.core.Json;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.jsondb.impl.SqlJsonDB;
+
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
-
-import javax.annotation.PostConstruct;
-import java.io.UnsupportedEncodingException;
-import java.nio.file.Paths;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/verifier/pom.xml
+++ b/verifier/pom.xml
@@ -17,7 +17,7 @@
 
 -->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.syndesis</groupId>
@@ -33,12 +33,27 @@
 
     <dependency>
       <groupId>io.syndesis</groupId>
+      <artifactId>model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
       <artifactId>project-generator</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
     </dependency>
 
     <dependency>
@@ -52,14 +67,37 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
   </dependencies>
+
 </project>

--- a/verifier/src/main/java/io/syndesis/verifier/ExternalVerifierService.java
+++ b/verifier/src/main/java/io/syndesis/verifier/ExternalVerifierService.java
@@ -18,7 +18,10 @@ package io.syndesis.verifier;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.client.*;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 

--- a/verifier/src/main/java/io/syndesis/verifier/LocalProcessVerifier.java
+++ b/verifier/src/main/java/io/syndesis/verifier/LocalProcessVerifier.java
@@ -15,15 +15,25 @@
  */
 package io.syndesis.verifier;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import io.syndesis.model.connection.Connector;
 import io.syndesis.project.converter.ProjectGenerator;
 
 import org.springframework.util.FileSystemUtils;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 // Needs to be adapted to new API signature.
 /*
@@ -37,6 +47,8 @@ import org.springframework.util.FileSystemUtils;
 public class LocalProcessVerifier {
 
     private final ProjectGenerator projectGenerator;
+
+    @SuppressFBWarnings("UWF_NULL_FIELD")
     private String localMavenRepoLocation = null; // "/tmp/syndesis-local-mvn-repo";
 
     public LocalProcessVerifier(ProjectGenerator projectGenerator) {
@@ -164,7 +176,7 @@ public class LocalProcessVerifier {
     }
 
     private String parseClasspath(InputStream inputStream) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         boolean useNextLine = true;
         String result = null;
         String line;


### PR DESCRIPTION
This is can be contentious. [Basepom](https://github.com/basepom/basepom) is a project by one of Maven's most prolific commiters it embodies best practices and, contentiously enough, enforces most of them.
I propose changing Syndesis parent's parent to Basepom. Using Basepom is either hit-or-miss as it can be quite annoying in enforcing _the right_ way of using dependency management and enforcing style checks.
I've used it before and I'm a big fan, but then again I do love to self immolate myself with every check imaginable.
Creating a WIP PR to test the grounds with just a couple of changes done (doesn't build ATM).