### PR TITLE
Fix serialization error when descriptions are missing

### DIFF
--- a/verifier/src/main/java/io/syndesis/verifier/Verifier.java
+++ b/verifier/src/main/java/io/syndesis/verifier/Verifier.java
@@ -17,6 +17,7 @@ package io.syndesis.verifier;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
@@ -56,7 +57,7 @@ public interface Verifier {
         String getCode();
 
         // A description of the error in plain english
-        String getDescription();
+        Optional<String> getDescription();
 
         // List of parameters which caused this particular verification to fail
         List<String> getParameters();


### PR DESCRIPTION
This PR is related to syndesisio/syndesis-verifier#12 and syndesisio/syndesis-ui#583 where the Camel verifier didn't set the description and the immutable deserializer broke.