### PR TITLE
Increase timeout for individual tests to 150s

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -233,6 +233,7 @@
                 <!-- workaround suggested in https://github.com/spring-projects/spring-boot/issues/6254 -->
                 <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
               </additionalClasspathElements>
+              <forkedProcessTimeoutInSeconds>150</forkedProcessTimeoutInSeconds>
               <systemProperties>
                 <keycloak.http.port>${keycloak.http.port}</keycloak.http.port>
               </systemProperties>


### PR DESCRIPTION
The selected default of 30s for a single test timeout in basepom is too less as the build time has been increased considerably because of much more checks.

Fixes #387