### PR TITLE
chore(build): Sync Checkstyle, Findbugs, PMD configuration with Codacy (#417)

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (C) 2016 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+  <suppress files="[\\/]generated-sources[\\/]" checks=".*"/>
+</suppressions>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE module PUBLIC
+"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <!-- http://checkstyle.sourceforge.net/config_filters.html -->
+  <module name="SuppressWarningsFilter" />
+  <module name="SuppressWithNearbyCommentFilter"/>
+  <module name="SuppressionFilter">
+    <property name="file" value="${checkstyle.suppression.file}"/>
+  </module>
+
+  <!-- http://checkstyle.sourceforge.net/config_misc.html -->
+  <module name="NewlineAtEndOfFile">
+    <property name="lineSeparator" value="lf"/>
+  </module>
+
+  <!-- http://checkstyle.sourceforge.net/config_whitespace.html -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+  <!-- http://checkstyle.sourceforge.net/config_regexp.html -->
+  <module name="RegexpSingleline">
+    <!-- \s matches whitespace character, $ matches end of line. -->
+    <property name="format" value="\s+$"/>
+    <property name="message" value="Line has trailing spaces."/>
+  </module>
+
+  <!-- =========================================================== -->
+  <!--                                                             -->
+  <!-- TreeWalker config                                           -->
+  <!--                                                             -->
+  <!-- =========================================================== -->
+
+  <module name="TreeWalker">
+    <property name="cacheFile" value="checkstyle.cache"/>
+
+    <!-- http://checkstyle.sourceforge.net/config_annotation.html -->
+    <module name="SuppressWarningsHolder" />
+
+    <!-- http://checkstyle.sourceforge.net/config_filters.html -->
+    <module name="FileContentsHolder"/>
+
+    <!-- Checks for blocks. You know, those {}'s         -->
+    <!-- See http://checkstyle.sf.net/config_blocks.html -->
+    <module name="NeedBraces"/>
+
+    <!-- Checks for imports                              -->
+    <!-- See http://checkstyle.sf.net/config_import.html -->
+    <module name="AvoidStarImport"/>
+    <module name="RedundantImport"/>
+
+    <!-- Modifier Checks                                    -->
+    <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+    <module name="ModifierOrder"/>
+
+    <!-- UnusedModifier in PMD is also only warning -->
+    <module name="RedundantModifier">
+      <property name="severity" value="warning"/>
+    </module>
+
+    <!-- http://checkstyle.sourceforge.net/config_misc.html -->
+    <module name="UpperEll"/>
+  </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -639,6 +639,15 @@
           <artifactId>exec-maven-plugin</artifactId>
           <version>${exec-maven-plugin.version}</version>
         </plugin>
+        <plugin>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <configuration>
+            <configLocation>../checkstyle.xml</configLocation>
+            <propertyExpansion>
+              checkstyle.suppression.file=../checkstyle-suppressions.xml
+            </propertyExpansion>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -694,6 +703,16 @@
           <ignoredResourcePatterns>
             <ignoredResourcePattern>features.xml</ignoredResourcePattern>
           </ignoredResourcePatterns>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <configLocation>checkstyle.xml</configLocation>
+          <propertyExpansion>
+            checkstyle.suppression.file=checkstyle-suppressions.xml
+          </propertyExpansion>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
This adds Checkstyle rules, these are taken from basepom-policy[1] and renamed to fit this project layout.

According to[2] Codacy should pickup the `checkstyle.xml` file.

[1] https://github.com/basepom/basepom-policy
[2] https://support.codacy.com/hc/en-us/articles/207994335-Code-Patterns