### PR TITLE
fix(project): Dependency issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,10 +167,10 @@
     <module>openshift</module>
     <module>project-generator</module>
     <module>rest</module>
+    <module>syndesis-maven-plugin</module>
     <module>runtime</module>
     <module>verifier</module>
     <module>inspector</module>
-    <module>syndesis-maven-plugin</module>
   </modules>
 
   <dependencyManagement>
@@ -458,6 +458,12 @@
             <artifactId>spring-social-web</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
 
       <dependency>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -238,7 +238,7 @@
               <groupId>com.fasterxml.jackson.core</groupId>
               <artifactId>jackson-annotations</artifactId>
               <expectedVersion>2.8.4</expectedVersion>
-              <resolvedVersion>2.8.0</resolvedVersion>
+              <resolvedVersion>2.8.8</resolvedVersion>
             </exception>
           </exceptions>
         </configuration>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -304,31 +304,31 @@
             <exception>
               <groupId>com.fasterxml.jackson.core</groupId>
               <artifactId>jackson-annotations</artifactId>
-              <resolvedVersion>2.8.0</resolvedVersion>
+              <resolvedVersion>2.8.8</resolvedVersion>
               <expectedVersion>2.5.4</expectedVersion>
             </exception>
             <exception>
               <groupId>com.fasterxml.jackson.core</groupId>
               <artifactId>jackson-annotations</artifactId>
-              <resolvedVersion>2.8.0</resolvedVersion>
+              <resolvedVersion>2.8.8</resolvedVersion>
               <expectedVersion>2.6.0</expectedVersion>
             </exception>
             <exception>
               <groupId>com.fasterxml.jackson.core</groupId>
               <artifactId>jackson-annotations</artifactId>
-              <resolvedVersion>2.8.0</resolvedVersion>
+              <resolvedVersion>2.8.8</resolvedVersion>
               <expectedVersion>2.7.0</expectedVersion>
             </exception>
             <exception>
               <groupId>com.fasterxml.jackson.core</groupId>
               <artifactId>jackson-annotations</artifactId>
-              <resolvedVersion>2.8.0</resolvedVersion>
+              <resolvedVersion>2.8.8</resolvedVersion>
               <expectedVersion>2.8.3</expectedVersion>
             </exception>
             <exception>
               <groupId>com.fasterxml.jackson.core</groupId>
               <artifactId>jackson-annotations</artifactId>
-              <resolvedVersion>2.8.0</resolvedVersion>
+              <resolvedVersion>2.8.8</resolvedVersion>
               <expectedVersion>2.8.6</expectedVersion>
             </exception>
             <exception>

--- a/syndesis-maven-plugin/pom.xml
+++ b/syndesis-maven-plugin/pom.xml
@@ -29,17 +29,79 @@
   <name>Syndesis Maven Plugin</name>
   <packaging>maven-plugin</packaging>
 
+  <properties>
+    <maven.version>3.5.0</maven.version>
+  </properties>
+
   <dependencies>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>model</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>dao</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.atlasmap</groupId>
       <artifactId>atlasmap-maven-plugin</artifactId>
       <version>${atlasmap.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.containers</groupId>
+          <artifactId>jersey-container-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.hk2.external</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.hk2.external</groupId>
+          <artifactId>aopalliance-repackaged</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-json-jackson</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
@@ -48,34 +110,34 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.el</groupId>
-      <artifactId>javax.el-api</artifactId>
-      <version>2.2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.web</groupId>
-      <artifactId>javax.el</artifactId>
-      <version>2.2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-validator-annotation-processor</artifactId>
-      <version>4.1.0.Final</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>1.0.3</version>
     </dependency>
 
     <!-- Runtime Dependencies -->
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>rest</artifactId>
+      <scope>runtime</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -95,36 +157,55 @@
         </executions>
       </plugin>
 
-      <!--
-          Don't have time to resolve all the dependency issues, but it works
-          so disable all these plugin checks since it's only used at build time.
-      -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>com.ning.maven.plugins</groupId>
         <artifactId>maven-dependency-versions-check-plugin</artifactId>
         <configuration>
-          <skip>true</skip>
+          <exceptions>
+            <exception>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <resolvedVersion>2.8.8</resolvedVersion>
+              <expectedVersion>2.8.4</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
+              <resolvedVersion>18.0</resolvedVersion>
+              <expectedVersion>20.0</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>org.apache.commons</groupId>
+              <artifactId>commons-lang3</artifactId>
+              <resolvedVersion>3.2.1</resolvedVersion>
+              <expectedVersion>3.5</expectedVersion>
+            </exception>
+            <exception>
+              <groupId>org.apache.maven</groupId>
+              <artifactId>maven-settings-builder</artifactId>
+              <resolvedVersion>3.2.1</resolvedVersion>
+              <expectedVersion>3.5.0</expectedVersion>
+            </exception>
+          </exceptions>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.basepom.maven</groupId>
         <artifactId>duplicate-finder-maven-plugin</artifactId>
         <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.hubspot.maven.plugins</groupId>
-        <artifactId>dependency-management-maven-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
+          <ignoredClassPatterns>
+            <ignoredClassPattern>org.aopalliance.*</ignoredClassPattern>
+            <ignoredClassPattern>javax.annotation.*</ignoredClassPattern>
+            <ignoredClassPattern>io.fabric8.kubernetes.client.*</ignoredClassPattern>
+            <ignoredClassPattern>org.infinispan.*</ignoredClassPattern>
+            <ignoredClassPattern>org.springframework.security.crypto.*</ignoredClassPattern>
+            <ignoredClassPattern>org.objectweb.asm.*</ignoredClassPattern>
+          </ignoredClassPatterns>
+          <ignoredResourcePatterns>
+            <ignoredResourcePattern>about.html</ignoredResourcePattern>
+            <ignoredResourcePattern>features.xml</ignoredResourcePattern>
+          </ignoredResourcePatterns>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
This reinstates the dependency plugin checks. Also of note fixes
incorrect version of jackson-annotations (resolved 2.8.0, rest of the
jackson dependencies are at 2.8.8).

A number of jersey dependencies were excluded as they are not needed.

`syndesis-maven-plugin` module was placed before the `runtime` module
in order to be built in proper order.