### PR TITLE
fix(persistence): Caching and returning wrong entity from `DataManger::create`

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -108,6 +108,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
+++ b/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
@@ -177,9 +177,9 @@ public class DataManager implements DataAccessObjectRegistry {
         }
 
         this.<T, T>doWithDataAccessObject(kind.getModelClass(), d -> d.create(entityToCreate));
-        cache.put(idVal, entity);
+        cache.put(idVal, entityToCreate);
         broadcast("created", kind.getModelName(), idVal);
-        return entity;
+        return entityToCreate;
     }
 
     public <T extends WithId<T>> void update(T entity) {

--- a/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 
 import io.syndesis.core.Json;
 import io.syndesis.dao.manager.DataManager;
+import io.syndesis.model.Kind;
 import io.syndesis.model.ListResult;
 import io.syndesis.model.connection.Connection;
 import io.syndesis.model.connection.Connector;
@@ -29,6 +30,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DataManagerTest {
 
@@ -111,4 +114,22 @@ public class DataManagerTest {
         Assert.assertEquals(int2.getDesiredStatus(), int3.getDesiredStatus());
     }
 
+    @Test
+    public void createShouldCreateWithUnspecifiedIds() {
+        final Connector given = new Connector.Builder().icon("my-icon").build();
+        final Connector got = dataManager.create(given);
+
+        assertThat(got).isEqualToIgnoringGivenFields(given, "id");
+        assertThat(got.getId()).isPresent();
+        assertThat(infinispan.getCaches().getCache(Kind.Connector.modelName).get(got.getId().get())).isSameAs(got);
+    }
+
+    @Test
+    public void createShouldCreateWithSpecifiedId() {
+        final Connector connector = new Connector.Builder().id("custom-id").build();
+        final Connector got = dataManager.create(connector);
+
+        assertThat(got).isSameAs(connector);
+        assertThat(infinispan.getCaches().getCache(Kind.Connector.modelName).get("custom-id")).isSameAs(connector);
+    }
 }

--- a/inspector/src/main/java/io/syndesis/inspector/DataMapperClassInspector.java
+++ b/inspector/src/main/java/io/syndesis/inspector/DataMapperClassInspector.java
@@ -77,9 +77,9 @@ public class DataMapperClassInspector implements ClassInspector {
     protected List<String> getPathsForJavaClassName(String prefix, String fullyQualifiedName, List<String> visited) {
         if (visited.contains(fullyQualifiedName)) {
             return Collections.emptyList();
-        } else {
-            visited.add(fullyQualifiedName);
         }
+
+        visited.add(fullyQualifiedName);
 
         ResponseEntity<String> response = null;
         try {
@@ -113,9 +113,9 @@ public class DataMapperClassInspector implements ClassInspector {
                                 if (isPrimitive || isTerminal(fieldClassName)) {
                                     paths.add(prefix + DEFAULT_SEPARATOR + name);
                                     continue;
-                                } else {
-                                    paths.addAll(getPathsForJavaClassName(prefix + DEFAULT_SEPARATOR + name, fieldClassName, visited));
                                 }
+
+                                paths.addAll(getPathsForJavaClassName(prefix + DEFAULT_SEPARATOR + name, fieldClassName, visited));
                             }
                         }
                     }
@@ -132,7 +132,9 @@ public class DataMapperClassInspector implements ClassInspector {
         int index = fullyQualifiedName.lastIndexOf(".");
         if (index > 0) {
             return fullyQualifiedName.substring(index + 1);
-        } else return fullyQualifiedName;
+        }
+
+        return fullyQualifiedName;
     }
 
     /**

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/BaseExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/BaseExceptionMapper.java
@@ -31,7 +31,7 @@ abstract class BaseExceptionMapper<E extends Throwable> implements ExceptionMapp
 
     private final String userMessage;
 
-    public BaseExceptionMapper(final Status status, final String userMessage) {
+    protected BaseExceptionMapper(final Status status, final String userMessage) {
         this.status = status;
         this.userMessage = userMessage;
     }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppHandler.java
@@ -15,13 +15,11 @@
  */
 package io.syndesis.rest.v1.handler.setup;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
-import io.syndesis.core.SuppressFBWarnings;
-import io.syndesis.dao.manager.DataManager;
-import io.syndesis.model.connection.ConfigurationProperty;
-import io.syndesis.model.connection.Connector;
-import org.springframework.stereotype.Component;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
@@ -35,11 +33,15 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeSet;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
+import io.syndesis.core.SuppressFBWarnings;
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.model.connection.ConfigurationProperty;
+import io.syndesis.model.connection.Connector;
+
+import org.springframework.stereotype.Component;
 
 /**
  * This rest endpoint handles working with global oauth settings.
@@ -95,9 +97,9 @@ public class OAuthAppHandler {
         }
         if (isOauthConnector(connector)) {
             return createOAuthApp(connector);
-        } else {
-            throw new EntityNotFoundException();
         }
+
+        throw new EntityNotFoundException();
     }
 
     private static OAuthApp createOAuthApp(Connector connector) {
@@ -132,9 +134,8 @@ public class OAuthAppHandler {
     }
 
     private static boolean isOauthConnector(Connector connector) {
-        TreeSet EMPTY = new TreeSet();
         return connector.getProperties().values().stream().anyMatch(x -> {
-                return x.getTags().orElse(EMPTY).contains("oauth-client-id");
+                return x.getTags().orElse(Collections.emptySortedSet()).contains("oauth-client-id");
             }
         );
     }
@@ -143,9 +144,8 @@ public class OAuthAppHandler {
         if( connector.getProperties() == null ) {
             return null;
         }
-        TreeSet EMPTY = new TreeSet();
         for (Map.Entry<String,ConfigurationProperty> entry : connector.getProperties().entrySet()) {
-            if( entry.getValue().getTags().orElse(EMPTY).contains(name) ) {
+            if( entry.getValue().getTags().orElse(Collections.emptySortedSet()).contains(name) ) {
                 return connector.getConfiguredProperties().get(entry.getKey());
             }
         }
@@ -153,9 +153,8 @@ public class OAuthAppHandler {
     }
 
     private static void setPropertyTaggedAs(Connector connector, Map<String, String> configuredProperties, String name, String value) {
-        TreeSet EMPTY = new TreeSet();
         for (Map.Entry<String,ConfigurationProperty> entry : connector.getProperties().entrySet()) {
-            if( entry.getValue().getTags().orElse(EMPTY).contains(name) ) {
+            if( entry.getValue().getTags().orElse(Collections.emptySortedSet()).contains(name) ) {
                 configuredProperties.put(entry.getKey(), value);
                 return;
             }


### PR DESCRIPTION
In the code cleanup (#426) result of the `DataManger::create` was wrongly assigned and cached as the given entity, it should be the `entityToCreate` thats being assigned if the `id` is not present.

Fixes syndesisio/syndesis-ui#662