### PR TITLE
Credentials support

### DIFF
--- a/credential/pom.xml
+++ b/credential/pom.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.syndesis</groupId>
+    <artifactId>syndesis-rest-parent</artifactId>
+    <version>0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>credential</artifactId>
+  <name>Syndesis REST :: Credential</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>dao</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-config</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+    </dependency>
+
+
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
+    </dependency>
+
+    <!-- === Supported services ============================================================== -->
+
+    <dependency>
+      <groupId>com.github.mikegirard</groupId>
+      <artifactId>spring-social-salesforce</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-twitter</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- === Test ============================================================================ -->
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/credential/src/main/java/io/syndesis/credential/Acquisition.java
+++ b/credential/src/main/java/io/syndesis/credential/Acquisition.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(builder = Acquisition.Builder.class)
+public interface Acquisition {
+
+    class Builder extends ImmutableAcquisition.Builder {
+        // builder implemented by Immutables, access allowed through this
+        // subclass
+    }
+
+    enum Type {
+        REDIRECT
+    }
+
+    Type getType();
+
+    String getUrl();
+}

--- a/credential/src/main/java/io/syndesis/credential/AcquisitionMethod.java
+++ b/credential/src/main/java/io/syndesis/credential/AcquisitionMethod.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.immutables.value.Value;
+
+/**
+ * Information on the method of credential acquisition, needed for UI to present
+ * it to the user.
+ */
+@Value.Immutable
+@JsonDeserialize(builder = AcquisitionMethod.Builder.class)
+public interface AcquisitionMethod {
+
+    AcquisitionMethod NONE = new Builder().build();
+
+    class Builder extends ImmutableAcquisitionMethod.Builder {
+        // builder implemented by Immutables, access allowed through this
+        // subclass
+    }
+
+    enum Type {
+        OAUTH1, OAUTH2
+    }
+
+    String getDescription();
+
+    String getIcon();
+
+    String getLabel();
+
+    Type getType();
+}

--- a/credential/src/main/java/io/syndesis/credential/AcquisitionRequest.java
+++ b/credential/src/main/java/io/syndesis/credential/AcquisitionRequest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.net.URI;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.immutables.value.Value;
+import org.springframework.validation.annotation.Validated;
+
+@Value.Immutable
+@JsonDeserialize(builder = AcquisitionRequest.Builder.class)
+@Validated
+public interface AcquisitionRequest {
+
+    class Builder extends ImmutableAcquisitionRequest.Builder {
+        // builder implemented by Immutables, access allowed through this
+        // subclass
+    }
+
+    @RelativeUri
+    URI returnUrl();
+}

--- a/credential/src/main/java/io/syndesis/credential/Applicator.java
+++ b/credential/src/main/java/io/syndesis/credential/Applicator.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import io.syndesis.model.connection.Connection;
+
+import static org.springframework.util.StringUtils.hasText;
+
+public interface Applicator<T> {
+
+    Connection applyTo(Connection connection, T token);
+
+    static void applyProperty(final Connection.Builder mutableConnection, final String property, final String value) {
+        if (!hasText(property) || !hasText(value)) {
+            return;
+        }
+
+        mutableConnection.putConfiguredProperty(property, value);
+    }
+}

--- a/credential/src/main/java/io/syndesis/credential/CredentialConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialConfiguration.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.syndesis.dao.manager.DataManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CredentialConfiguration {
+
+    private List<CredentialProviderConfiguration> configurations = Collections.emptyList();
+
+    @Bean
+    public CredentialProviderLocator credentialProviderLocator() {
+        final DefaultCredentialProviderFactoryConfigurer configurer = new DefaultCredentialProviderFactoryConfigurer();
+
+        for (final CredentialProviderConfiguration configuration : configurations) {
+            configuration.addCredentialProviderTo(configurer);
+        }
+
+        return configurer.getCredentialProviderLocator();
+    }
+
+    @Bean
+    public Credentials credentials(final CredentialProviderLocator connectionProviderLocator,
+        final DataManager dataManager, final CacheManager cacheManager) {
+        return new Credentials(connectionProviderLocator, dataManager, cacheManager);
+    }
+
+    @Autowired(required = false)
+    public void setCredentialProviderConfigurers(final List<CredentialProviderConfiguration> configurations) {
+        this.configurations = configurations;
+    }
+
+}

--- a/credential/src/main/java/io/syndesis/credential/CredentialFlowState.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialFlowState.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.net.URI;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.immutables.value.Value;
+import org.springframework.social.oauth1.OAuthToken;
+
+@Value.Immutable
+@JsonDeserialize(builder = CredentialFlowState.Builder.class)
+public interface CredentialFlowState {
+
+    class Builder extends ImmutableCredentialFlowState.Builder {
+        // builder implemented by Immutables, access allowed through this
+        // subclass
+    }
+
+    String getConnectionId();
+
+    String getProviderId();
+
+    URI getReturnUrl();
+
+    String getKey();
+
+    OAuthToken getToken();
+}

--- a/credential/src/main/java/io/syndesis/credential/CredentialProvider.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProvider.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import org.springframework.social.connect.ConnectionFactory;
+
+public interface CredentialProvider<A, T> {
+
+    Applicator<T> applicator();
+
+    ConnectionFactory<A> connectionFactory();
+
+}

--- a/credential/src/main/java/io/syndesis/credential/CredentialProviderConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProviderConfiguration.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+public interface CredentialProviderConfiguration {
+
+    void addCredentialProviderTo(CredentialProviderConfigurer configurer);
+
+}

--- a/credential/src/main/java/io/syndesis/credential/CredentialProviderConfigurer.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProviderConfigurer.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+public interface CredentialProviderConfigurer {
+
+    <A, T> void addCredentialProvider(CredentialProvider<A, T> credentialProvider);
+
+}

--- a/credential/src/main/java/io/syndesis/credential/CredentialProviderFactoryConfigurer.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProviderFactoryConfigurer.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+public interface CredentialProviderFactoryConfigurer {
+
+    <A, T> void addCredentialProvider(CredentialProvider<A, T> credentialProvider);
+
+}

--- a/credential/src/main/java/io/syndesis/credential/CredentialProviderLocator.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProviderLocator.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import org.springframework.social.connect.ConnectionFactory;
+
+public interface CredentialProviderLocator {
+
+    Applicator<?> getApplicator(String providerId);
+
+    /**
+     * Lookup a ConnectionFactory by providerId; for example, "facebook". The
+     * returned factory can be used to create connections to the provider. Used
+     * to support connection creation in a dynamic manner across the set of
+     * registered providers.
+     *
+     * @param providerId the provider ID used to look up the ConnectionFactory.
+     * @return the requested ConnectionFactory
+     */
+    ConnectionFactory<?> getConnectionFactory(String providerId);
+
+}

--- a/credential/src/main/java/io/syndesis/credential/CredentialProviderRegistry.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProviderRegistry.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.social.connect.ConnectionFactory;
+
+final class CredentialProviderRegistry implements CredentialProviderLocator {
+
+    private final Map<String, CredentialProvider<?, ?>> providers = new ConcurrentHashMap<>();
+
+    public <A, T> void addCredentialProvider(final CredentialProvider<A, T> credentialProvider) {
+        final ConnectionFactory<A> connectionFactory = credentialProvider.connectionFactory();
+        final String providerId = connectionFactory.getProviderId();
+
+        providers.put(providerId, credentialProvider);
+    }
+
+    @Override
+    public Applicator<?> getApplicator(final String providerId) {
+        return providerWithId(providerId).applicator();
+    }
+
+    @Override
+    public ConnectionFactory<?> getConnectionFactory(final String providerId) {
+        return providerWithId(providerId).connectionFactory();
+    }
+
+    private CredentialProvider<?, ?> providerWithId(final String providerId) {
+        final CredentialProvider<?, ?> providerWithId = providers.get(providerId);
+
+        if (providerWithId == null) {
+            throw new IllegalArgumentException("Unable to locate credential provider with id: " + providerId);
+        }
+
+        return providerWithId;
+    }
+
+}

