### PR TITLE
chore(build): Don't use local maven repository ...

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
                     containerEnvVar(key:'GITHUB_OAUTH_CLIENT_ID', value: "${env.GITHUB_OAUTH_CLIENT_ID}"),
                     containerEnvVar(key:'GITHUB_OAUTH_CLIENT_SECRET', value: "${env.GITHUB_OAUTH_CLIENT_SECRET}")
                 ],
-                serviceAccount: "jenkins", mavenRepositoryClaim: "m2-local-repo", mavenSettingsXmlSecret: 'm2-settings'
+                serviceAccount: "jenkins", mavenSettingsXmlSecret: 'm2-settings'
             ) {
                 inside {
                     def testingNamespace = generateProjectName()


### PR DESCRIPTION
...volume

Since we're having issues with volume mounting:

    Unable to mount volumes for pod "syndesis-rest-pr-442-7-gc2ph-hsmw5_syndesis-ci(af10c38f-6db2-11e7-8ec7-0e13a02d8ebd)": timeout expired waiting for volumes to attach/mount for pod "syndesis-rest-pr-442-7-gc2ph-hsmw5"/"syndesis-ci". list of unattached/unmounted volumes=[volume-1]

This removes mounting `m2-local-repo` volume, so the local Maven
repository will be trashed when the build job finishes.

This could make our builds a bit slower (measurement needed) as now they
need to download the needed artifacts from Nexus.

fixes #455