### PR TITLE
PMD ruleset tweaks, reported fixes

### DIFF
--- a/connector-catalog/src/main/java/io/syndesis/connector/catalog/ConnectorCatalogProperties.java
+++ b/connector-catalog/src/main/java/io/syndesis/connector/catalog/ConnectorCatalogProperties.java
@@ -15,17 +15,17 @@
  */
 package io.syndesis.connector.catalog;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("camel.connector.catalog")
 public class ConnectorCatalogProperties {
 
-    private Map<String, String> mavenRepos = new HashMap<>(1);
+    private Map<String, String> mavenRepos = new ConcurrentHashMap<>(1);
 
     private List<String> connectorGAVs = new ArrayList<>(5);
 

--- a/controllers/src/main/java/io/syndesis/controllers/integration/DemoHandlerProvider.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/DemoHandlerProvider.java
@@ -38,11 +38,11 @@ public class DemoHandlerProvider implements StatusChangeHandlerProvider {
                             );
     }
 
-    static class DemoHandler implements StatusChangeHandler {
+    /* default */ static class DemoHandler implements StatusChangeHandler {
         private final Integration.Status status;
         private final long waitMillis;
 
-        DemoHandler(Integration.Status status, long waitMillis) {
+        /* default */ DemoHandler(Integration.Status status, long waitMillis) {
             this.status = status;
             this.waitMillis = waitMillis;
         }

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
@@ -49,8 +49,8 @@ import org.slf4j.LoggerFactory;
 public class ActivateHandler implements StatusChangeHandlerProvider.StatusChangeHandler {
 
     // Step used which should be performed only once per integration
-    static final String STEP_GITHUB = "github-setup";
-    static final String STEP_OPENSHIFT = "openshift-setup";
+    /* default */ static final String STEP_GITHUB = "github-setup";
+    /* default */ static final String STEP_OPENSHIFT = "openshift-setup";
 
     private final DataManager dataManager;
     private final OpenShiftService openShiftService;
@@ -59,7 +59,7 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
 
     private static final Logger LOG = LoggerFactory.getLogger(ActivateHandler.class);
 
-    ActivateHandler(DataManager dataManager, OpenShiftService openShiftService,
+    /* default */ ActivateHandler(DataManager dataManager, OpenShiftService openShiftService,
                     GitHubService gitHubService, ProjectGenerator projectConverter) {
         this.dataManager = dataManager;
         this.openShiftService = openShiftService;

--- a/credential/src/main/java/io/syndesis/credential/AcquisitionResponse.java
+++ b/credential/src/main/java/io/syndesis/credential/AcquisitionResponse.java
@@ -23,6 +23,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = AcquisitionResponse.Builder.class)
 public interface AcquisitionResponse {
 
+    @SuppressWarnings("PMD.UseUtilityClass")
     final class Builder extends ImmutableAcquisitionResponse.Builder {
 
         public static AcquisitionResponse.Builder from(final AcquisitionFlow flow) {
@@ -35,6 +36,7 @@ public interface AcquisitionResponse {
     @JsonDeserialize(builder = State.Builder.class)
     interface State {
 
+        @SuppressWarnings("PMD.UseUtilityClass")
         final class Builder extends ImmutableState.Builder {
 
             public static State cookie(final String spec) {

--- a/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.social.salesforce.connect.SalesforceConnectionFactory
 @ConditionalOnClass(SalesforceConnectionFactory.class)
 @ConditionalOnProperty(prefix = "spring.social.salesforce", name = "app-id")
 @EnableConfigurationProperties(SalesforceProperties.class)
+@SuppressWarnings("PMD.UseUtilityClass")
 public class SalesforceConfiguration {
 
     protected static final class SalesforceApplicator extends OAuth2Applicator {

--- a/credential/src/main/java/io/syndesis/credential/twitter/TwitterConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/twitter/TwitterConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.social.twitter.connect.TwitterConnectionFactory;
 @ConditionalOnClass(TwitterConnectionFactory.class)
 @ConditionalOnProperty(prefix = "spring.social.twitter", name = "app-id")
 @EnableConfigurationProperties(TwitterProperties.class)
+@SuppressWarnings("PMD.UseUtilityClass")
 public class TwitterConfiguration {
 
     @Autowired

--- a/dao/src/main/java/io/syndesis/dao/init/ModelData.java
+++ b/dao/src/main/java/io/syndesis/dao/init/ModelData.java
@@ -39,6 +39,7 @@ public class ModelData<T extends WithId<T>> implements ToJson {
     private String json;
 
     public ModelData() {
+        // makes it easier to handle as a Java bean
     }
 
     public ModelData(Kind kind, T data) {

--- a/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
+++ b/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
@@ -17,10 +17,10 @@ package io.syndesis.dao.manager;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import javax.annotation.PostConstruct;
@@ -57,7 +57,7 @@ public class DataManager implements DataAccessObjectRegistry {
     private String dataFileName;
 
     private final List<DataAccessObject<?>> dataAccessObjects = new ArrayList<>();
-    private final Map<Class<? extends WithId<?>>, DataAccessObject<?>> dataAccessObjectMapping = new HashMap<>();
+    private final Map<Class<? extends WithId<?>>, DataAccessObject<?>> dataAccessObjectMapping = new ConcurrentHashMap<>();
 
     // Constructor to help with testing.
     public DataManager(CacheContainer caches, List<DataAccessObject<?>> dataAccessObjects, String dataFileName) {

--- a/github/src/main/java/io/syndesis/github/backend/FileContent.java
+++ b/github/src/main/java/io/syndesis/github/backend/FileContent.java
@@ -22,12 +22,10 @@ import java.util.Base64;
  */
 class FileContent {
 
-    private String content;
-    private String path;
-    private String message;
-    private String sha;
-
-    FileContent() {}
+    private final String content;
+    private final String path;
+    private final String message;
+    private final String sha;
 
     FileContent(String path, String message, byte[] content, String sha) {
         this.path = assertNotNull("path", path);

--- a/inspector/src/main/java/io/syndesis/inspector/ClassInspectorConfigurationProperties.java
+++ b/inspector/src/main/java/io/syndesis/inspector/ClassInspectorConfigurationProperties.java
@@ -32,6 +32,7 @@ public class ClassInspectorConfigurationProperties {
     private boolean strict = true;
 
     public ClassInspectorConfigurationProperties() {
+        // behave like a Java bean
     }
 
     public ClassInspectorConfigurationProperties(String host, int port, boolean strict) {

--- a/inspector/src/main/java/io/syndesis/inspector/DataMapperClassInspector.java
+++ b/inspector/src/main/java/io/syndesis/inspector/DataMapperClassInspector.java
@@ -52,9 +52,9 @@ public class DataMapperClassInspector implements ClassInspector {
 
     private static final String CACHE_NAME = ClassInspector.class.getName();
 
-    private CacheContainer caches;
-    private RestTemplate restTemplate;
-    private ClassInspectorConfigurationProperties config;
+    private final CacheContainer caches;
+    private final RestTemplate restTemplate;
+    private final ClassInspectorConfigurationProperties config;
 
 
     protected DataMapperClassInspector(CacheContainer caches, RestTemplate restTemplate, ClassInspectorConfigurationProperties config) {

--- a/model/src/main/java/io/syndesis/model/filter/Op.java
+++ b/model/src/main/java/io/syndesis/model/filter/Op.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 
 @Value.Immutable
 @JsonDeserialize(builder = Op.Builder.class)
+@SuppressWarnings("PMD.ShortClassName")
 public interface Op extends Serializable {
 
     Op EQUALS = new Op.Builder().label("equals").operator("==").build();

--- a/model/src/main/java/io/syndesis/model/integration/StepDeserializer.java
+++ b/model/src/main/java/io/syndesis/model/integration/StepDeserializer.java
@@ -25,6 +25,7 @@ import io.syndesis.model.filter.ExpressionFilterStep;
 import io.syndesis.model.filter.RuleFilterStep;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,11 +34,14 @@ public class StepDeserializer extends JsonDeserializer<Step> {
     private static final String STEP_KIND = "stepKind";
 
     private static final Class<SimpleStep> DEFAULT_STEP_TYPE = SimpleStep.class;
-    private static final Map<String, Class<? extends Step>> KIND_TO_STEP_MAPPING = new HashMap<>();
+    private static final Map<String, Class<? extends Step>> KIND_TO_STEP_MAPPING;
 
     static {
-        KIND_TO_STEP_MAPPING.put(ExpressionFilterStep.STEP_KIND, ExpressionFilterStep.class);
-        KIND_TO_STEP_MAPPING.put(RuleFilterStep.STEP_KIND, RuleFilterStep.class);
+        final Map<String, Class<? extends Step>> mapping = new HashMap<>();
+        mapping.put(ExpressionFilterStep.STEP_KIND, ExpressionFilterStep.class);
+        mapping.put(RuleFilterStep.STEP_KIND, RuleFilterStep.class);
+
+        KIND_TO_STEP_MAPPING = Collections.unmodifiableMap(mapping);
     }
 
     @Override

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
@@ -230,14 +230,14 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     }
 
 
-    static class DockerImage {
+    /* default */ static class DockerImage {
         private final String image;
 
         private String tag = "latest";
 
         private final String shortName;
 
-        DockerImage(String fullImage) {
+        /* default */ DockerImage(String fullImage) {
             image = fullImage;
 
             int colonIndex = fullImage.lastIndexOf(':');

--- a/pom.xml
+++ b/pom.xml
@@ -829,6 +829,7 @@
           <excludeRoots>
             <excludeRoot>target/generated-sources</excludeRoot>
           </excludeRoots>
+          <printFailingErrors>true</printFailingErrors>
         </configuration>
       </plugin>
 

--- a/rest/src/main/java/io/syndesis/rest/v1/JacksonContextResolver.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/JacksonContextResolver.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Service;
 @Produces(MediaType.APPLICATION_JSON)
 @Service
 public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     public JacksonContextResolver() {
         this.objectMapper = Json.mapper();

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/BaseHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/BaseHandler.java
@@ -21,7 +21,7 @@ import io.syndesis.dao.manager.WithDataManager;
 
 public abstract class BaseHandler implements WithDataManager {
 
-    private DataManager dataMgr;
+    private final DataManager dataMgr;
 
     protected BaseHandler(DataManager dataMgr) {
         this.dataMgr = dataMgr;

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionHandler.java
@@ -45,9 +45,9 @@ public class ConnectionHandler extends BaseHandler
 
     private final Credentials credentials;
 
-    private ClientSideState state;
+    private final ClientSideState state;
 
-    public ConnectionHandler(final DataManager dataMgr, final Credentials credentials, ClientSideState state) {
+    public ConnectionHandler(final DataManager dataMgr, final Credentials credentials, final ClientSideState state) {
         super(dataMgr);
         this.credentials = credentials;
         this.state = state;

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorActionHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorActionHandler.java
@@ -36,7 +36,7 @@ import javax.ws.rs.core.UriInfo;
 @Api(value = "actions")
 public class ConnectorActionHandler extends BaseHandler implements Lister<Action>, Getter<Action> {
 
-    private String connectorId;
+    private final String connectorId;
 
     ConnectorActionHandler(DataManager dataMgr, String connectorId) {
         super(dataMgr);

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/RestError.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/RestError.java
@@ -29,15 +29,16 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 public class RestError {
 
     @JsonProperty("developerMsg")
-    String developerMsg;
+    /* default */ String developerMsg;
 
     @JsonProperty("userMsg")
-    String userMsg;
+    /* default */ String userMsg;
 
     @JsonProperty("errorCode")
-    Integer errorCode;
+    /* default */ Integer errorCode;
 
     public RestError() {
+        // makes it a Java bean
     }
 
     public RestError(String developerMsg, String userMsg, Integer errorCode) {

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppToCredentialsBridge.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppToCredentialsBridge.java
@@ -95,7 +95,7 @@ public class OAuthAppToCredentialsBridge {
                         });
                     }
                 } catch (IOException e) {
-                    LOG.error("Error while processing change-event " + data, e);
+                    LOG.error("Error while processing change-event {}", data, e);
                 }
             }
         };

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/tests/TestSupportHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/tests/TestSupportHandler.java
@@ -84,7 +84,7 @@ public class TestSupportHandler {
     @GET
     @Path("/snapshot-db")
     @Produces(MediaType.APPLICATION_JSON)
-    public ArrayList<ModelData<?>> snapshotDB() {
+    public List<ModelData<?>> snapshotDB() {
         LOG.info("user {} is making snapshot", context.getRemoteUser());
         ArrayList<ModelData<?>> result = new ArrayList<>();
         for (DataAccessObject<?> dao : daos) {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -444,7 +444,7 @@ or
     <priority>3</priority>
     <properties>
       <property name="maximumAsserts">
-        <value><![CDATA[1]]></value>
+        <value><![CDATA[3]]></value>
       </property>
       <property name="xpath">
         <value><![CDATA[
@@ -700,9 +700,6 @@ and count(PrimarySuffix) = 0)]
                   ]]></value>
       </property>
     </properties>
-  </rule>
-  <rule ref="rulesets/java/junit.xml/JUnitAssertionsShouldIncludeMessage">
-    <priority>3</priority>
   </rule>
   <rule ref="rulesets/java/unnecessary.xml/UnnecessaryConversionTemporary">
     <priority>3</priority>
@@ -1802,6 +1799,11 @@ count(PrimarySuffix) = 1
   </rule>
   <rule ref="rulesets/java/design.xml/CloseResource">
     <priority>3</priority>
+    <properties>
+      <property name="types">
+        <value>java.sql.Connection,java.sql.Statement,java.sql.ResultSet,java.io.InputStream,java.io.ObjectInputStream,java.io.ObjectOutputStream,java.io.ObjectInput,java.io.Closeable,java.io.OutputStream,java.io.ObjectOutput</value>
+      </property>
+    </properties>
   </rule>
   <rule ref="rulesets/java/basic.xml/OverrideBothEqualsAndHashcode">
     <priority>3</priority>
@@ -2766,9 +2768,6 @@ starts-with(@Image,'Runtime.getRuntime') and
   </rule>
   <rule ref="rulesets/java/unnecessary.xml/UselessOperationOnImmutable">
     <priority>3</priority>
-  </rule>
-  <rule ref="rulesets/java/optimizations.xml/AvoidInstantiatingObjectsInLoops">
-    <priority>5</priority>
   </rule>
   <rule ref="rulesets/java/strings.xml/StringInstantiation">
     <priority>3</priority>

--- a/runtime/src/main/java/io/syndesis/runtime/Application.java
+++ b/runtime/src/main/java/io/syndesis/runtime/Application.java
@@ -66,14 +66,15 @@ public class Application extends SpringBootServletInitializer {
     @Bean
     public ClientSideState clientSideState(final ClientSideStateProperties properties) {
         if (!properties.areSet()) {
-            LOG.warn("\n*** Client side state persistence configuration is not defined, please set\n"
-                + "    CLIENT_STATE_AUTHENTICATION_ALGORITHM\n"//
-                + "    CLIENT_STATE_AUTHENTICATION_KEY\n"//
-                + "    CLIENT_STATE_ENCRYPTION_ALGORITHM\n"//
-                + "    CLIENT_STATE_ENCRYPTION_KEY\n"//
-                + "    CLIENT_STATE_TID\n"//
-                + " environment variables.\n"//
-                + "*** Using randomized values for missing properties, this will not work across restarts or when scaled!");
+            LOG.warn(new StringBuilder("\n*** Client side state persistence configuration is not defined, please set\n")
+                .append("    CLIENT_STATE_AUTHENTICATION_ALGORITHM\n")//
+                .append("    CLIENT_STATE_AUTHENTICATION_KEY\n")//
+                .append("    CLIENT_STATE_ENCRYPTION_ALGORITHM\n")//
+                .append("    CLIENT_STATE_ENCRYPTION_KEY\n")//
+                .append("    CLIENT_STATE_TID\n")//
+                .append(" environment variables.\n")//
+                .append("*** Using randomized values for missing properties, this will not work across restarts or when scaled!")//
+                .toString());
         }
 
         final StaticEdition edition = new StaticEdition(properties);

--- a/runtime/src/main/java/io/syndesis/runtime/KeycloakConfiguration.java
+++ b/runtime/src/main/java/io/syndesis/runtime/KeycloakConfiguration.java
@@ -48,7 +48,7 @@ public class KeycloakConfiguration extends KeycloakWebSecurityConfigurerAdapter 
 
     // the default HttpSessionManager tries to access HttpSession, when used with Infinispan spring-session support
     // the session is `null`, see AbstractApplicationPublisherBridge::emitSessionCreatedEvent
-    static class NopHttpSessionManager extends HttpSessionManager {
+    /* default */ static class NopHttpSessionManager extends HttpSessionManager {
 
         public static final HttpSessionManager INSTANCE = new NopHttpSessionManager();
 

--- a/syndesis-maven-plugin/src/main/java/io/syndesis/maven/GenerateMapperInspectionsMojo.java
+++ b/syndesis-maven-plugin/src/main/java/io/syndesis/maven/GenerateMapperInspectionsMojo.java
@@ -37,6 +37,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Set;
 import java.util.HashSet;
 import java.util.List;
 
@@ -69,7 +70,7 @@ public class GenerateMapperInspectionsMojo extends AbstractMojo {
             resource.setDirectory(outputDir.getCanonicalPath());
             project.addResource(resource);
 
-            HashSet<File> generated = new HashSet<>();
+            Set<File> generated = new HashSet<>();
 
             ReadApiClientData reader = new ReadApiClientData();
             List<ModelData<?>> modelList = reader.readDataFromFile("io/syndesis/dao/deployment.json");
@@ -91,7 +92,7 @@ public class GenerateMapperInspectionsMojo extends AbstractMojo {
         }
     }
 
-    private void process(HashSet<File> generated, Connector connector, Action action, DataShape shape) throws MojoFailureException, MojoExecutionException {
+    private void process(Set<File> generated, Connector connector, Action action, DataShape shape) throws MojoFailureException, MojoExecutionException {
         if (shape == null) {
             return;
         }

--- a/verifier/src/main/java/io/syndesis/verifier/ExternalVerifierService.java
+++ b/verifier/src/main/java/io/syndesis/verifier/ExternalVerifierService.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty(value = "verifier.kind", havingValue = "service", matchIfMissing = true)
 public class ExternalVerifierService implements Verifier {
 
-    private VerificationConfigurationProperties config;
+    private final VerificationConfigurationProperties config;
 
     public ExternalVerifierService(VerificationConfigurationProperties config) {
         this.config = config;


### PR DESCRIPTION
Changes to ruleset.xml:

 - allows 3 asserts to be present in JUnit test (was 1)
 - removes the necessity of message in asserts
 - explicitly sets the types of resources that must be closed (in a hope
   not to be mistaken with io.syndesis.model.connection.Connection)
 - allows instantiation of objects in loops (never fully understood the
   rationale behind that one)

Includes code changes to more-or-less complies with the given ruleset.