### PR TITLE
fix(credentials): Finishing OAuth credential flow on a wrong URL (#431)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -662,6 +662,14 @@
         <artifactId>compiler</artifactId>
         <version>0.9.2</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>1.10.19</version>
+        <scope>test</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -158,6 +158,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.el</artifactId>
       <scope>test</scope>

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandler.java
@@ -15,6 +15,9 @@
  */
 package io.syndesis.rest.v1.handler.connection;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -52,6 +55,18 @@ public class ConnectionCredentialHandler {
     public Acquisition create(final AcquisitionRequest request, @Context final HttpServletRequest httpRequest) {
         final ServletWebRequest webRequest = new ServletWebRequest(httpRequest);
 
-        return credentials.acquire(connectionId, connectorId, request.returnUrl(), webRequest);
+        return credentials.acquire(connectionId, connectorId, absoluteTo(httpRequest, request), webRequest);
+    }
+
+    protected static URI absoluteTo(final HttpServletRequest httpRequest, final AcquisitionRequest request) {
+        final URI current = URI.create(httpRequest.getRequestURL().toString());
+        final URI returnUrl = request.returnUrl();
+
+        try {
+            return new URI(current.getScheme(), null, current.getHost(), current.getPort(), returnUrl.getPath(),
+                returnUrl.getQuery(), returnUrl.getFragment());
+        } catch (final URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandler.java
@@ -66,7 +66,8 @@ public class ConnectionCredentialHandler {
             return new URI(current.getScheme(), null, current.getHost(), current.getPort(), returnUrl.getPath(),
                 returnUrl.getQuery(), returnUrl.getFragment());
         } catch (final URISyntaxException e) {
-            throw new IllegalArgumentException(e);
+            throw new IllegalArgumentException("Unable to generate URI based on the current (`" + current
+                + "`) and the return (`" + returnUrl + "`) URLs", e);
         }
     }
 }

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandlerTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandlerTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.connection;
+
+import java.net.URI;
+
+import javax.servlet.http.HttpServletRequest;
+
+import io.syndesis.credential.AcquisitionRequest;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConnectionCredentialHandlerTest {
+
+    @Test
+    public void shouldAbsolutizeReturnUrl() {
+        final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+
+        when(httpRequest.getRequestURL())
+            .thenReturn(new StringBuffer("https://syndesis.io/api/v1/connections/1/credentials"));
+
+        final AcquisitionRequest request = new AcquisitionRequest.Builder().returnUrl(URI.create("/ui?ret=true#state"))
+            .build();
+
+        final URI uri = ConnectionCredentialHandler.absoluteTo(httpRequest, request);
+
+        assertThat(uri).isEqualTo(URI.create("https://syndesis.io/ui?ret=true#state"));
+    }
+}

--- a/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
@@ -144,9 +144,15 @@ public class CredentialITCase extends BaseITCase {
             CredentialFlowState.class);
 
         final CredentialFlowState expected = new CredentialFlowState.Builder().key("test-state")
-            .providerId("test-provider").connectionId("test-connection").returnUrl(URI.create("/ui#state")).build();
+            .providerId("test-provider").connectionId("test-connection").build();
 
-        assertThat(credentialFlowState).as("The flow state should be as expected").isEqualTo(expected);
+        assertThat(credentialFlowState).as("The flow state should be as expected")
+            .isEqualToIgnoringGivenFields(expected, "returnUrl");
+        final URI returnUrl = credentialFlowState.getReturnUrl();
+        assertThat(returnUrl).isNotNull();
+        assertThat(returnUrl.isAbsolute()).isTrue();
+        assertThat(returnUrl.getPath()).isEqualTo("/ui");
+        assertThat(returnUrl.getFragment()).isEqualTo("state");
     }
 
     @Test


### PR DESCRIPTION
When the UI specifies the return URL in credential acquisition it should be taken as an absolute path not relative path to the API base URI.

This changes to compute the absolute URI at the point the UI submits the relative URI to return to on successful OAuth acquisition.

I've also taken the opportunity to declare Mockito as _test_ dependency.