--- a/credential/src/main/java/io/syndesis/credential/Credentials.java
+++ b/credential/src/main/java/io/syndesis/credential/Credentials.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import javax.persistence.EntityNotFoundException;
+import javax.servlet.http.HttpServletRequest;
+
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.model.connection.Connection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.social.connect.ConnectionFactory;
+import org.springframework.social.connect.support.OAuth1ConnectionFactory;
+import org.springframework.social.connect.support.OAuth2ConnectionFactory;
+import org.springframework.social.oauth1.AuthorizedRequestToken;
+import org.springframework.social.oauth1.OAuth1Operations;
+import org.springframework.social.oauth1.OAuth1Parameters;
+import org.springframework.social.oauth1.OAuth1Version;
+import org.springframework.social.oauth1.OAuthToken;
+import org.springframework.social.oauth2.AccessGrant;
+import org.springframework.social.oauth2.OAuth2Operations;
+import org.springframework.social.oauth2.OAuth2Parameters;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public final class Credentials {
+
+    public static final String CACHE_NAME = "credentials";
+
+    private static final Pattern API_BASE_PATH = Pattern.compile("(/[^/]+/[^/]+)/.*");
+
+    private static final MultiValueMap<String, String> EMPTY = new LinkedMultiValueMap<>();
+
+    private final CredentialProviderLocator credentialProviderLocator;
+
+    private final DataManager dataManager;
+
+    private final Cache state;
+
+    @Autowired
+    public Credentials(final CredentialProviderLocator credentialProviderLocator, final DataManager dataManager,
+        final CacheManager cacheManager) {
+        this.credentialProviderLocator = credentialProviderLocator;
+        this.dataManager = dataManager;
+        state = cacheManager.getCache(CACHE_NAME);
+    }
+
+    public Acquisition acquire(final String connectionId, final String providerId, final URI returnUrl,
+        final NativeWebRequest request) {
+
+        final ConnectionFactory<?> connectionFactory = factoryFor(providerId);
+
+        final String redirectUrl;
+        final CredentialFlowState.Builder flowStateBuilder = new CredentialFlowState.Builder().returnUrl(returnUrl)
+            .connectionId(connectionId).providerId(providerId);
+
+        if (connectionFactory instanceof OAuth1ConnectionFactory) {
+            redirectUrl = prepareOAuth1((OAuth1ConnectionFactory<?>) connectionFactory, flowStateBuilder, request);
+        } else if (connectionFactory instanceof OAuth2ConnectionFactory) {
+            redirectUrl = prepareOAuth2((OAuth2ConnectionFactory<?>) connectionFactory, flowStateBuilder, request);
+        } else {
+            throw new IllegalStateException("Unsupported connection factory implementation: " + connectionFactory);
+        }
+
+        final CredentialFlowState flowState = flowStateBuilder.build();
+        state.put(flowState.getKey(), flowState);
+
+        return new Acquisition.Builder().type(Acquisition.Type.REDIRECT).url(redirectUrl).build();
+    }
+
+    public AcquisitionMethod acquisitionMethodFor(final String providerId) {
+        try {
+            return acquisitionMethodFor(factoryFor(providerId));
+        } catch (final IllegalArgumentException ignored) {
+            return AcquisitionMethod.NONE;
+        }
+    }
+
+    public URI finishAcquisition(final String oauthState, final NativeWebRequest request) {
+        final CredentialFlowState flowState = state.get(oauthState, CredentialFlowState.class);
+
+        if (flowState == null) {
+            throw new EntityNotFoundException("Flow state could not be found, this might mean that the state "
+                + "parameter was not passed correctly or that the allowed timeout has been reached");
+        }
+
+        final String connectionId = flowState.getConnectionId();
+        final Connection connection = dataManager.fetch(Connection.class, connectionId);
+
+        final String providerId = flowState.getProviderId();
+        final ConnectionFactory<?> connectionFactory = factoryFor(providerId);
+
+        final Connection updatedConnection;
+        if (connectionFactory instanceof OAuth1ConnectionFactory) {
+            updatedConnection = finishOAuth1((OAuth1ConnectionFactory<?>) connectionFactory, connection, flowState,
+                request);
+        } else if (connectionFactory instanceof OAuth2ConnectionFactory) {
+            updatedConnection = finishOAuth2((OAuth2ConnectionFactory<?>) connectionFactory, connection, flowState,
+                request);
+        } else {
+            throw new IllegalStateException("Unsupported connection factory implementation: " + connectionFactory);
+        }
+
+        dataManager.update(updatedConnection);
+
+        return flowState.getReturnUrl();
+    }
+
+    protected <T> Applicator<T> applicatorFor(final String providerId) {
+        @SuppressWarnings("unchecked")
+        final Applicator<T> applicator = (Applicator<T>) credentialProviderLocator.getApplicator(providerId);
+
+        return applicator;
+    }
+
+    protected ConnectionFactory<?> factoryFor(final String providerId) {
+        return credentialProviderLocator.getConnectionFactory(providerId);
+    }
+
+    protected Connection finishOAuth1(final OAuth1ConnectionFactory<?> oauth1, final Connection connection,
+        final CredentialFlowState flowState, final NativeWebRequest request) {
+        final String providerId = flowState.getProviderId();
+
+        final String verifier = request.getParameter("oauth_verifier");
+        final AuthorizedRequestToken requestToken = new AuthorizedRequestToken(flowState.getToken(), verifier);
+        final OAuthToken accessToken = oauth1.getOAuthOperations().exchangeForAccessToken(requestToken, null);
+
+        final Applicator<OAuthToken> applicator = applicatorFor(providerId);
+
+        return applicator.applyTo(connection, accessToken);
+    }
+
+    protected Connection finishOAuth2(final OAuth2ConnectionFactory<?> oauth2, final Connection connection,
+        final CredentialFlowState flowState, final NativeWebRequest request) {
+        final String providerId = flowState.getProviderId();
+
+        final String code = request.getParameter("code");
+
+        final AccessGrant accessGrant = oauth2.getOAuthOperations().exchangeForAccess(code,
+            callbackUrlFor(request, EMPTY), null);
+
+        final Applicator<AccessGrant> applicator = applicatorFor(providerId);
+
+        return applicator.applyTo(connection, accessGrant);
+    }
+
+    protected static AcquisitionMethod acquisitionMethodFor(final ConnectionFactory<?> connectionFactory) {
+        final String providerId = connectionFactory.getProviderId();
+
+        return new AcquisitionMethod.Builder().label(labelFor(providerId)).icon(iconFor(providerId))
+            .type(typeOf(connectionFactory)).description(descriptionFor(providerId)).build();
+    }
+
+    protected static String callbackUrlFor(final NativeWebRequest request,
+        final MultiValueMap<String, String> additionalParams) {
+        final HttpServletRequest httpServletRequest = request.getNativeRequest(HttpServletRequest.class);
+
+        final URI requestUri = URI.create(httpServletRequest.getRequestURL().toString());
+
+        final String path = requestUri.getPath();
+
+        final String callbackPath = API_BASE_PATH.matcher(path).replaceFirst("$1/credentials/callback");
+
+        try {
+            final URI base = new URI(requestUri.getScheme(), requestUri.getHost(), callbackPath, null);
+
+            return UriComponentsBuilder.fromUri(base).queryParams(additionalParams).build().toUriString();
+        } catch (final URISyntaxException e) {
+            throw new IllegalStateException("Unable to generate callback URI", e);
+        }
+    }
+
+    protected static String descriptionFor(final String providerId) {
+        return providerId;
+    }
+
+    protected static String iconFor(final String providerId) {
+        return providerId;
+    }
+
+    protected static String labelFor(final String providerId) {
+        return providerId;
+    }
+
+    protected static String prepareOAuth1(final OAuth1ConnectionFactory<?> oauth1,
+        final CredentialFlowState.Builder flowStateBuilder, final NativeWebRequest request) {
+        final OAuth1Operations oauthOperations = oauth1.getOAuthOperations();
+        final OAuth1Parameters parameters = new OAuth1Parameters();
+
+        final String stateKey = UUID.randomUUID().toString();
+        flowStateBuilder.key(stateKey);
+
+        final OAuthToken oAuthToken;
+        final OAuth1Version oAuthVersion = oauthOperations.getVersion();
+
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        parameters.set("state", stateKey);
+
+        if (oAuthVersion == OAuth1Version.CORE_10) {
+            parameters.setCallbackUrl(callbackUrlFor(request, params));
+
+            oAuthToken = oauthOperations.fetchRequestToken(null, null);
+        } else if (oAuthVersion == OAuth1Version.CORE_10_REVISION_A) {
+            oAuthToken = oauthOperations.fetchRequestToken(callbackUrlFor(request, params), null);
+        } else {
+            throw new IllegalStateException("Unsupported OAuth 1 version: " + oAuthVersion);
+        }
+        flowStateBuilder.token(oAuthToken);
+
+        return oauthOperations.buildAuthorizeUrl(oAuthToken.getValue(), parameters);
+    }
+
+    protected static String prepareOAuth2(final OAuth2ConnectionFactory<?> oauth2,
+        final CredentialFlowState.Builder flowStateBuilder, final NativeWebRequest request) {
+        final OAuth2Parameters parameters = new OAuth2Parameters();
+
+        final String callbackUrl = callbackUrlFor(request, EMPTY);
+        parameters.setRedirectUri(callbackUrl);
+
+        final String scope = oauth2.getScope();
+        parameters.setScope(scope);
+
+        final String stateKey = oauth2.generateState();
+        flowStateBuilder.key(stateKey);
+        parameters.add("state", stateKey);
+
+        final OAuth2Operations oauthOperations = oauth2.getOAuthOperations();
+
+        return oauthOperations.buildAuthorizeUrl(parameters);
+    }
+
+    protected static AcquisitionMethod.Type typeOf(final ConnectionFactory<?> connectionFactory) {
+        Assert.notNull(connectionFactory, "ConnectionFactory is required");
+
+        if (connectionFactory instanceof OAuth1ConnectionFactory) {
+            return AcquisitionMethod.Type.OAUTH1;
+        } else if (connectionFactory instanceof OAuth2ConnectionFactory) {
+            return AcquisitionMethod.Type.OAUTH2;
+        }
+
+        throw new IllegalArgumentException("Unknown ConnectionFactory type: " + connectionFactory.getClass());
+    }
+}

--- a/credential/src/main/java/io/syndesis/credential/DefaultCredentialProvider.java
+++ b/credential/src/main/java/io/syndesis/credential/DefaultCredentialProvider.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import org.springframework.social.connect.ConnectionFactory;
+
+public class DefaultCredentialProvider<A, T> implements CredentialProvider<A, T> {
+
+    private final Applicator<T> applicator;
+
+    private final ConnectionFactory<A> connectionFactory;
+
+    public DefaultCredentialProvider(final ConnectionFactory<A> connectionFactory, final Applicator<T> applicator) {
+        this.connectionFactory = connectionFactory;
+        this.applicator = applicator;
+    }
+
+    @Override
+    public Applicator<T> applicator() {
+        return applicator;
+    }
+
+    @Override
+    public ConnectionFactory<A> connectionFactory() {
+        return connectionFactory;
+    }
+
+}

--- a/credential/src/main/java/io/syndesis/credential/DefaultCredentialProviderFactoryConfigurer.java
+++ b/credential/src/main/java/io/syndesis/credential/DefaultCredentialProviderFactoryConfigurer.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+final class DefaultCredentialProviderFactoryConfigurer implements CredentialProviderConfigurer {
+
+    private final CredentialProviderRegistry registry;
+
+    public DefaultCredentialProviderFactoryConfigurer() {
+        registry = new CredentialProviderRegistry();
+    }
+
+    @Override
+    public <A, T> void addCredentialProvider(final CredentialProvider<A, T> credentialProvider) {
+        registry.addCredentialProvider(credentialProvider);
+    }
+
+    public CredentialProviderLocator getCredentialProviderLocator() {
+        return registry;
+    }
+
+}

