### PR TITLE
refactor(database): Use H2 instead of SQLite fo...

### DIFF
--- a/jsondb/pom.xml
+++ b/jsondb/pom.xml
@@ -102,8 +102,8 @@
 
     <!-- == Test ==========================================================================  -->
     <dependency>
-      <groupId>org.xerial</groupId>
-      <artifactId>sqlite-jdbc</artifactId>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jsondb/src/test/java/io/syndesis/jsondb/impl/JsonDBTest.java
+++ b/jsondb/src/test/java/io/syndesis/jsondb/impl/JsonDBTest.java
@@ -16,21 +16,28 @@
 package io.syndesis.jsondb.impl;
 
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.syndesis.jsondb.GetOptions;
-import io.syndesis.jsondb.JsonDBException;
-import org.junit.Before;
-import org.junit.Test;
-import org.skife.jdbi.v2.DBI;
-import org.sqlite.SQLiteDataSource;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.syndesis.jsondb.GetOptions;
+import io.syndesis.jsondb.JsonDBException;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -48,8 +55,8 @@ public class JsonDBTest {
 
     @Before
     public void before() {
-        SQLiteDataSource ds = new SQLiteDataSource();
-        ds.setUrl("jdbc:sqlite:target/sqlite.db");
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
         DBI dbi = new DBI(ds);
         this.jsondb = new SqlJsonDB(dbi, null);
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
     <spring-security.version>4.2.2.RELEASE</spring-security.version>
     <spring-social.version>1.1.4.RELEASE</spring-social.version>
     <swagger.version>1.5.12</swagger.version>
-    <sqlite-jdbc.version>3.16.1</sqlite-jdbc.version>
     <undertow.version>1.4.13.Final</undertow.version>
     <atlasmap.version>1.17.0</atlasmap.version>
     <camel-atlasmap.version>1.10.0</camel-atlasmap.version>
@@ -658,12 +657,6 @@
         <artifactId>postgresql</artifactId>
         <version>${postgresql.version}</version>
         <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.xerial</groupId>
-        <artifactId>sqlite-jdbc</artifactId>
-        <version>${sqlite-jdbc.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jdbi</groupId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -653,11 +653,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.xerial</groupId>
-      <artifactId>sqlite-jdbc</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
     </dependency>
@@ -701,6 +696,12 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/runtime/src/test/resources/application-test.yml
+++ b/runtime/src/test/resources/application-test.yml
@@ -28,10 +28,8 @@ controllers:
 
 spring:
   datasource:
-    url: 'jdbc:sqlite:target/sqlite.db'
-    username: sa
-    password: sa
-    driver-class-name: org.sqlite.JDBC
+    url: 'jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL'
+    driver-class-name: org.h2.Driver
 
 github:
   enabled: false


### PR DESCRIPTION
...r tests

Switches from SQLite to H2 for integration tests. SQLite is somewhat
harder to manage than H2 and with H2 we gain (relatively speaking) more
portability.

Fixes #496