### PR TITLE
feat(rest): Parameter validation (#440)

### DIFF
--- a/credential/src/main/java/io/syndesis/credential/AcquisitionRequest.java
+++ b/credential/src/main/java/io/syndesis/credential/AcquisitionRequest.java
@@ -25,6 +25,7 @@ import org.springframework.validation.annotation.Validated;
 @Value.Immutable
 @JsonDeserialize(builder = AcquisitionRequest.Builder.class)
 @Validated
+@Value.Style(passAnnotations = RelativeUri.class)
 public interface AcquisitionRequest {
 
     class Builder extends ImmutableAcquisitionRequest.Builder {
@@ -33,5 +34,5 @@ public interface AcquisitionRequest {
     }
 
     @RelativeUri
-    URI returnUrl();
+    URI getReturnUrl();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -579,6 +579,12 @@
       </dependency>
 
       <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-validator-provider-11</artifactId>
+          <version>${resteasy.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-jaxrs</artifactId>
         <version>${swagger.version}</version>
@@ -782,6 +788,7 @@
           <ignoredResourcePatterns>
             <ignoredResourcePattern>features.xml</ignoredResourcePattern>
             <ignoredResourcePattern>org/infinispan/.*</ignoredResourcePattern>
+            <ignoredResourcePattern>ValidationMessages.properties</ignoredResourcePattern>
           </ignoredResourcePatterns>
         </configuration>
       </plugin>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -125,8 +125,18 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
       <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+    </dependency>
+
+    <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jaxrs</artifactId>
     </dependency>
 
     <dependency>

--- a/rest/src/main/java/io/syndesis/rest/v1/JacksonContextResolver.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/JacksonContextResolver.java
@@ -35,6 +35,7 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
         this.objectMapper = Json.mapper();
     }
 
+    @Override
     public ObjectMapper getContext(Class<?> objectType) {
         return objectMapper;
     }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionCredentialHandler.java
@@ -20,6 +20,8 @@ import java.net.URISyntaxException;
 
 import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Produces;
@@ -52,7 +54,7 @@ public class ConnectionCredentialHandler {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Acquisition create(final AcquisitionRequest request, @Context final HttpServletRequest httpRequest) {
+    public Acquisition create(@NotNull @Valid final AcquisitionRequest request, @Context final HttpServletRequest httpRequest) {
         final ServletWebRequest webRequest = new ServletWebRequest(httpRequest);
 
         return credentials.acquire(connectionId, connectorId, absoluteTo(httpRequest, request), webRequest);
@@ -60,7 +62,7 @@ public class ConnectionCredentialHandler {
 
     protected static URI absoluteTo(final HttpServletRequest httpRequest, final AcquisitionRequest request) {
         final URI current = URI.create(httpRequest.getRequestURL().toString());
-        final URI returnUrl = request.returnUrl();
+        final URI returnUrl = request.getReturnUrl();
 
         try {
             return new URI(current.getScheme(), null, current.getHost(), current.getPort(), returnUrl.getPath(),

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
@@ -18,6 +18,7 @@ package io.syndesis.rest.v1.handler.connection;
 import java.util.List;
 import java.util.Map;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -66,13 +67,13 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{id}/verifier")
-    public List<Verifier.Result> verifyConnectionParameters(@PathParam("id") final String connectorId,
+    public List<Verifier.Result> verifyConnectionParameters(@NotNull @PathParam("id") final String connectorId,
         final Map<String, String> props) {
         return verifier.verify(connectorId, props);
     }
 
     @Path("/{id}/credentials")
-    public ConnectorCredentialHandler credentials(final @PathParam("id") String connectorId) {
+    public ConnectorCredentialHandler credentials(@NotNull final @PathParam("id") String connectorId) {
         return new ConnectorCredentialHandler(credentials, connectorId);
     }
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/BaseExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/BaseExceptionMapper.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.exception;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class BaseExceptionMapper<E extends Throwable> implements ExceptionMapper<E> {
+
+    private final Logger LOG = LoggerFactory.getLogger(getClass());
+
+    private final Status status;
+
+    private final String userMessage;
+
+    public BaseExceptionMapper(final Status status, final String userMessage) {
+        this.status = status;
+        this.userMessage = userMessage;
+    }
+
+    @Override
+    public final Response toResponse(final E exception) {
+        final String developerMessage = developerMessage(exception);
+
+        LOG.error(developerMessage, exception);
+
+        final RestError error = new RestError(developerMessage, userMessage, status.getStatusCode());
+
+        return Response.status(error.errorCode).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
+    }
+
+    protected String developerMessage(final E exception) {
+        return exception.getMessage();
+    }
+}

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ConstraintViolationExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ConstraintViolationExceptionMapper.java
@@ -15,7 +15,9 @@
  */
 package io.syndesis.rest.v1.handler.exception;
 
-import javax.persistence.EntityNotFoundException;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
@@ -23,15 +25,19 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Provider
-public class EntityNotFoundExceptionMapper extends BaseExceptionMapper<EntityNotFoundException> {
+public class ConstraintViolationExceptionMapper extends BaseExceptionMapper<ConstraintViolationException> {
 
-    public EntityNotFoundExceptionMapper() {
-        super(Response.Status.NOT_FOUND, "Please check your request data");
+    public ConstraintViolationExceptionMapper() {
+        super(Response.Status.BAD_REQUEST, "Please make sure that you're sending the correct parameters");
     }
 
     @Override
-    protected String developerMessage(final EntityNotFoundException exception) {
-        return "Entity Not Found Exception " + exception.getMessage();
+    protected String developerMessage(final ConstraintViolationException exception) {
+        return exception.getConstraintViolations()
+            .stream().map(c -> " - value `" + c.getInvalidValue() + "` specified at `" + c.getPropertyPath()
+                + "` is invalid: " + c.getMessage())
+            .collect(Collectors.joining(", ", "Invalid values specified: ", ""));
+
     }
 
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/IllegalArgumentExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/IllegalArgumentExceptionMapper.java
@@ -15,26 +15,22 @@
  */
 package io.syndesis.rest.v1.handler.exception;
 
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 @Provider
-public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+public class IllegalArgumentExceptionMapper extends BaseExceptionMapper<IllegalArgumentException> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(IllegalArgumentExceptionMapper.class);
+    public IllegalArgumentExceptionMapper() {
+        super(Response.Status.BAD_REQUEST, "Please check your sorting arguments");
+    }
 
     @Override
-    public Response toResponse(IllegalArgumentException e) {
-        LOG.error(e.getMessage(),e);
-        RestError error = new RestError("Illegal Argument on Call " + e.getMessage(), "Please check your sorting arguments", 400);
-        return Response.status(error.errorCode).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
+    protected String developerMessage(IllegalArgumentException exception) {
+        return "Illegal Argument on Call " + exception.getMessage();
     }
 
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ReaderExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ReaderExceptionMapper.java
@@ -15,23 +15,23 @@
  */
 package io.syndesis.rest.v1.handler.exception;
 
-import javax.persistence.EntityNotFoundException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import org.jboss.resteasy.spi.ReaderException;
 import org.springframework.stereotype.Component;
 
+/**
+ * RESTEasy will use the built in {@link ExceptionMapper} if we don't specify
+ * our own mapper, and the built in mapper will not produce JSON output.
+ */
 @Component
 @Provider
-public class EntityNotFoundExceptionMapper extends BaseExceptionMapper<EntityNotFoundException> {
+public class ReaderExceptionMapper extends BaseExceptionMapper<ReaderException> {
 
-    public EntityNotFoundExceptionMapper() {
-        super(Response.Status.NOT_FOUND, "Please check your request data");
-    }
-
-    @Override
-    protected String developerMessage(final EntityNotFoundException exception) {
-        return "Entity Not Found Exception " + exception.getMessage();
+    public ReaderExceptionMapper() {
+        super(Response.Status.BAD_REQUEST, "Please make sure that you're sending the correct parameters");
     }
 
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/SyndesisServerExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/SyndesisServerExceptionMapper.java
@@ -15,24 +15,22 @@
  */
 package io.syndesis.rest.v1.handler.exception;
 
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 @Provider
-public class SyndesisServerExceptionMapper implements javax.ws.rs.ext.ExceptionMapper<Exception> {
+public class SyndesisServerExceptionMapper extends BaseExceptionMapper<Exception> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SyndesisServerExceptionMapper.class);
+    public SyndesisServerExceptionMapper() {
+        super(Response.Status.INTERNAL_SERVER_ERROR, "Please contact the administrator and file a bug report");
+    }
 
     @Override
-    public Response toResponse(Exception e) {
-        LOG.error(e.getMessage(),e);
-        RestError error = new RestError("Internal Server Exception. " + e.getMessage(), "Please contact the administrator and file a bug report", 500);
-        return Response.status(error.errorCode).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
+    protected String developerMessage(final Exception exception) {
+        return "Internal Server Exception. " + exception.getMessage();
     }
+
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/WriterExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/WriterExceptionMapper.java
@@ -15,23 +15,23 @@
  */
 package io.syndesis.rest.v1.handler.exception;
 
-import javax.persistence.EntityNotFoundException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import org.jboss.resteasy.spi.WriterException;
 import org.springframework.stereotype.Component;
 
+/**
+ * RESTEasy will use the built in {@link ExceptionMapper} if we don't specify
+ * our own mapper, and the built in mapper will not produce JSON output.
+ */
 @Component
 @Provider
-public class EntityNotFoundExceptionMapper extends BaseExceptionMapper<EntityNotFoundException> {
+public class WriterExceptionMapper extends BaseExceptionMapper<WriterException> {
 
-    public EntityNotFoundExceptionMapper() {
-        super(Response.Status.NOT_FOUND, "Please check your request data");
-    }
-
-    @Override
-    protected String developerMessage(final EntityNotFoundException exception) {
-        return "Entity Not Found Exception " + exception.getMessage();
+    public WriterExceptionMapper() {
+        super(Response.Status.INTERNAL_SERVER_ERROR, "Result of your request is not available");
     }
 
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
@@ -35,6 +35,7 @@ import io.syndesis.rest.v1.operations.Lister;
 import io.syndesis.rest.v1.operations.Updater;
 import org.springframework.stereotype.Component;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -107,7 +108,7 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path(value = "/{id}/filter/options")
-    public FilterOptions getFilterOptions(@PathParam("id") @ApiParam(required = true) String id) {
+    public FilterOptions getFilterOptions(@NotNull @PathParam("id") @ApiParam(required = true) String id) {
         FilterOptions.Builder builder = new FilterOptions.Builder().addOp(Op.DEFAULT_OPTS);
         Integration integration = Getter.super.get(id);
 

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppHandler.java
@@ -15,13 +15,14 @@
  */
 package io.syndesis.rest.v1.handler.setup;
 
-import io.swagger.annotations.Api;
-import io.syndesis.core.SuppressFBWarnings;
-import io.syndesis.dao.manager.DataManager;
-import io.syndesis.model.connection.ConfigurationProperty;
-import io.syndesis.model.connection.Connector;
-import org.springframework.stereotype.Component;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -31,11 +32,14 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeSet;
+
+import io.swagger.annotations.Api;
+import io.syndesis.core.SuppressFBWarnings;
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.model.connection.ConfigurationProperty;
+import io.syndesis.model.connection.Connector;
+
+import org.springframework.stereotype.Component;
 
 /**
  * This rest endpoint handles working with global oauth settings.
@@ -89,7 +93,7 @@ public class OAuthAppHandler {
     @PUT
     @Path(value = "/{id}")
     @Consumes("application/json")
-    public void update(@PathParam("id") String id, OAuthApp app) {
+    public void update(@NotNull @PathParam("id") String id, @NotNull @Valid OAuthApp app) {
         Connector connector = dataMgr.fetch(Connector.class, id);
         if( connector==null ) {
             throw new WebApplicationException(Response.Status.NOT_FOUND);

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Creator.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Creator.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.rest.v1.operations;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Produces;
@@ -28,7 +30,7 @@ public interface Creator<T extends WithId<T>> extends Resource, WithDataManager 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes("application/json")
-    default T create(T obj) {
+    default T create(@NotNull @Valid T obj) {
         return getDataManager().create(obj);
     }
 

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Deleter.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Deleter.java
@@ -15,11 +15,13 @@
  */
 package io.syndesis.rest.v1.operations;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
+import io.swagger.annotations.ApiParam;
 import io.syndesis.dao.manager.WithDataManager;
 import io.syndesis.model.WithId;
 
@@ -28,7 +30,7 @@ public interface Deleter<T extends WithId<T>> extends Resource, WithDataManager 
     @DELETE
     @Consumes("application/json")
     @Path(value = "/{id}")
-    default void delete(@PathParam("id") String id) {
+    default void delete(@NotNull @PathParam("id") @ApiParam(required = true) String id) {
         Class<T> modelClass = resourceKind().getModelClass();
         getDataManager().delete(modelClass, id);
     }

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Getter.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Getter.java
@@ -16,6 +16,7 @@
 package io.syndesis.rest.v1.operations;
 
 import javax.persistence.EntityNotFoundException;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -31,7 +32,7 @@ public interface Getter<T extends WithId<T>> extends Resource, WithDataManager {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path(value = "/{id}")
-    default T get(@PathParam("id") @ApiParam(required = true) String id) {
+    default T get(@NotNull @PathParam("id") @ApiParam(required = true) String id) {
         Class<T> modelClass = resourceKind().getModelClass();
         T result = getDataManager().fetch(modelClass, id);
         if( result == null ) {

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Updater.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Updater.java
@@ -15,11 +15,14 @@
  */
 package io.syndesis.rest.v1.operations;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
+import io.swagger.annotations.ApiParam;
 import io.syndesis.dao.manager.WithDataManager;
 import io.syndesis.model.WithId;
 
@@ -28,7 +31,7 @@ public interface Updater<T extends WithId<T>> extends Resource, WithDataManager 
     @PUT
     @Path(value = "/{id}")
     @Consumes("application/json")
-    default void update(@PathParam("id") String id, T obj) {
+    default void update(@NotNull @PathParam("id") @ApiParam(required = true) String id, @NotNull @Valid T obj) {
         getDataManager().update(obj);
     }
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -273,6 +273,7 @@
             <ignoredUnusedDeclaredDependency>postgresql:postgresql</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>com.github.mikegirard:spring-social-salesforce</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.springframework.social:spring-social-twitter</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.jboss.resteasy:resteasy-validator-provider-11</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
@@ -555,6 +556,12 @@
       <groupId>com.paypal.springboot</groupId>
       <artifactId>resteasy-spring-boot-starter</artifactId>
     </dependency>
+
+    <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-validator-provider-11</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/runtime/src/main/resources/ValidationMessages.properties
+++ b/runtime/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.syndesis.credential.RelativeUri.message = Given URI value must be relative


### PR DESCRIPTION
This configures RESTEasy to validate parameters in accordance to JSR 303 (Bean Validation). It also adds JSR 303 annotations to interfaces in `io.syndesis.rest.v1.operations` package so that the standard CRUD method parameters and to other *Handler implementations so that they are all validated.

A new ExceptionMapper was added to provide JSON output in case of constraint validation.

With the specific way the exceptions are handled in RESTEasy (handler for [Reader|Writter]Exception is not looked up the inheritance chain) two ExceptionMappers to handle those are added.

And with those changes in the exception handling it made sense to create a base class for ExceptionMappers.

The only way to for the validations to work with Immutables is to use the standard Java Beans method signatures (get/set) as there is currently no way to specify an annotation on the field with Immutables[1].

There is still more work to be done on validations, for instance deeper syntax validations might be beneficial (e.g. disallow certain characters in IDs to prevent injection).

fixes #440

[1] https://github.com/immutables/immutables/issues/475