--- a/credential/src/main/java/io/syndesis/credential/OAuth1Applicator.java
+++ b/credential/src/main/java/io/syndesis/credential/OAuth1Applicator.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.util.Date;
+
+import io.syndesis.model.connection.Connection;
+
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.social.oauth1.OAuthToken;
+
+public class OAuth1Applicator implements Applicator<OAuthToken> {
+
+    private String accessTokenSecretProperty;
+
+    private String accessTokenValueProperty;
+
+    private final String consumerKey;
+
+    private String consumerKeyProperty;
+
+    private final String consumerSecret;
+
+    private String consumerSecretProperty;
+
+    public OAuth1Applicator(final SocialProperties properties) {
+        consumerKey = properties.getAppId();
+        consumerSecret = properties.getAppSecret();
+    }
+
+    @Override
+    public Connection applyTo(final Connection connection, final OAuthToken token) {
+        final Connection.Builder mutableConnection = new Connection.Builder().createFrom(connection)
+            .lastUpdated(new Date());
+
+        Applicator.applyProperty(mutableConnection, accessTokenValueProperty, token.getValue());
+        Applicator.applyProperty(mutableConnection, accessTokenSecretProperty, token.getSecret());
+        Applicator.applyProperty(mutableConnection, consumerKeyProperty, consumerKey);
+        Applicator.applyProperty(mutableConnection, consumerSecretProperty, consumerSecret);
+
+        return mutableConnection.build();
+    }
+
+    public void setAccessTokenSecretProperty(final String accessTokenSecretProperty) {
+        this.accessTokenSecretProperty = accessTokenSecretProperty;
+    }
+
+    public void setAccessTokenValueProperty(final String accessTokenValueProperty) {
+        this.accessTokenValueProperty = accessTokenValueProperty;
+    }
+
+    public void setConsumerKeyProperty(final String consumerKeyProperty) {
+        this.consumerKeyProperty = consumerKeyProperty;
+    }
+
+    public void setConsumerSecretProperty(final String consumerSecretProperty) {
+        this.consumerSecretProperty = consumerSecretProperty;
+    }
+
+}

--- a/credential/src/main/java/io/syndesis/credential/OAuth2Applicator.java
+++ b/credential/src/main/java/io/syndesis/credential/OAuth2Applicator.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.util.Date;
+
+import io.syndesis.model.connection.Connection;
+
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.social.connect.ConnectionFactory;
+import org.springframework.social.oauth2.AccessGrant;
+
+/**
+ * Applies given {@link AccessGrant} to mutable Connection (i.e.
+ * {@link Connection.Builder}. This allows {@link ConnectionFactory}
+ * implementations to apply the credentials to specific properties of the
+ * {@link Connection}.
+ * <p>
+ * For instance setting {@code camel.component.salesforce.clientId} and
+ * {@code camel.component.salesforce.clientSecret} properties on the Salesforce
+ * connector.
+ */
+public class OAuth2Applicator implements Applicator<AccessGrant> {
+
+    private String accessTokenProperty;
+
+    private String clientIdProperty;
+
+    private String clientSecretProperty;
+
+    private String refreshTokenProperty;
+
+    private final SocialProperties socialProperties;
+
+    public OAuth2Applicator(final SocialProperties socialProperties) {
+        this.socialProperties = socialProperties;
+    }
+
+    /**
+     * Default implementation that applies {@link SocialProperties} and
+     * {@link AccessGrant} to {@link Connection.Builder}.
+     */
+    @Override
+    public final Connection applyTo(final Connection connection, final AccessGrant accessGrant) {
+        final Connection.Builder mutableConnection = new Connection.Builder().createFrom(connection)
+            .lastUpdated(new Date());
+
+        Applicator.applyProperty(mutableConnection, clientIdProperty, socialProperties.getAppId());
+        Applicator.applyProperty(mutableConnection, clientSecretProperty, socialProperties.getAppSecret());
+        Applicator.applyProperty(mutableConnection, accessTokenProperty, accessGrant.getAccessToken());
+        Applicator.applyProperty(mutableConnection, refreshTokenProperty, accessGrant.getRefreshToken());
+
+        additionalApplication(mutableConnection, accessGrant);
+
+        return mutableConnection.build();
+    }
+
+    public final void setAccessTokenProperty(final String accessTokenProperty) {
+        this.accessTokenProperty = accessTokenProperty;
+    }
+
+    public final void setClientIdProperty(final String clientIdProperty) {
+        this.clientIdProperty = clientIdProperty;
+    }
+
+    public final void setClientSecretProperty(final String clientSecretProperty) {
+        this.clientSecretProperty = clientSecretProperty;
+    }
+
+    public final void setRefreshTokenProperty(final String refreshTokenProperty) {
+        this.refreshTokenProperty = refreshTokenProperty;
+    }
+
+    protected void additionalApplication(final Connection.Builder mutableConnection, final AccessGrant accessGrant) {
+        // subclass hook
+    }
+
+}

