### PR TITLE
refactor(rule-filter): Adapt data format of a basic filter step according to the UI needs.

### DIFF
--- a/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
+++ b/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
@@ -16,6 +16,9 @@
 
 package io.syndesis.model.integration;
 
+import java.util.Locale;
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.syndesis.model.filter.*;
@@ -28,12 +31,13 @@ public class StepDeserializerTest {
     @Test
     public void shouldDeserializeRuleFilterStep() throws Exception {
         RuleFilterStep step = readTestFilter("/rule-filter-step.json");
-        RuleFilterStep ruleFilterStep = (RuleFilterStep) step;
-        assertEquals("1", ruleFilterStep.getId().get());
-        assertEquals(FilterPredicate.AND, ruleFilterStep.getPredicate());
-        assertEquals("rule-filter", ruleFilterStep.getStepKind());
-        assertEquals(2, ruleFilterStep.getRules().size());
-        assertEquals("${body.text} == 'antman' && ${header.kind} =~ 'DC Comics'", ruleFilterStep.getFilterExpression());
+        assertEquals("1", step.getId().get());
+        assertTrue(step.getConfiguredProperties().isPresent());
+        Map<String, String> props = step.getConfiguredProperties().get();
+        assertEquals(FilterPredicate.AND, FilterPredicate.valueOf(props.get("predicate").toUpperCase(Locale.US)));
+        assertNotNull(props.get("rules"));
+        assertEquals("rule-filter", step.getStepKind());
+        assertEquals("${body.text} == 'antman' && ${header.kind} =~ 'DC Comics'", step.getFilterExpression());
     }
 
     @Test

--- a/model/src/test/resources/rule-filter-step.json
+++ b/model/src/test/resources/rule-filter-step.json
@@ -2,17 +2,8 @@
   "id": "1",
   "kind": "step",
   "stepKind": "rule-filter",
-  "predicate": "and",
-  "rules": [
-    {
-      "path": "body.text",
-      "op": "==",
-      "value": "antman"
-    },
-    {
-      "path": "header.kind",
-      "op": "=~",
-      "value": "DC Comics"
-    }
-  ]
+  "configuredProperties": {
+    "predicate": "and",
+    "rules": "[{\"path\": \"body.text\",\"op\": \"==\",\"value\": \"antman\"},{\"path\": \"header.kind\",\"op\": \"=~\",\"value\": \"DC Comics\"}]"
+  }
 }

--- a/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
@@ -212,12 +212,10 @@ public class DefaultProjectGeneratorTest {
     public void testWithFilter() throws Exception {
         Step step1 = new SimpleStep.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("period",5000)).action(new Action.Builder().connectorId("timer").camelConnectorPrefix("periodic-timer").camelConnectorGAV("io.syndesis:timer-connector:0.4.5").build()).build();
         //Step step1 = new SimpleStep.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).action(new Action.Builder().connectorId("twitter").camelConnectorPrefix("twitter-mention").camelConnectorGAV("io.syndesis:twitter-mention-connector:0.4.5").build()).build();
-        Step step2 = new RuleFilterStep.Builder().predicate(FilterPredicate.AND)
-                                                 .addRule(new FilterRule.Builder()
-            .path("in.header.counter")
-                .op(">")
-                .value("10")
-            .build()).build();
+        Map<String, String> props = new HashMap<>();
+        props.put("predicate", FilterPredicate.AND.toString());
+        props.put("rules", "[{ \"path\": \"in.header.counter\", \"op\": \">\", \"value\": \"10\" }]");
+        Step step2 = new RuleFilterStep.Builder().configuredProperties(props).build();
 
         Step step3 = new SimpleStep.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(Collections.emptyMap()).build()).configuredProperties(map("httpUri", "http://localhost:8080/bye")).action(new Action.Builder().connectorId("http").camelConnectorPrefix("http-post").camelConnectorGAV("io.syndesis:http-post-connector:0.4.5").build()).build();
 

--- a/project-generator/src/test/java/io/syndesis/project/converter/visitor/RuleFilterStepVisitorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/visitor/RuleFilterStepVisitorTest.java
@@ -16,8 +16,10 @@
 
 package io.syndesis.project.converter.visitor;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import io.syndesis.model.filter.FilterPredicate;
-import io.syndesis.model.filter.FilterRule;
 import io.syndesis.model.filter.RuleFilterStep;
 import org.junit.Test;
 
@@ -27,11 +29,13 @@ public class RuleFilterStepVisitorTest {
 
     @Test
     public void createExpression() throws Exception {
+        Map<String, String> props = new ConcurrentHashMap<>();
+        props.put("predicate", FilterPredicate.AND.toString());
+        props.put("rules","[ { \"path\": \"person.name\", \"op\": \"==\", \"value\": \"Ioannis\"}, " +
+                          "  { \"path\": \"person.favoriteDrinks\", \"op\": \"contains\", \"value\": \"Gin\" } ]");
         RuleFilterStep step = new RuleFilterStep.Builder()
             .id("1")
-            .predicate(FilterPredicate.AND)
-            .addRule(new FilterRule.Builder().path("person.name").op("==").value("Ioannis").build())
-            .addRule(new FilterRule.Builder().path("person.favoriteDrinks").op("contains").value("Gin").build())
+            .configuredProperties(props)
             .build();
 
         // Reading notes: Unit tests are like personal diaries. Feel honoured when you have the chance to be part of them ;-)

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
@@ -113,10 +113,12 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
         integration.getSteps().orElse(Collections.emptyList()).forEach(s -> {
             s.getAction().ifPresent(a -> {
                 DataShape dataShape = a.getOutputDataShape();
-                String kind = dataShape.getKind();
-                if (kind.equals(DataShapeKinds.JAVA)) {
-                    String type = dataShape.getType();
-                    builder.addAllPaths(classInspector.getPaths(type));
+                if (dataShape != null) {
+                    String kind = dataShape.getKind();
+                    if (kind != null && kind.equals(DataShapeKinds.JAVA)) {
+                        String type = dataShape.getType();
+                        builder.addAllPaths(classInspector.getPaths(type));
+                    }
                 }
             });
         });


### PR DESCRIPTION
It's an ugly change. sorry. Instead of the typed interface
configuredProperties is used which contains values as serialized JSON strings.

Its change that way to make it happen and serious efforts should be undertaken to come to a more typed interface.

For possible options see https://github.com/syndesisio/syndesis-rest/issues/451#issuecomment-321249672