### PR TITLE
fix(credentials): Determinisim in CredentialProvider registration (#447)

### DIFF
--- a/credential/pom.xml
+++ b/credential/pom.xml
@@ -81,11 +81,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.social</groupId>
-      <artifactId>spring-social-config</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/credential/src/main/java/io/syndesis/credential/CredentialConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialConfiguration.java
@@ -16,27 +16,17 @@
 package io.syndesis.credential;
 
 import io.syndesis.dao.manager.DataManager;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.List;
-import java.util.Optional;
 
 @Configuration
 public class CredentialConfiguration {
 
     @Bean
-    @Autowired()
-    public CredentialProviderLocator credentialProviderLocator(Optional<List<CredentialProvider>> providers) {
-        final CredentialProviderRegistry registry = new CredentialProviderRegistry();
-        if ( providers.isPresent() ) {
-            for (CredentialProvider provider : providers.get()) {
-                registry.addCredentialProvider(provider);
-            }
-        }
-        return registry;
+    public CredentialProviderLocator credentialProviderLocator() {
+        return new CredentialProviderRegistry();
     }
 
     @Bean
@@ -44,5 +34,4 @@ public class CredentialConfiguration {
         final DataManager dataManager, final CacheManager cacheManager) {
         return new Credentials(connectionProviderLocator, dataManager, cacheManager);
     }
-
 }

--- a/credential/src/main/java/io/syndesis/credential/CredentialProviderConfigurer.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProviderConfigurer.java
@@ -15,8 +15,8 @@
  */
 package io.syndesis.credential;
 
-public interface CredentialProviderFactoryConfigurer {
+public interface CredentialProviderConfigurer {
 
-    <A, T> void addCredentialProvider(CredentialProvider<A, T> credentialProvider);
+    void addCredentialProvider(CredentialProviderLocator providerLocator);
 
 }

--- a/credential/src/main/java/io/syndesis/credential/CredentialProviderLocator.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProviderLocator.java
@@ -19,6 +19,13 @@ import org.springframework.social.connect.ConnectionFactory;
 
 public interface CredentialProviderLocator {
 
+    /**
+     * Adds or replaces a CredentialProvider in the locator.
+     *
+     * @param credentialProvider the provider to add
+     */
+    <A, T> void addCredentialProvider(final CredentialProvider<A, T> credentialProvider);
+
     Applicator<?> getApplicator(String providerId);
 
     /**
@@ -31,12 +38,5 @@ public interface CredentialProviderLocator {
      * @return the requested ConnectionFactory
      */
     ConnectionFactory<?> getConnectionFactory(String providerId);
-
-    /**
-     * Adds or replaces a CredentialProvider in the locator.
-     *
-     * @param credentialProvider the provider to add
-     */
-    public <A, T> void addCredentialProvider(final CredentialProvider<A, T> credentialProvider);
 
 }

--- a/credential/src/main/java/io/syndesis/credential/CredentialProviderRegistry.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProviderRegistry.java
@@ -15,15 +15,16 @@
  */
 package io.syndesis.credential;
 
-import org.springframework.social.connect.ConnectionFactory;
-
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.social.connect.ConnectionFactory;
 
 final class CredentialProviderRegistry implements CredentialProviderLocator {
 
     private final Map<String, CredentialProvider<?, ?>> providers = new ConcurrentHashMap<>();
 
+    @Override
     public <A, T> void addCredentialProvider(final CredentialProvider<A, T> credentialProvider) {
         providers.put(credentialProvider.id(), credentialProvider);
     }

--- a/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceConfiguration.java
@@ -16,25 +16,24 @@
 package io.syndesis.credential.salesforce;
 
 import io.syndesis.credential.Applicator;
-import io.syndesis.credential.CredentialProvider;
+import io.syndesis.credential.CredentialProviderLocator;
 import io.syndesis.credential.DefaultCredentialProvider;
 import io.syndesis.credential.OAuth2Applicator;
 import io.syndesis.model.connection.Connection;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.social.SocialProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.social.config.annotation.SocialConfigurerAdapter;
 import org.springframework.social.oauth2.AccessGrant;
 import org.springframework.social.oauth2.OAuth2Template;
 import org.springframework.social.salesforce.api.Salesforce;
 import org.springframework.social.salesforce.connect.SalesforceConnectionFactory;
 
 @Configuration
-@ConditionalOnClass({SocialConfigurerAdapter.class, SalesforceConnectionFactory.class})
+@ConditionalOnClass(SalesforceConnectionFactory.class)
 @ConditionalOnProperty(prefix = "spring.social.salesforce", name = "app-id")
 @EnableConfigurationProperties(SalesforceProperties.class)
 public class SalesforceConfiguration {
@@ -67,20 +66,17 @@ public class SalesforceConfiguration {
     }
 
     @Autowired
-    public SalesforceConfiguration(final SalesforceProperties salesforceProperties) {
+    public SalesforceConfiguration(final SalesforceProperties salesforceProperties,
+        final CredentialProviderLocator locator) {
         this(createConnectionFactory(salesforceProperties), salesforceProperties);
+
+        locator.addCredentialProvider(new DefaultCredentialProvider<>("salesforce", salesforce, applicator));
     }
 
     protected SalesforceConfiguration(final SalesforceConnectionFactory salesforce,
         final SocialProperties salesforceProperties) {
         this.salesforce = salesforce;
         applicator = new SalesforceApplicator(salesforceProperties);
-    }
-
-    @Bean
-    public CredentialProvider<Salesforce, AccessGrant> create() {
-        return new DefaultCredentialProvider<>(
-            "salesforce", salesforce, applicator);
     }
 
     protected static SalesforceConnectionFactory

--- a/credential/src/main/java/io/syndesis/credential/twitter/TwitterConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/twitter/TwitterConfiguration.java
@@ -15,45 +15,37 @@
  */
 package io.syndesis.credential.twitter;
 
-import io.syndesis.credential.CredentialProvider;
+import io.syndesis.credential.CredentialProviderLocator;
 import io.syndesis.credential.DefaultCredentialProvider;
 import io.syndesis.credential.OAuth1Applicator;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.social.TwitterProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.social.config.annotation.SocialConfigurerAdapter;
-import org.springframework.social.oauth1.OAuthToken;
-import org.springframework.social.twitter.api.Twitter;
 import org.springframework.social.twitter.connect.TwitterConnectionFactory;
 
 @Configuration
-@ConditionalOnClass({SocialConfigurerAdapter.class, TwitterConnectionFactory.class})
+@ConditionalOnClass(TwitterConnectionFactory.class)
 @ConditionalOnProperty(prefix = "spring.social.twitter", name = "app-id")
 @EnableConfigurationProperties(TwitterProperties.class)
 public class TwitterConfiguration {
-
 
     private final OAuth1Applicator applicator;
     private final TwitterConnectionFactory twitter;
 
     @Autowired
-    protected TwitterConfiguration(final TwitterProperties properties) {
+    protected TwitterConfiguration(final TwitterProperties properties, final CredentialProviderLocator locator) {
         twitter = new TwitterConnectionFactory(properties.getAppId(), properties.getAppSecret());
         applicator = new OAuth1Applicator(properties);
         applicator.setConsumerKeyProperty("consumerKey");
         applicator.setConsumerSecretProperty("consumerSecret");
         applicator.setAccessTokenSecretProperty("accessTokenSecret");
         applicator.setAccessTokenValueProperty("accessToken");
-    }
 
-    @Bean
-    public CredentialProvider<Twitter, OAuthToken> create() {
-        return new DefaultCredentialProvider<>(
-            "twitter", twitter, applicator);
+        locator.addCredentialProvider(new DefaultCredentialProvider<>("twitter", twitter, applicator));
     }
 
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.rest.v1.handler.connection;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -34,13 +33,11 @@ import io.syndesis.credential.Credentials;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.inspector.ClassInspector;
 import io.syndesis.model.Kind;
-import io.syndesis.model.connection.Action;
 import io.syndesis.model.connection.Connector;
 import io.syndesis.model.connection.DataShape;
 import io.syndesis.model.connection.DataShapeKinds;
 import io.syndesis.model.filter.FilterOptions;
 import io.syndesis.model.filter.Op;
-import io.syndesis.model.integration.Integration;
 import io.syndesis.rest.v1.handler.BaseHandler;
 import io.syndesis.rest.v1.operations.Getter;
 import io.syndesis.rest.v1.operations.Lister;

--- a/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
@@ -23,6 +23,7 @@ import io.syndesis.credential.Acquisition;
 import io.syndesis.credential.AcquisitionMethod;
 import io.syndesis.credential.CredentialFlowState;
 import io.syndesis.credential.CredentialProvider;
+import io.syndesis.credential.CredentialProviderLocator;
 import io.syndesis.credential.Credentials;
 import io.syndesis.credential.OAuth2Applicator;
 import io.syndesis.model.connection.Connection;
@@ -38,7 +39,6 @@ import org.mockito.Matchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.social.SocialProperties;
 import org.springframework.cache.CacheManager;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -64,7 +64,11 @@ public class CredentialITCase extends BaseITCase {
     private CacheManager cache;
 
     public static class TestConfiguration {
-        @Bean
+
+        public TestConfiguration(CredentialProviderLocator locator) {
+            locator.addCredentialProvider(provider());
+        }
+
         public CredentialProvider<Object, AccessGrant> provider() {
             @SuppressWarnings("unchecked")
             final CredentialProvider<Object, AccessGrant> credentialProvider = mock(CredentialProvider.class);


### PR DESCRIPTION
The way we register CredentialProviders is not deterministic and can fail to register all CredentialProviders configured in @Configuration classes that are incorporated in the Spring Application Context after CredentialsConfiguration @Configuration class is done configuring and registering them.

This reverses the role from "I'll find you" to "I'll register with you" for CredentialProvider @Configurations. It also resurects the Configurer classes so that CredentialProviders don't end up being singletons in the Spring Application Context. They should not be accessible by other means other than through CredentialProviderLocator and it alone should handle their lifecycle.

fixes #447