### PR TITLE
Increase timeout for single integration tests to 150s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <basepom.test.timeout>300</basepom.test.timeout>
     <basepom.check.skip-all>true</basepom.check.skip-all>
+    <basepom.test.timeout>150</basepom.test.timeout>
+    <basepom.failsafe.timeout>150</basepom.failsafe.timeout>
 
     <syndesis-connectors.version>0.4.4</syndesis-connectors.version>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -233,7 +233,6 @@
                 <!-- workaround suggested in https://github.com/spring-projects/spring-boot/issues/6254 -->
                 <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
               </additionalClasspathElements>
-              <forkedProcessTimeoutInSeconds>150</forkedProcessTimeoutInSeconds>
               <systemProperties>
                 <keycloak.http.port>${keycloak.http.port}</keycloak.http.port>
               </systemProperties>


### PR DESCRIPTION
The basepom default of 30s for a single integration test timeout in basepom, i.e. the tests run using failsafe plugin, is much too small for the integration tests to complete.
Previously in c91ed3454f78f9516eb98613dc21718098497e7d property `basepom.test.timeout` was set, but property `basepom.failsafe.timeout` should have been set.