### PR TITLE
New resource for validation

### DIFF
--- a/model/src/main/java/io/syndesis/model/validation/AllValidations.java
+++ b/model/src/main/java/io/syndesis/model/validation/AllValidations.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.validation;
+
+/**
+ * Requires all validations.
+ */
+public interface AllValidations extends UniquenessRequired {
+    // tag interface
+}

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionHandler.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Validator;
 import javax.validation.groups.ConvertGroup;
 import javax.validation.groups.Default;
 import javax.ws.rs.Path;
@@ -40,6 +41,7 @@ import io.syndesis.rest.v1.operations.Deleter;
 import io.syndesis.rest.v1.operations.Getter;
 import io.syndesis.rest.v1.operations.Lister;
 import io.syndesis.rest.v1.operations.Updater;
+import io.syndesis.rest.v1.operations.Validating;
 import io.syndesis.rest.v1.state.ClientSideState;
 
 import org.springframework.stereotype.Component;
@@ -48,7 +50,7 @@ import org.springframework.stereotype.Component;
 @Api(value = "connections")
 @Component
 public class ConnectionHandler extends BaseHandler
-    implements Lister<Connection>, Getter<Connection>, Creator<Connection>, Deleter<Connection>, Updater<Connection> {
+    implements Lister<Connection>, Getter<Connection>, Creator<Connection>, Deleter<Connection>, Updater<Connection>, Validating<Connection> {
 
     private final Credentials credentials;
 
@@ -60,8 +62,11 @@ public class ConnectionHandler extends BaseHandler
     @Context
     private HttpServletResponse response;
 
-    public ConnectionHandler(final DataManager dataMgr, final Credentials credentials, final ClientSideState state) {
+    private final Validator validator;
+
+    public ConnectionHandler(final DataManager dataMgr, final Validator validator, final Credentials credentials, final ClientSideState state) {
         super(dataMgr);
+        this.validator = validator;
         this.credentials = credentials;
         this.state = state;
     }
@@ -110,4 +115,8 @@ public class ConnectionHandler extends BaseHandler
         Updater.super.update(id, updatedConnection);
     }
 
+    @Override
+    public Validator getValidator() {
+        return validator;
+    }
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Validating.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Validating.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.operations;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.syndesis.model.WithId;
+import io.syndesis.model.validation.AllValidations;
+
+public interface Validating<T extends WithId<T>> extends Resource {
+
+    Validator getValidator();
+
+    @POST
+    @Path(value = "/validation")
+    @Consumes("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponses({//
+        @ApiResponse(code = 204, message = "All validations pass"), //
+        @ApiResponse(code = 400, message = "Found violations in validation", responseContainer = "Set",
+            response = Violation.class)//
+    })
+    default Response validate(@NotNull final T obj) {
+        final Set<ConstraintViolation<T>> constraintViolations = getValidator().validate(obj, AllValidations.class);
+
+        if (constraintViolations.isEmpty()) {
+            return Response.noContent().build();
+        }
+
+        final Set<Violation> violations = constraintViolations.stream().map(Violation.Builder::fromConstraintViolation)
+            .collect(Collectors.toSet());
+
+        return Response.status(Status.BAD_REQUEST).entity(violations).build();
+    }
+
+}

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Violation.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Violation.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.operations;
+
+import javax.validation.ConstraintViolation;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import io.syndesis.model.ImmutablesStyle;
+
+import org.immutables.value.Value;
+
+@ImmutablesStyle
+@Value.Immutable
+@JsonDeserialize(builder = Violation.Builder.class)
+public interface Violation {
+
+    @SuppressWarnings("PMD.UseUtilityClass")
+    final class Builder extends ImmutableViolation.Builder {
+
+        /* default */ static Violation fromConstraintViolation(final ConstraintViolation<?> constraintViolation) {
+            final String property = constraintViolation.getPropertyPath().toString();
+            final String message = constraintViolation.getMessage();
+
+            return new Builder().property(property).message(message).build();
+        }
+    }
+
+    String message();
+
+    String property();
+
+}

--- a/runtime/src/test/java/io/syndesis/runtime/ConnectionsITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/ConnectionsITCase.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.runtime;
+
+import java.util.List;
+
+import io.syndesis.model.connection.Connection;
+import io.syndesis.rest.v1.operations.Violation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConnectionsITCase extends BaseITCase {
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private final static Class<List<Violation>> RESPONSE_TYPE = (Class) List.class;
+
+    @Before
+    public void preexistingConnection() {
+        @SuppressWarnings("PMD.CloseResource")
+        final Connection connection = new Connection.Builder().name("Existing connection").build();
+
+        dataManager.create(connection);
+    }
+
+    @Test
+    public void shouldDetermineValidityForInvalidConnections() {
+        @SuppressWarnings("PMD.CloseResource")
+        final Connection connection = new Connection.Builder().name("Existing connection").build();
+
+        final ResponseEntity<List<Violation>> got = post("/api/v1/connections/validation", connection, RESPONSE_TYPE,
+            tokenRule.validToken(), HttpStatus.BAD_REQUEST);
+
+        assertThat(got.getBody()).hasSize(1);
+    }
+
+    @Test
+    public void shouldDetermineValidityForValidConnections() {
+        @SuppressWarnings("PMD.CloseResource")
+        final Connection connection = new Connection.Builder().name("Test connection").build();
+
+        final ResponseEntity<List<Violation>> got = post("/api/v1/connections/validation", connection, RESPONSE_TYPE,
+            tokenRule.validToken(), HttpStatus.NO_CONTENT);
+
+        assertThat(got.getBody()).isNull();
+    }
+
+}


### PR DESCRIPTION
**Based on #495, please review it and merge before this**

Adds a new connection sub-resource (`validation`) that can be used to
perform validation of the soon-to-be created connection resource.

Full endpoint of the resource is `/api/v1/connections/validation` and
for connection payloads sent via `POST` method it will respond with
status `200` and 0-length body if the connection passes validation; or
status `409` and body containing a set of objects containing `property`
(what property) and `message` (validation message) properties.

Fixes #476