--- a/credential/src/main/java/io/syndesis/credential/RelativeUri.java
+++ b/credential/src/main/java/io/syndesis/credential/RelativeUri.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Validates that the given URI is relative.
+ */
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = RelativeUriValidator.class)
+public @interface RelativeUri {
+
+    Class<?>[] groups() default {};
+
+    String message() default "{io.syndesis.credential.RelativeUri.message}";
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/credential/src/main/java/io/syndesis/credential/RelativeUriValidator.java
+++ b/credential/src/main/java/io/syndesis/credential/RelativeUriValidator.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.net.URI;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class RelativeUriValidator implements ConstraintValidator<RelativeUri, URI> {
+
+    @Override
+    public void initialize(final RelativeUri constraintAnnotation) {
+        // nothing to configure
+    }
+
+    @Override
+    public boolean isValid(final URI value, final ConstraintValidatorContext context) {
+        return value != null && !value.isAbsolute();
+    }
+
+}

--- a/credential/src/main/java/io/syndesis/credential/package-info.java
+++ b/credential/src/main/java/io/syndesis/credential/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@io.syndesis.model.ImmutablesStyle
+package io.syndesis.credential;

--- a/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceConfiguration.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential.salesforce;
+
+import io.syndesis.credential.Applicator;
+import io.syndesis.credential.CredentialProvider;
+import io.syndesis.credential.CredentialProviderConfiguration;
+import io.syndesis.credential.CredentialProviderConfigurer;
+import io.syndesis.credential.DefaultCredentialProvider;
+import io.syndesis.credential.OAuth2Applicator;
+import io.syndesis.model.connection.Connection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.social.config.annotation.SocialConfigurerAdapter;
+import org.springframework.social.oauth2.AccessGrant;
+import org.springframework.social.oauth2.OAuth2Template;
+import org.springframework.social.salesforce.api.Salesforce;
+import org.springframework.social.salesforce.connect.SalesforceConnectionFactory;
+
+@Configuration
+@ConditionalOnClass({SocialConfigurerAdapter.class, SalesforceConnectionFactory.class})
+@ConditionalOnProperty(prefix = "spring.social.salesforce", name = "app-id")
+@EnableConfigurationProperties(SalesforceProperties.class)
+public class SalesforceConfiguration implements CredentialProviderConfiguration {
+
+    protected final SalesforceApplicator applicator;
+
+    protected final SalesforceConnectionFactory salesforce;
+
+    protected final class SalesforceApplicator extends OAuth2Applicator {
+
+        public SalesforceApplicator(final SocialProperties socialProperties) {
+            super(socialProperties);
+
+            setClientIdProperty("clientId");
+            setClientSecretProperty("clientSecret");
+            setRefreshTokenProperty("refreshToken");
+        }
+
+        @Override
+        protected void additionalApplication(final Connection.Builder mutableConnection,
+            final AccessGrant accessGrant) {
+
+            final org.springframework.social.connect.Connection<Salesforce> salesforceConnection = salesforce
+                .createConnection(accessGrant);
+            final Salesforce salesforceApi = salesforceConnection.getApi();
+
+            final String instanceUrl = salesforceApi.getInstanceUrl();
+            Applicator.applyProperty(mutableConnection, "instanceUrl", instanceUrl);
+        }
+    }
+
+    @Autowired
+    public SalesforceConfiguration(final SalesforceProperties salesforceProperties) {
+        this(createConnectionFactory(salesforceProperties), salesforceProperties);
+    }
+
+    protected SalesforceConfiguration(final SalesforceConnectionFactory salesforce,
+        final SocialProperties salesforceProperties) {
+        this.salesforce = salesforce;
+        applicator = new SalesforceApplicator(salesforceProperties);
+    }
+
+    @Override
+    public void addCredentialProviderTo(final CredentialProviderConfigurer configurer) {
+        final CredentialProvider<Salesforce, AccessGrant> credentialProvider = new DefaultCredentialProvider<>(
+            salesforce, applicator);
+
+        configurer.addCredentialProvider(credentialProvider);
+    }
+
+    protected static SalesforceConnectionFactory
+        createConnectionFactory(final SalesforceProperties salesforceProperties) {
+        final SalesforceConnectionFactory salesforce = new SalesforceConnectionFactory(salesforceProperties.getAppId(),
+            salesforceProperties.getAppSecret());
+
+        final OAuth2Template oAuthOperations = (OAuth2Template) salesforce.getOAuthOperations();
+
+        // Salesforce requires OAuth client id and secret on the OAuth request
+        oAuthOperations.setUseParametersForClientAuthentication(true);
+
+        return salesforce;
+    }
+
+}

--- a/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceProperties.java
+++ b/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceProperties.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential.salesforce;
+
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.social.salesforce")
+public final class SalesforceProperties extends SocialProperties {
+
+}

--- a/credential/src/main/java/io/syndesis/credential/twitter/TwitterConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/twitter/TwitterConfiguration.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential.twitter;
+
+import io.syndesis.credential.CredentialProviderConfiguration;
+import io.syndesis.credential.CredentialProviderConfigurer;
+import io.syndesis.credential.DefaultCredentialProvider;
+import io.syndesis.credential.OAuth1Applicator;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.social.TwitterProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.social.config.annotation.SocialConfigurerAdapter;
+import org.springframework.social.oauth1.OAuthToken;
+import org.springframework.social.twitter.api.Twitter;
+import org.springframework.social.twitter.connect.TwitterConnectionFactory;
+
+@Configuration
+@ConditionalOnClass({SocialConfigurerAdapter.class, TwitterConnectionFactory.class})
+@ConditionalOnProperty(prefix = "spring.social.twitter", name = "app-id")
+@EnableConfigurationProperties(TwitterProperties.class)
+public class TwitterConfiguration implements CredentialProviderConfiguration {
+
+    private final OAuth1Applicator applicator;
+
+    private final TwitterConnectionFactory twitter;
+
+    protected TwitterConfiguration(final TwitterProperties properties) {
+        twitter = new TwitterConnectionFactory(properties.getAppId(), properties.getAppSecret());
+        applicator = new OAuth1Applicator(properties);
+        applicator.setConsumerKeyProperty("consumerKey");
+        applicator.setConsumerSecretProperty("consumerSecret");
+        applicator.setAccessTokenSecretProperty("accessTokenSecret");
+        applicator.setAccessTokenValueProperty("accessToken");
+    }
+
+    @Override
+    public void addCredentialProviderTo(final CredentialProviderConfigurer configurer) {
+        final DefaultCredentialProvider<Twitter, OAuthToken> twitterCredentialProvider = new DefaultCredentialProvider<>(
+            twitter, applicator);
+
+        configurer.addCredentialProvider(twitterCredentialProvider);
+
+    }
+
+}

--- a/credential/src/main/resources/META-INF/spring.factories
+++ b/credential/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.syndesis.credential.CredentialConfiguration,\
+io.syndesis.credential.salesforce.SalesforceConfiguration,\
+io.syndesis.credential.twitter.TwitterConfiguration

--- a/credential/src/test/java/io/syndesis/credential/ApplicatorTest.java
+++ b/credential/src/test/java/io/syndesis/credential/ApplicatorTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import io.syndesis.model.connection.Connection;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ApplicatorTest {
+
+    @Test
+    public void shouldApplyPropertyValues() {
+        final Connection.Builder connection = new Connection.Builder();
+
+        Applicator.applyProperty(connection, "property", "value");
+
+        final Connection built = connection.build();
+
+        assertThat(built.getConfiguredProperties()).containsEntry("property", "value");
+    }
+
+    @Test
+    public void shouldNotApplyNullOrEmptyPropertyValues() {
+        final Connection.Builder connection = new Connection.Builder();
+
+        Applicator.applyProperty(connection, "emptyProperty", "");
+
+        Applicator.applyProperty(connection, "nullProperty", "");
+
+        final Connection built = connection.build();
+
+        assertThat(built.getConfiguredProperties()).isEmpty();
+    }
+}

--- a/credential/src/test/java/io/syndesis/credential/CredentialProviderRegistryTest.java
+++ b/credential/src/test/java/io/syndesis/credential/CredentialProviderRegistryTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import org.junit.Test;
+import org.springframework.social.connect.ConnectionFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CredentialProviderRegistryTest {
+
+    @Test
+    public void shouldAllowProviderRegistration() {
+        final CredentialProviderRegistry registry = new CredentialProviderRegistry();
+
+        @SuppressWarnings("unchecked")
+        final CredentialProvider<Object, ?> provider = mock(CredentialProvider.class);
+
+        @SuppressWarnings("unchecked")
+        final ConnectionFactory<Object> connectionFactory = mock(ConnectionFactory.class);
+        when(provider.connectionFactory()).thenReturn(connectionFactory);
+        when(connectionFactory.getProviderId()).thenReturn("a-provider");
+
+        registry.addCredentialProvider(provider);
+
+        assertThat(registry.getConnectionFactory("a-provider")).isEqualTo(connectionFactory);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldComplainAboutUnregisteredProviders() {
+        final CredentialProviderRegistry registry = new CredentialProviderRegistry();
+
+        registry.getConnectionFactory("unregistered");
+    }
+}

--- a/credential/src/test/java/io/syndesis/credential/CredentialsIntegrationTest.java
+++ b/credential/src/test/java/io/syndesis/credential/CredentialsIntegrationTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.syndesis.core.EventBus;
+import io.syndesis.credential.CredentialsIntegrationTest.TestConfiguration;
+import io.syndesis.dao.ConnectionDao;
+
+import org.infinispan.manager.CacheContainer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.social.FacebookAutoConfiguration;
+import org.springframework.boot.autoconfigure.social.LinkedInAutoConfiguration;
+import org.springframework.boot.autoconfigure.social.SocialWebAutoConfiguration;
+import org.springframework.boot.autoconfigure.social.TwitterAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(Parameterized.class)
+@ContextConfiguration(classes = {CredentialConfiguration.class, TestConfiguration.class})
+@SpringBootTest
+@EnableAutoConfiguration(exclude = {TwitterAutoConfiguration.class, FacebookAutoConfiguration.class,
+    LinkedInAutoConfiguration.class, SocialWebAutoConfiguration.class})
+@PropertySource(value = "dynamic", name = "dynamic", factory = CredentialsIntegrationTest.DynamicPropertySource.class)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@Configuration
+public class CredentialsIntegrationTest {
+
+    @Parameter(0)
+    public static String PROVIDER;
+
+    @ClassRule
+    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
+
+    @Rule
+    public final SpringMethodRule springMethodRule = new SpringMethodRule();
+
+    @Autowired
+    private CredentialProviderLocator credentialProviderLocator;
+
+    @Configuration
+    public static class TestConfiguration {
+        @Bean
+        public CacheContainer cacheContainer() {
+            return mock(CacheContainer.class);
+        }
+
+        @Bean
+        public CacheManager cacheManager() {
+            final SimpleCacheManager cacheManager = new SimpleCacheManager();
+
+            final Cache cache = new ConcurrentMapCache(Credentials.CACHE_NAME);
+
+            cacheManager.setCaches(Collections.singletonList(cache));
+
+            return cacheManager;
+        }
+
+        @Bean
+        public ConnectionDao connectionDao() {
+            return mock(ConnectionDao.class);
+        }
+
+        @Bean
+        public EventBus eventBus() {
+            return mock(EventBus.class);
+        }
+    }
+
+    static class DynamicPropertySource implements PropertySourceFactory {
+        @Override
+        public org.springframework.core.env.PropertySource<?> createPropertySource(final String name,
+            final EncodedResource resource) throws IOException {
+            final Map<String, Object> properties = new HashMap<>();
+
+            // needed by DataManager
+            properties.put("deployment.file", "");
+
+            properties.put("spring.social." + PROVIDER + ".appId", "testClientId");
+            properties.put("spring.social." + PROVIDER + ".appSecret", "testClientSecret");
+
+            return new MapPropertySource(name, properties);
+        }
+    }
+
+    @Test
+    public void shouldSupportResourceProviders() {
+        assertThat(credentialProviderLocator.getConnectionFactory(PROVIDER)).isNotNull();
+        assertThat(credentialProviderLocator.getApplicator(PROVIDER)).isNotNull();
+    }
+
+    @Parameters(name = "provider={0}")
+    public static Iterable<String> resourceProviders() {
+        return Arrays.asList("salesforce", "twitter");
+    }
+}

--- a/credential/src/test/java/io/syndesis/credential/CredentialsTest.java
+++ b/credential/src/test/java/io/syndesis/credential/CredentialsTest.java
@@ -1,0 +1,323 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import io.syndesis.credential.Acquisition.Type;
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.model.connection.Connection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.social.connect.ConnectionFactory;
+import org.springframework.social.connect.support.OAuth1ConnectionFactory;
+import org.springframework.social.connect.support.OAuth2ConnectionFactory;
+import org.springframework.social.oauth1.AuthorizedRequestToken;
+import org.springframework.social.oauth1.OAuth1Operations;
+import org.springframework.social.oauth1.OAuth1Parameters;
+import org.springframework.social.oauth1.OAuth1Version;
+import org.springframework.social.oauth1.OAuthToken;
+import org.springframework.social.oauth2.AccessGrant;
+import org.springframework.social.oauth2.OAuth2Operations;
+import org.springframework.social.oauth2.OAuth2Parameters;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CredentialsTest {
+
+    private static final MultiValueMap<String, String> NONE = new LinkedMultiValueMap<>();
+
+    @Mock
+    private CacheManager cacheManager;
+
+    private Credentials credentials;
+
+    @Mock
+    private DataManager dataManager;
+
+    @Mock
+    private CredentialProviderLocator locator;
+
+    private final SocialProperties properties = new SocialProperties() {
+    };
+
+    @Mock
+    private NativeWebRequest request;
+
+    @Mock
+    private Cache state;
+
+    @Before
+    public void setupMocks() {
+        when(cacheManager.getCache(Credentials.CACHE_NAME)).thenReturn(state);
+
+        final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(request.getNativeRequest(HttpServletRequest.class)).thenReturn(httpRequest);
+        when(httpRequest.getRequestURL())
+            .thenReturn(new StringBuffer("https://syndesis.io/api/v1/connections/providerId/credentials"));
+
+        final Connection connection = new Connection.Builder().build();
+        when(dataManager.fetch(Connection.class, "connectionId")).thenReturn(connection);
+
+        credentials = new Credentials(locator, dataManager, cacheManager);
+
+        properties.setAppId("appId");
+        properties.setAppSecret("appSecret");
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void shouldAcquireOAuth1aCredentials() {
+        final OAuth1ConnectionFactory<?> oauth1 = mock(OAuth1ConnectionFactory.class);
+        when((OAuth1ConnectionFactory) locator.getConnectionFactory("providerId")).thenReturn(oauth1);
+        final OAuth1Operations operations = mock(OAuth1Operations.class);
+        when(oauth1.getOAuthOperations()).thenReturn(operations);
+        when(operations.getVersion()).thenReturn(OAuth1Version.CORE_10_REVISION_A);
+        final OAuthToken token = new OAuthToken("value", "secret");
+        when(operations.fetchRequestToken("https://syndesis.io/api/v1/credentials/callback", null)).thenReturn(token);
+
+        final ArgumentCaptor<OAuth1Parameters> parameters = ArgumentCaptor.forClass(OAuth1Parameters.class);
+        when(operations.buildAuthorizeUrl(eq("value"), parameters.capture()))
+            .thenReturn("https://provider.io/oauth/authorize");
+
+        final Acquisition acquisition = credentials.acquire("connectionId", "providerId", URI.create("/ui#state"),
+            request);
+
+        final Acquisition expected = new Acquisition.Builder().type(Type.REDIRECT)
+            .url("https://provider.io/oauth/authorize").build();
+        assertThat(acquisition).isEqualTo(expected);
+        final OAuth1Parameters oAuth1Parameters = parameters.getValue();
+        assertThat(oAuth1Parameters.getCallbackUrl()).isNull();
+        final List<String> capturedState = oAuth1Parameters.get("state");
+        assertThat(capturedState).hasSize(1);
+        final String stateValue = capturedState.get(0);
+        assertThat(stateValue).isNotEmpty();
+
+        final CredentialFlowState flowState = new CredentialFlowState.Builder().key(stateValue)
+            .connectionId("connectionId").providerId("providerId").returnUrl(URI.create("/ui#state")).token(token)
+            .build();
+        verify(state).put(stateValue, flowState);
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void shouldAcquireOAuth1Credentials() {
+        final OAuth1ConnectionFactory<?> oauth1 = mock(OAuth1ConnectionFactory.class);
+        when((OAuth1ConnectionFactory) locator.getConnectionFactory("providerId")).thenReturn(oauth1);
+        final OAuth1Operations operations = mock(OAuth1Operations.class);
+        when(oauth1.getOAuthOperations()).thenReturn(operations);
+        when(operations.getVersion()).thenReturn(OAuth1Version.CORE_10);
+        final OAuthToken token = new OAuthToken("value", "secret");
+        when(operations.fetchRequestToken(null, null)).thenReturn(token);
+
+        final ArgumentCaptor<OAuth1Parameters> parameters = ArgumentCaptor.forClass(OAuth1Parameters.class);
+        when(operations.buildAuthorizeUrl(eq("value"), parameters.capture()))
+            .thenReturn("https://provider.io/oauth/authorize");
+
+        final Acquisition acquisition = credentials.acquire("connectionId", "providerId", URI.create("/ui#state"),
+            request);
+
+        final Acquisition expected = new Acquisition.Builder().type(Type.REDIRECT)
+            .url("https://provider.io/oauth/authorize").build();
+        assertThat(acquisition).isEqualTo(expected);
+        final OAuth1Parameters oAuth1Parameters = parameters.getValue();
+        assertThat(oAuth1Parameters.getCallbackUrl()).isEqualTo("https://syndesis.io/api/v1/credentials/callback");
+        final List<String> capturedState = oAuth1Parameters.get("state");
+        assertThat(capturedState).hasSize(1);
+        final String stateValue = capturedState.get(0);
+        assertThat(stateValue).isNotEmpty();
+
+        final CredentialFlowState flowState = new CredentialFlowState.Builder().key(stateValue)
+            .connectionId("connectionId").providerId("providerId").returnUrl(URI.create("/ui#state")).token(token)
+            .build();
+        verify(state).put(stateValue, flowState);
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void shouldAcquireOAuth2Credentials() {
+        final OAuth2ConnectionFactory<?> oauth2 = mock(OAuth2ConnectionFactory.class);
+        when((OAuth2ConnectionFactory) locator.getConnectionFactory("providerId")).thenReturn(oauth2);
+        when(oauth2.getScope()).thenReturn("scope");
+        when(oauth2.generateState()).thenReturn("state-token");
+        final OAuth2Operations operations = mock(OAuth2Operations.class);
+        when(oauth2.getOAuthOperations()).thenReturn(operations);
+        final ArgumentCaptor<OAuth2Parameters> parameters = ArgumentCaptor.forClass(OAuth2Parameters.class);
+        when(operations.buildAuthorizeUrl(parameters.capture())).thenReturn("https://provider.io/oauth/authorize");
+
+        final Acquisition acquisition = credentials.acquire("connectionId", "providerId", URI.create("/ui#state"),
+            request);
+
+        final Acquisition expected = new Acquisition.Builder().type(Type.REDIRECT)
+            .url("https://provider.io/oauth/authorize").build();
+        assertThat(acquisition).isEqualTo(expected);
+
+        final OAuth2Parameters capturedParameters = parameters.getValue();
+        assertThat(capturedParameters.getRedirectUri()).isEqualTo("https://syndesis.io/api/v1/credentials/callback");
+        assertThat(capturedParameters.getScope()).isEqualTo("scope");
+        assertThat(capturedParameters.getState()).isEqualTo("state-token");
+
+        final CredentialFlowState flowState = new CredentialFlowState.Builder().key("state-token")
+            .connectionId("connectionId").providerId("providerId").returnUrl(URI.create("/ui#state")).build();
+        verify(state).put("state-token", flowState);
+    }
+
+    @Test
+    public void shouldCreateAcquisitionMethodFromConnectionFactory() {
+        final ConnectionFactory<?> oauth1 = mock(OAuth1ConnectionFactory.class);
+        when(oauth1.getProviderId()).thenReturn("provider1");
+        final ImmutableAcquisitionMethod method1 = new AcquisitionMethod.Builder().description("provider1")
+            .label("provider1").icon("provider1").type(AcquisitionMethod.Type.OAUTH1).build();
+        assertThat(Credentials.acquisitionMethodFor(oauth1)).isEqualTo(method1);
+
+        final ConnectionFactory<?> oauth2 = mock(OAuth2ConnectionFactory.class);
+        when(oauth2.getProviderId()).thenReturn("provider2");
+        final ImmutableAcquisitionMethod method2 = new AcquisitionMethod.Builder().description("provider2")
+            .label("provider2").icon("provider2").type(AcquisitionMethod.Type.OAUTH2).build();
+        assertThat(Credentials.acquisitionMethodFor(oauth2)).isEqualTo(method2);
+    }
+
+    @Test
+    public void shouldDetermineAcquisitionMethodOfConnectionFactories() {
+        final ConnectionFactory<?> oauth1 = mock(OAuth1ConnectionFactory.class);
+        assertThat(Credentials.typeOf(oauth1)).isEqualTo(AcquisitionMethod.Type.OAUTH1);
+
+        final ConnectionFactory<?> oauth2 = mock(OAuth2ConnectionFactory.class);
+        assertThat(Credentials.typeOf(oauth2)).isEqualTo(AcquisitionMethod.Type.OAUTH2);
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void shouldFinishOAuth1Acquisition() {
+        final OAuthToken token = new OAuthToken("value", "secret");
+        when(state.get("state", CredentialFlowState.class))
+            .thenReturn(new CredentialFlowState.Builder().connectionId("connectionId").providerId("providerId")
+                .token(token).returnUrl(URI.create("/ui#state")).build());
+
+        final OAuth1ConnectionFactory<?> oauth1 = mock(OAuth1ConnectionFactory.class);
+        when((OAuth1ConnectionFactory) locator.getConnectionFactory("providerId")).thenReturn(oauth1);
+        final OAuth1Operations operations = mock(OAuth1Operations.class);
+        when(oauth1.getOAuthOperations()).thenReturn(operations);
+
+        when(request.getParameter("oauth_verifier")).thenReturn("verifier");
+
+        final ArgumentCaptor<AuthorizedRequestToken> requestToken = ArgumentCaptor
+            .forClass(AuthorizedRequestToken.class);
+        final OAuthToken accessToken = new OAuthToken("tokenValue", "tokenSecret");
+        @SuppressWarnings("unchecked")
+        final Class<MultiValueMap<String, String>> multimapType = (Class) MultiValueMap.class;
+        when(operations.exchangeForAccessToken(requestToken.capture(), isNull(multimapType))).thenReturn(accessToken);
+
+        final OAuth1Applicator applicator = new OAuth1Applicator(properties);
+        applicator.setAccessTokenSecretProperty("accessTokenSecretProperty");
+        applicator.setAccessTokenValueProperty("accessTokenValueProperty");
+        applicator.setConsumerKeyProperty("consumerKeyProperty");
+        applicator.setConsumerSecretProperty("consumerSecretProperty");
+        when((OAuth1Applicator) locator.getApplicator("providerId")).thenReturn(applicator);
+
+        final URI uri = credentials.finishAcquisition("state", request);
+
+        assertThat(uri).isEqualTo(URI.create("/ui#state"));
+        final AuthorizedRequestToken capturedRequestToken = requestToken.getValue();
+        assertThat(capturedRequestToken.getValue()).isEqualTo("value");
+        assertThat(capturedRequestToken.getSecret()).isEqualTo("secret");
+        assertThat(capturedRequestToken.getVerifier()).isEqualTo("verifier");
+
+        final ArgumentCaptor<Connection> updatedConnection = ArgumentCaptor.forClass(Connection.class);
+        verify(dataManager).update(updatedConnection.capture());
+
+        final Connection capturedConnection = updatedConnection.getValue();
+        final Connection expected = new Connection.Builder()
+            .putConfiguredProperty("accessTokenSecretProperty", "tokenSecret")
+            .putConfiguredProperty("accessTokenValueProperty", "tokenValue")
+            .putConfiguredProperty("consumerKeyProperty", "appId")
+            .putConfiguredProperty("consumerSecretProperty", "appSecret").build();
+        assertThat(capturedConnection).isEqualToIgnoringGivenFields(expected, "lastUpdated");
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void shouldFinishOAuth2Acquisition() {
+        final OAuthToken token = new OAuthToken("value", "secret");
+        when(state.get("state", CredentialFlowState.class))
+            .thenReturn(new CredentialFlowState.Builder().connectionId("connectionId").providerId("providerId")
+                .token(token).returnUrl(URI.create("/ui#state")).build());
+
+        final OAuth2ConnectionFactory<?> oauth2 = mock(OAuth2ConnectionFactory.class);
+        when((OAuth2ConnectionFactory) locator.getConnectionFactory("providerId")).thenReturn(oauth2);
+        final OAuth2Operations operations = mock(OAuth2Operations.class);
+        when(oauth2.getOAuthOperations()).thenReturn(operations);
+
+        when(request.getParameter("code")).thenReturn("code");
+
+        final OAuth2Applicator applicator = new OAuth2Applicator(properties);
+        applicator.setAccessTokenProperty("accessTokenProperty");
+        applicator.setClientIdProperty("clientIdProperty");
+        applicator.setClientSecretProperty("clientSecretProperty");
+        applicator.setRefreshTokenProperty("refreshTokenProperty");
+        when((OAuth2Applicator) locator.getApplicator("providerId")).thenReturn(applicator);
+
+        when(operations.exchangeForAccess("code", "https://syndesis.io/api/v1/credentials/callback", null))
+            .thenReturn(new AccessGrant("accessToken", "scope", "refreshToken", 1L));
+
+        final URI uri = credentials.finishAcquisition("state", request);
+
+        assertThat(uri).isEqualTo(URI.create("/ui#state"));
+
+        final ArgumentCaptor<Connection> updatedConnection = ArgumentCaptor.forClass(Connection.class);
+        verify(dataManager).update(updatedConnection.capture());
+
+        final Connection capturedConnection = updatedConnection.getValue();
+        final Connection expected = new Connection.Builder().putConfiguredProperty("accessTokenProperty", "accessToken")
+            .putConfiguredProperty("clientIdProperty", "appId")
+            .putConfiguredProperty("clientSecretProperty", "appSecret")
+            .putConfiguredProperty("refreshTokenProperty", "refreshToken").build();
+        assertThat(capturedConnection).isEqualToIgnoringGivenFields(expected, "lastUpdated");
+    }
+
+    @Test
+    public void shouldGenerateConnectUrl() {
+        assertThat(Credentials.callbackUrlFor(request, NONE)).as("The computed callback URL is not as expected")
+            .isEqualTo("https://syndesis.io/api/v1/credentials/callback");
+
+        final MultiValueMap<String, String> some = new LinkedMultiValueMap<>();
+        some.set("param1", "value1");
+        some.set("param2", "value2");
+
+        assertThat(Credentials.callbackUrlFor(request, some)).as("The computed callback URL is not as expected")
+            .isEqualTo("https://syndesis.io/api/v1/credentials/callback?param1=value1&param2=value2");
+    }
+}

--- a/credential/src/test/java/io/syndesis/credential/OAuth1ApplicatorTest.java
+++ b/credential/src/test/java/io/syndesis/credential/OAuth1ApplicatorTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import io.syndesis.model.connection.Connection;
+
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.social.oauth1.OAuthToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OAuth1ApplicatorTest {
+
+    @Test
+    public void shouldApplyTokens() {
+        final SocialProperties properties = new SocialProperties() {
+        };
+        properties.setAppId("appId");
+        properties.setAppSecret("appSecret");
+
+        final OAuth1Applicator applicator = new OAuth1Applicator(properties);
+        applicator.setAccessTokenSecretProperty("accessTokenSecretProperty");
+        applicator.setAccessTokenValueProperty("accessTokenValueProperty");
+        applicator.setConsumerKeyProperty("consumerKeyProperty");
+        applicator.setConsumerSecretProperty("consumerSecretProperty");
+
+        final Connection connection = new Connection.Builder().build();
+
+        final Connection result = applicator.applyTo(connection, new OAuthToken("tokenValue", "tokenSecret"));
+
+        final Connection expected = new Connection.Builder()
+            .putConfiguredProperty("accessTokenSecretProperty", "tokenSecret")
+            .putConfiguredProperty("accessTokenValueProperty", "tokenValue")
+            .putConfiguredProperty("consumerKeyProperty", "appId")
+            .putConfiguredProperty("consumerSecretProperty", "appSecret").build();
+
+        assertThat(result).isEqualToIgnoringGivenFields(expected, "lastUpdated");
+        assertThat(result.getLastUpdated()).isPresent();
+    }
+}

--- a/credential/src/test/java/io/syndesis/credential/OAuth2ApplicatorTest.java
+++ b/credential/src/test/java/io/syndesis/credential/OAuth2ApplicatorTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import io.syndesis.model.connection.Connection;
+
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.social.oauth2.AccessGrant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OAuth2ApplicatorTest {
+
+    @Test
+    public void shouldApplyAccessGrants() {
+        final SocialProperties properties = new SocialProperties() {
+        };
+        properties.setAppId("appId");
+        properties.setAppSecret("appSecret");
+
+        final OAuth2Applicator applicator = new OAuth2Applicator(properties);
+        applicator.setAccessTokenProperty("accessTokenProperty");
+        applicator.setClientIdProperty("clientIdProperty");
+        applicator.setClientSecretProperty("clientSecretProperty");
+        applicator.setRefreshTokenProperty("refreshTokenProperty");
+
+        final Connection connection = new Connection.Builder().build();
+
+        final Connection result = applicator.applyTo(connection,
+            new AccessGrant("accessToken", "scope", "refreshToken", 1L));
+
+        final Connection expected = new Connection.Builder().putConfiguredProperty("accessTokenProperty", "accessToken")
+            .putConfiguredProperty("clientIdProperty", "appId")
+            .putConfiguredProperty("clientSecretProperty", "appSecret")
+            .putConfiguredProperty("refreshTokenProperty", "refreshToken").build();
+
+        assertThat(result).isEqualToIgnoringGivenFields(expected, "lastUpdated");
+        assertThat(result.getLastUpdated()).isPresent();
+    }
+
+}

--- a/credential/src/test/java/io/syndesis/credential/RelativeUriValidatorTest.java
+++ b/credential/src/test/java/io/syndesis/credential/RelativeUriValidatorTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RelativeUriValidatorTest {
+
+    private final RelativeUriValidator validator = new RelativeUriValidator();
+
+    @Test
+    public void nullUrisShouldBeInvalid() {
+        assertThat(validator.isValid(null, null)).isFalse();
+    }
+
+    @Test
+    public void shouldAllowRelativeUris() {
+        assertThat(validator.isValid(URI.create("/relative"), null)).isTrue();
+    }
+
+    @Test
+    public void shouldNotAllowNonRelativeUris() {
+        assertThat(validator.isValid(URI.create("scheme:/absolute"), null)).isFalse();
+    }
+}

--- a/credential/src/test/java/io/syndesis/credential/salesforce/SalesforceApplicatorTest.java
+++ b/credential/src/test/java/io/syndesis/credential/salesforce/SalesforceApplicatorTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential.salesforce;
+
+import io.syndesis.model.connection.Connection;
+
+import org.junit.Test;
+import org.springframework.social.oauth2.AccessGrant;
+import org.springframework.social.salesforce.api.Salesforce;
+import org.springframework.social.salesforce.connect.SalesforceConnectionFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SalesforceApplicatorTest {
+
+    @Test
+    public void shouldApplyAdditionalProperties() {
+        final SalesforceProperties properties = new SalesforceProperties();
+        properties.setAppId("appId");
+        properties.setAppSecret("appSecret");
+
+        final AccessGrant accessGrant = new AccessGrant("accessToken", "scope", "refreshToken", 1L);
+
+        final SalesforceConnectionFactory salesforce = mock(SalesforceConnectionFactory.class);
+        @SuppressWarnings("unchecked")
+        final org.springframework.social.connect.Connection<Salesforce> salesforceConnection = mock(
+            org.springframework.social.connect.Connection.class);
+
+        final Salesforce salesforceApi = mock(Salesforce.class);
+        when(salesforceConnection.getApi()).thenReturn(salesforceApi);
+        when(salesforceApi.getInstanceUrl()).thenReturn("https://instance.salesforce.com");
+
+        when(salesforce.createConnection(accessGrant)).thenReturn(salesforceConnection);
+
+        final SalesforceConfiguration salesforceConfiguration = new SalesforceConfiguration(salesforce, properties);
+
+        final Connection.Builder mutableConnection = new Connection.Builder();
+        salesforceConfiguration.applicator.additionalApplication(mutableConnection, accessGrant);
+
+        assertThat(((Connection) mutableConnection.build()).getConfiguredProperties())
+            .containsExactly(entry("instanceUrl", "https://instance.salesforce.com"));
+    }
+
+}

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -91,6 +91,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/model/src/main/java/io/syndesis/model/ListResult.java
+++ b/model/src/main/java/io/syndesis/model/ListResult.java
@@ -17,6 +17,7 @@ package io.syndesis.model;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collector;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
@@ -50,5 +51,8 @@ public interface ListResult<T> {
         return new Builder<T>().items(items).totalCount(items.size()).build();
     }
 
+    static <T> Collector<T, Builder<T>, Builder<T>> collector() {
+        return Collector.of(Builder::new, Builder::addItem, (b1, b2) -> b1.addAllItems(b2.build().getItems()));
+    }
 
 }

--- a/model/src/test/java/io/syndesis/model/ListResultTest.java
+++ b/model/src/test/java/io/syndesis/model/ListResultTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.model;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListResultTest {
+
+    @Test
+    public void shouldCollectFromEmptyStream() {
+        final ListResult<Object> collected = Stream.of().collect(ListResult.collector()).build();
+        assertThat(collected).isNotNull();
+        assertThat(collected.getItems()).isEmpty();
+    }
+
+    @Test
+    public void shouldCollectFromSingletonStream() {
+        final ListResult<String> collected = Stream.of("item").collect(ListResult.collector()).build();
+        assertThat(collected).isNotNull();
+        assertThat(collected.getItems()).containsExactly("item");
+    }
+
+    @Test
+    public void shouldCollectFromStreamWithSomeElements() {
+        final ListResult<String> collected = IntStream.range(1, 11).mapToObj(String::valueOf)
+            .collect(ListResult.collector()).build();
+        assertThat(collected).isNotNull();
+        assertThat(collected.getItems()).containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
   </distributionManagement>
 
   <repositories>
+
     <repository>
       <snapshots>
         <enabled>false</enabled>
@@ -81,6 +82,13 @@
       <name>jcenter</name>
       <url>https://jcenter.bintray.com</url>
     </repository>
+
+    <!-- needed for Spring Social Salesforce fork from mikegirard/spring-social-salesforce -->
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+
   </repositories>
 
   <pluginRepositories>
@@ -127,6 +135,7 @@
     <spring-cloud-kubernetes.version>0.1.5</spring-cloud-kubernetes.version>
     <spring-cloud-sleuth.version>1.2.1.RELEASE</spring-cloud-sleuth.version>
     <spring-security.version>4.2.2.RELEASE</spring-security.version>
+    <spring-social.version>1.1.4.RELEASE</spring-social.version>
     <swagger.version>1.5.12</swagger.version>
     <sqlite-jdbc.version>3.16.1</sqlite-jdbc.version>
     <undertow.version>1.4.13.Final</undertow.version>
@@ -149,6 +158,7 @@
     <module>connector-catalog</module>
     <module>controllers</module>
     <module>core</module>
+    <module>credential</module>
     <module>dao</module>
     <module>github</module>
     <module>jsondb</module>
@@ -182,13 +192,6 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-bom</artifactId>
-        <version>${infinispan.version}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -292,6 +295,13 @@
       </dependency>
 
       <dependency>
+        <groupId>io.syndesis</groupId>
+        <artifactId>credential</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <!-- Funktion -->
+      <dependency>
         <groupId>io.syndesis.integration-runtime</groupId>
         <artifactId>model</artifactId>
         <version>${syndesis-integration-runtime.version}</version>
@@ -318,9 +328,33 @@
       </dependency>
 
       <dependency>
+        <groupId>org.hibernate.javax.persistence</groupId>
+        <artifactId>hibernate-jpa-2.1-api</artifactId>
+        <version>1.0.0.Final</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>${hibernate.validator.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-core</artifactId>
+        <version>${infinispan.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-spring4-embedded</artifactId>
+        <version>${infinispan.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-spring4-common</artifactId>
+        <version>${infinispan.version}</version>
       </dependency>
 
       <dependency>
@@ -402,7 +436,31 @@
           <exclusion>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-        </exclusion>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.social</groupId>
+        <artifactId>spring-social-config</artifactId>
+        <version>${spring-social.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.springframework.social</groupId>
+            <artifactId>spring-social-web</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.mikegirard</groupId>
+        <artifactId>spring-social-salesforce</artifactId>
+        <version>1.3.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.force.api</groupId>
+            <artifactId>force-wsc</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -472,6 +530,12 @@
         <version>2.5</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.2.1</version>
+      </dependency>
+
       <!-- Testing Dependencies -->
       <dependency>
         <groupId>junit</groupId>
@@ -501,9 +565,9 @@
         <version>${resteasy-spring-boot-starter.version}</version>
         <exclusions>
           <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>annotations</artifactId>
-        </exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -696,12 +760,13 @@
         <configuration>
           <ignoredClassPatterns>
             <ignoredClassPattern>io.fabric8.kubernetes.client.*</ignoredClassPattern>
-            <ignoredClassPattern>org.infinispan.util.*</ignoredClassPattern>
+            <ignoredClassPattern>org.infinispan.*</ignoredClassPattern>
             <ignoredClassPattern>org.springframework.security.crypto.*</ignoredClassPattern>
             <ignoredClassPattern>org.objectweb.asm.*</ignoredClassPattern>
           </ignoredClassPatterns>
           <ignoredResourcePatterns>
             <ignoredResourcePattern>features.xml</ignoredResourcePattern>
+            <ignoredResourcePattern>org/infinispan/.*</ignoredResourcePattern>
           </ignoredResourcePatterns>
         </configuration>
       </plugin>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>verifier</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>credential</artifactId>
+    </dependency>
+
     <!-- ===================================================================================== -->
 
     <dependency>
@@ -83,6 +88,11 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
     </dependency>
 
     <dependency>

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandler.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.connection;
+
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+import io.swagger.annotations.Api;
+import io.syndesis.credential.Acquisition;
+import io.syndesis.credential.AcquisitionRequest;
+import io.syndesis.credential.Credentials;
+
+import org.springframework.web.context.request.ServletWebRequest;
+
+@Api(value = "credentials")
+public class ConnectionCredentialHandler {
+
+    private final String connectionId;
+
+    private final String connectorId;
+
+    private final Credentials credentials;
+
+    public ConnectionCredentialHandler(@Nonnull final Credentials credentials, @Nonnull final String connectionId,
+        @Nonnull final String connectorId) {
+        this.credentials = credentials;
+        this.connectionId = connectionId;
+        this.connectorId = connectorId;
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Acquisition create(final AcquisitionRequest request, @Context final HttpServletRequest httpRequest) {
+        final ServletWebRequest webRequest = new ServletWebRequest(httpRequest);
+
+        return credentials.acquire(connectionId, connectorId, request.returnUrl(), webRequest);
+    }
+}

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorCredentialHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorCredentialHandler.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.rest.v1.handler.connection;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.swagger.annotations.Api;
+import io.syndesis.credential.AcquisitionMethod;
+import io.syndesis.credential.Credentials;
+
+@Api(value = "credentials")
+public class ConnectorCredentialHandler {
+
+    private final String connectorId;
+
+    private final Credentials credentials;
+
+    public ConnectorCredentialHandler(@Nonnull final Credentials credentials, @Nonnull final String connectorId) {
+        this.credentials = credentials;
+        this.connectorId = connectorId;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public AcquisitionMethod get() {
+        return credentials.acquisitionMethodFor(connectorId);
+    }
+
+}

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
@@ -26,6 +26,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import io.swagger.annotations.Api;
+import io.syndesis.credential.Credentials;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.Kind;
 import io.syndesis.model.connection.Connector;
@@ -34,16 +35,21 @@ import io.syndesis.rest.v1.operations.Getter;
 import io.syndesis.rest.v1.operations.Lister;
 import io.syndesis.verifier.Verifier;
 
+import org.springframework.stereotype.Component;
+
 @Path("/connectors")
 @Api(value = "connectors")
-@org.springframework.stereotype.Component
+@Component
 public class ConnectorHandler extends BaseHandler implements Lister<Connector>, Getter<Connector> {
 
     private final Verifier verifier;
 
-    public ConnectorHandler(DataManager dataMgr, Verifier verifier) {
+    private final Credentials credentials;
+
+    public ConnectorHandler(final DataManager dataMgr, final Verifier verifier, final Credentials credentials) {
         super(dataMgr);
         this.verifier = verifier;
+        this.credentials = credentials;
     }
 
     @Override
@@ -52,7 +58,7 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
     }
 
     @Path("/{id}/actions")
-    public ConnectorActionHandler getActions(@PathParam("id") String connectorId) {
+    public ConnectorActionHandler getActions(@PathParam("id") final String connectorId) {
         return new ConnectorActionHandler(getDataManager(), connectorId);
     }
 
@@ -60,7 +66,13 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{id}/verifier")
-    public List<Verifier.Result> verifyConnectionParameters(@PathParam("id") String connectorId, Map<String, String> props) {
+    public List<Verifier.Result> verifyConnectionParameters(@PathParam("id") final String connectorId,
+        final Map<String, String> props) {
         return verifier.verify(connectorId, props);
+    }
+
+    @Path("/{id}/credentials")
+    public ConnectorCredentialHandler credentials(final @PathParam("id") String connectorId) {
+        return new ConnectorCredentialHandler(credentials, connectorId);
     }
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/credential/CredentialHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/credential/CredentialHandler.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.credential;
+
+import java.net.URI;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import io.swagger.annotations.Api;
+import io.syndesis.credential.Credentials;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.ServletWebRequest;
+
+@Path("/credentials")
+@Api(value = "credentials")
+@Component
+public class CredentialHandler {
+
+    private final Credentials credentials;
+
+    public CredentialHandler(final Credentials credentials) {
+        this.credentials = credentials;
+    }
+
+    @GET
+    @Path("/callback")
+    public Response callback(@QueryParam("state") final String state, @Context final HttpServletRequest httpRequest) {
+        final ServletWebRequest webRequest = new ServletWebRequest(httpRequest);
+
+        final URI location = credentials.finishAcquisition(state, webRequest);
+
+        return Response.temporaryRedirect(location).build();
+    }
+}

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -17,7 +17,7 @@
 
 -->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.syndesis</groupId>
@@ -271,6 +271,8 @@
             <ignoredUnusedDeclaredDependency>org.springframework.cloud:spring-cloud-starter-security</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.springframework.cloud:spring-cloud-starter-zipkin</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>postgresql:postgresql</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>com.github.mikegirard:spring-social-salesforce</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.social:spring-social-twitter</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
@@ -434,6 +436,27 @@
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>verifier</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>credential</artifactId>
+    </dependency>
+
+    <!-- Credentials to support -->
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.mikegirard</groupId>
+      <artifactId>spring-social-salesforce</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-twitter</artifactId>
     </dependency>
 
     <!-- DAO implementations: -->
@@ -610,13 +633,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-spring4-embedded</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
 
     <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
 
     <dependency>

--- a/runtime/src/main/java/io/syndesis/runtime/Application.java
+++ b/runtime/src/main/java/io/syndesis/runtime/Application.java
@@ -20,12 +20,17 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.social.FacebookAutoConfiguration;
+import org.springframework.boot.autoconfigure.social.LinkedInAutoConfiguration;
+import org.springframework.boot.autoconfigure.social.SocialWebAutoConfiguration;
+import org.springframework.boot.autoconfigure.social.TwitterAutoConfiguration;
 import org.springframework.boot.context.embedded.undertow.UndertowDeploymentInfoCustomizer;
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {TwitterAutoConfiguration.class, FacebookAutoConfiguration.class,
+    LinkedInAutoConfiguration.class, SocialWebAutoConfiguration.class})
 public class Application extends SpringBootServletInitializer {
 
     public static void main(String[] args) {

--- a/runtime/src/main/java/io/syndesis/runtime/InfinispanCacheConfiguration.java
+++ b/runtime/src/main/java/io/syndesis/runtime/InfinispanCacheConfiguration.java
@@ -20,7 +20,9 @@ import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.eviction.EvictionType;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -47,4 +49,8 @@ public class InfinispanCacheConfiguration {
         );
     }
 
+    @Bean
+    public CacheManager cacheManager(final EmbeddedCacheManager nativeCacheManager) {
+        return new SpringEmbeddedCacheManager(nativeCacheManager);
+    }
 }

--- a/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
@@ -159,7 +159,9 @@ public abstract class BaseITCase {
         if( body!=null ) {
             headers.set(HttpHeaders.CONTENT_TYPE, "application/json");
         }
-        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        if (token != null) {
+            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
         ResponseEntity<T> response = restTemplate().exchange(url, method, new HttpEntity<>(body, headers), responseClass);
         if( expectedStatus!=null ) {
             assertThat(response.getStatusCode()).as("status code").isEqualTo(expectedStatus);

--- a/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.runtime.credential;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.Collections;
+
+import io.syndesis.credential.Acquisition;
+import io.syndesis.credential.AcquisitionMethod;
+import io.syndesis.credential.CredentialFlowState;
+import io.syndesis.credential.CredentialProvider;
+import io.syndesis.credential.CredentialProviderConfiguration;
+import io.syndesis.credential.Credentials;
+import io.syndesis.credential.OAuth2Applicator;
+import io.syndesis.model.connection.Connection;
+import io.syndesis.model.connection.Connector;
+import io.syndesis.runtime.Application;
+import io.syndesis.runtime.BaseITCase;
+import io.syndesis.runtime.credential.CredentialITCase.TestConfiguration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.social.connect.support.OAuth2ConnectionFactory;
+import org.springframework.social.oauth2.AccessGrant;
+import org.springframework.social.oauth2.OAuth2Operations;
+import org.springframework.social.oauth2.OAuth2Template;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.springframework.web.util.UriUtils.encode;
+
+@Import({Application.class, TestConfiguration.class})
+public class CredentialITCase extends BaseITCase {
+
+    @Autowired
+    private CacheManager cache;
+
+    public static class TestConfiguration {
+        @Bean
+        public static CredentialProviderConfiguration provider() {
+            @SuppressWarnings("unchecked")
+            final CredentialProvider<Object, AccessGrant> credentialProvider = mock(CredentialProvider.class);
+
+            @SuppressWarnings("unchecked")
+            final OAuth2ConnectionFactory<Object> connectionFactory = mock(OAuth2ConnectionFactory.class);
+            when(connectionFactory.getProviderId()).thenReturn("test-provider");
+
+            when(credentialProvider.connectionFactory()).thenReturn(connectionFactory);
+            when(connectionFactory.generateState()).thenReturn("test-state");
+
+            final OAuth2Operations operations = spy(new OAuth2Template("testClientId", "testClientSecret",
+                "https://test/oauth2/authorize", "https://test/oauth2/token"));
+            doReturn(new AccessGrant("token")).when(operations).exchangeForAccess(Matchers.anyString(),
+                Matchers.anyString(), Matchers.any(MultiValueMap.class));
+
+            when(connectionFactory.getOAuthOperations()).thenReturn(operations);
+
+            final SocialProperties properties = new SocialProperties() {
+            };
+            properties.setAppId("appId");
+            properties.setAppSecret("appSecret");
+
+            final OAuth2Applicator applicator = new OAuth2Applicator(properties);
+            applicator.setAccessTokenProperty("accessToken");
+            applicator.setClientIdProperty("clientId");
+            applicator.setClientSecretProperty("clientSecret");
+            applicator.setRefreshTokenProperty("refreshToken");
+
+            when(credentialProvider.applicator()).thenReturn(applicator);
+
+            return configurer -> configurer.addCredentialProvider(credentialProvider);
+        }
+    }
+
+    @After
+    public void cleanupDatabase() {
+        dataManager.delete(Connector.class, "test-provider");
+        dataManager.delete(Connection.class, "test-connection");
+        cache.getCache(Credentials.CACHE_NAME).evict("test-state");
+    }
+
+    @Before
+    public void prepopulateDatabase() {
+        final Connector provider = new Connector.Builder().id("test-provider").build();
+        dataManager.create(provider);
+
+        dataManager.create(new Connection.Builder().id("test-connection").connector(provider).build());
+    }
+
+    @Test
+    public void shouldInitiateCredentialFlow() throws UnsupportedEncodingException {
+        final ResponseEntity<Acquisition> acquisitionResponse = post("/api/v1/connections/test-connection/credentials",
+            Collections.singletonMap("returnUrl", "/ui#state"), Acquisition.class, tokenRule.validToken(),
+            HttpStatus.OK);
+
+        assertThat(acquisitionResponse.hasBody()).as("Should present a acquisition response in the HTTP body").isTrue();
+
+        final Acquisition acquisition = acquisitionResponse.getBody();
+
+        assertThat(acquisition.getType()).isEqualTo(Acquisition.Type.REDIRECT);
+
+        final String redirectUrl = acquisition.getUrl();
+        assertThat(redirectUrl).as("Should redirect to Salesforce and contain the correct callback URL")
+            .startsWith("https://test/oauth2/authorize?client_id=testClientId&response_type=code&redirect_uri=")
+            .contains(encode("/api/v1/credentials/callback", "ASCII"));
+
+        final MultiValueMap<String, String> params = UriComponentsBuilder.fromHttpUrl(redirectUrl).build()
+            .getQueryParams();
+
+        final String state = params.getFirst("state");
+
+        assertThat(state).as("state parameter should be set").isNotEmpty();
+
+        final CredentialFlowState credentialFlowState = cache.getCache(Credentials.CACHE_NAME).get(state,
+            CredentialFlowState.class);
+
+        final CredentialFlowState expected = new CredentialFlowState.Builder().key("test-state")
+            .providerId("test-provider").connectionId("test-connection").returnUrl(URI.create("/ui#state")).build();
+
+        assertThat(credentialFlowState).as("The flow state should be as expected").isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldProvideCredentialsApplicableTo() {
+        final ResponseEntity<AcquisitionMethod> acquisitionMethodEntity = get(
+            "/api/v1/connectors/test-provider/credentials", AcquisitionMethod.class, tokenRule.validToken(),
+            HttpStatus.OK);
+
+        assertThat(acquisitionMethodEntity.hasBody()).as("Should present a acquisition method in the HTTP body")
+            .isTrue();
+
+        final AcquisitionMethod acquisitionMethod = acquisitionMethodEntity.getBody();
+
+        final AcquisitionMethod salesforce = new AcquisitionMethod.Builder().type(AcquisitionMethod.Type.OAUTH2)
+            .label("test-provider").icon("test-provider").label("test-provider").description("test-provider").build();
+
+        assertThat(acquisitionMethod).isEqualTo(salesforce);
+    }
+
+    @Test
+    public void shouldReceiveCallbacksFromResourceProviders() {
+        cache.getCache(Credentials.CACHE_NAME).put("test-state", new CredentialFlowState.Builder()
+            .connectionId("test-connection").providerId("test-provider").returnUrl(URI.create("/ui#state")).build());
+
+        final ResponseEntity<Void> callbackResponse = get("/api/v1/credentials/callback?state=test-state", Void.class,
+            null, HttpStatus.TEMPORARY_REDIRECT);
+
+        assertThat(callbackResponse.getStatusCode()).as("Status should be temporarry redirect (307)")
+            .isEqualTo(HttpStatus.TEMPORARY_REDIRECT);
+        assertThat(callbackResponse.hasBody()).as("Should not contain HTTP body").isFalse();
+        assertThat(callbackResponse.getHeaders().getLocation().toString())
+            .matches("http.?://localhost:[0-9]*/api/v1/ui#state");
+
+        final Connection connection = dataManager.fetch(Connection.class, "test-connection");
+
+        assertThat(connection.getConfiguredProperties()).containsOnly(entry("accessToken", "token"),
+            entry("clientId", "appId"), entry("clientSecret", "appSecret"));
+    }
+
+}


### PR DESCRIPTION
This is a work in progress to support credentials, starting with the
easiest parts first :)

See: syndesisio/syndesis-ui#556

Problem:
There is a need for managing credentials (OAuth tokens, username and
passwords, certificates, private keys, ...) that are needed for a
connector to authenticate against a 3rd party resource (service,
database, queue, ...).

1/
First issue is how to store and provide connectors with appropriate
credentials.

2/
Second issue is how to obtain credentials as they can be issued by the
3rd party or require input from the user of the system.

Solution:
1/
Provide API to store and retrieve credentials that solves first issue.
This API can be queried to retrieve manage all credentials or to manage
only credentials applicable to single connector instance.
Selection of applicable credential is done via connector group name
i.e. Camel label, e.g. 'twitter'.

Proposed REST API:
`credentials/{id}` - manages all credentials in the system
`connectors/{id}/credentials/{id}` - manages credentials applicable to
  single connector

2/
Provide API for information on obtaining credentials that solves part of
the second issue. This API will provide information to the UI on how to
obtain credentials (e.g. type: username/password input or link,
properties: list of properties for manual input).

Proposed REST API:
`connectors/{id}/credentials/acquisition` - provides the info on
  obtaining the credential

3/
Provide (Java) plug-in API performing credential acquisition and
endpoint for each plugin to operate in (if needed).

Proposed REST API:
`connectors/{id}/credentials/acquisition/{type}/*` - endpoint for each
  method of credential acquisition

Proposed (Java) plug-in API:
interface CredentialAcquisitor {
  AcquisitionInfo info();
  AcquisitionHandler handler(CredentialRepository);
}

Issues:
Storage of credentials -- k8s secrets?
ACL enforcement -- tie in with Keycloak?