### PR TITLE
refactor(settings): Better bootstrap and configuration of OAuth settings

### DIFF
--- a/credential/src/main/java/io/syndesis/credential/CredentialProviderFactory.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialProviderFactory.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+
+/**
+ * Creates the {@link CredentialProvider} from the given properties.
+ */
+public interface CredentialProviderFactory {
+
+    CredentialProvider create(final SocialProperties properties);
+
+    String id();
+
+}

--- a/credential/src/main/java/io/syndesis/credential/Credentials.java
+++ b/credential/src/main/java/io/syndesis/credential/Credentials.java
@@ -16,19 +16,32 @@
 package io.syndesis.credential;
 
 import java.net.URI;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import io.syndesis.model.connection.Connection;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
 
 @Component
 public final class Credentials {
+
+    private final Map<String, CredentialProviderFactory> credentialProviderFactories;
+
     private final CredentialProviderLocator credentialProviderLocator;
 
     @Autowired
     public Credentials(final CredentialProviderLocator credentialProviderLocator) {
         this.credentialProviderLocator = credentialProviderLocator;
+
+        credentialProviderFactories = SpringFactoriesLoader
+            .loadFactories(CredentialProviderFactory.class, ClassUtils.getDefaultClassLoader()).stream()
+            .collect(Collectors.toMap(CredentialProviderFactory::id, Function.identity()));
     }
 
     public AcquisitionFlow acquire(final String providerId, final URI baseUrl, final URI returnUrl) {
@@ -59,6 +72,14 @@ public final class Credentials {
         final CredentialProvider credentialProvider = providerFrom(flowState);
 
         return credentialProvider.finish(flowState, baseUrl);
+    }
+
+    public void registerProvider(final String providerId, final SocialProperties properties) {
+        final CredentialProviderFactory credentialProviderFactory = credentialProviderFactories.get(providerId);
+
+        final CredentialProvider credentialProvider = credentialProviderFactory.create(properties);
+
+        credentialProviderLocator.addCredentialProvider(credentialProvider);
     }
 
     /* default */ CredentialProvider providerFor(final String providerId) {

--- a/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceConfiguration.java
@@ -16,10 +16,8 @@
 package io.syndesis.credential.salesforce;
 
 import io.syndesis.credential.Applicator;
-import io.syndesis.credential.CredentialProvider;
 import io.syndesis.credential.CredentialProviderLocator;
 import io.syndesis.credential.OAuth2Applicator;
-import io.syndesis.credential.OAuth2CredentialProvider;
 import io.syndesis.model.connection.Connection;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,15 +27,15 @@ import org.springframework.boot.autoconfigure.social.SocialProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.social.oauth2.AccessGrant;
-import org.springframework.social.oauth2.OAuth2Template;
 import org.springframework.social.salesforce.api.Salesforce;
 import org.springframework.social.salesforce.connect.SalesforceConnectionFactory;
+
+import static io.syndesis.credential.salesforce.SalesforceCredentialProviderFactory.createCredentialProvider;
 
 @Configuration
 @ConditionalOnClass(SalesforceConnectionFactory.class)
 @ConditionalOnProperty(prefix = "spring.social.salesforce", name = "app-id")
 @EnableConfigurationProperties(SalesforceProperties.class)
-@SuppressWarnings("PMD.UseUtilityClass")
 public class SalesforceConfiguration {
 
     protected static final class SalesforceApplicator extends OAuth2Applicator {
@@ -70,27 +68,7 @@ public class SalesforceConfiguration {
     @Autowired
     public SalesforceConfiguration(final SalesforceProperties salesforceProperties,
         final CredentialProviderLocator locator) {
-        locator.addCredentialProvider(create(salesforceProperties));
-    }
-
-    public static CredentialProvider create(final SalesforceProperties salesforceProperties) {
-        final SalesforceConnectionFactory connectionFactory = createConnectionFactory(salesforceProperties);
-
-        return new OAuth2CredentialProvider<>("salesforce", connectionFactory,
-            new SalesforceApplicator(connectionFactory, salesforceProperties));
-    }
-
-    protected static SalesforceConnectionFactory
-        createConnectionFactory(final SalesforceProperties salesforceProperties) {
-        final SalesforceConnectionFactory salesforce = new SalesforceConnectionFactory(salesforceProperties.getAppId(),
-            salesforceProperties.getAppSecret());
-
-        final OAuth2Template oAuthOperations = (OAuth2Template) salesforce.getOAuthOperations();
-
-        // Salesforce requires OAuth client id and secret on the OAuth request
-        oAuthOperations.setUseParametersForClientAuthentication(true);
-
-        return salesforce;
+        locator.addCredentialProvider(createCredentialProvider(salesforceProperties));
     }
 
 }

--- a/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceCredentialProviderFactory.java
+++ b/credential/src/main/java/io/syndesis/credential/salesforce/SalesforceCredentialProviderFactory.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential.salesforce;
+
+import io.syndesis.credential.CredentialProvider;
+import io.syndesis.credential.CredentialProviderFactory;
+import io.syndesis.credential.OAuth2CredentialProvider;
+import io.syndesis.credential.salesforce.SalesforceConfiguration.SalesforceApplicator;
+
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.social.oauth2.OAuth2Template;
+import org.springframework.social.salesforce.connect.SalesforceConnectionFactory;
+
+public final class SalesforceCredentialProviderFactory implements CredentialProviderFactory {
+
+    @Override
+    public CredentialProvider create(final SocialProperties properties) {
+        return createCredentialProvider(properties);
+    }
+
+    @Override
+    public String id() {
+        return "salesforce";
+    }
+
+    /* default */ static SalesforceConnectionFactory
+        createConnectionFactory(final SocialProperties salesforceProperties) {
+        final SalesforceConnectionFactory salesforce = new SalesforceConnectionFactory(salesforceProperties.getAppId(),
+            salesforceProperties.getAppSecret());
+
+        final OAuth2Template oAuthOperations = (OAuth2Template) salesforce.getOAuthOperations();
+
+        // Salesforce requires OAuth client id and secret on the OAuth request
+        oAuthOperations.setUseParametersForClientAuthentication(true);
+
+        return salesforce;
+    }
+
+    /* default */ static CredentialProvider createCredentialProvider(final SocialProperties properties) {
+        final SalesforceConnectionFactory connectionFactory = createConnectionFactory(properties);
+
+        return new OAuth2CredentialProvider<>("salesforce", connectionFactory,
+            new SalesforceApplicator(connectionFactory, properties));
+    }
+
+}

--- a/credential/src/main/java/io/syndesis/credential/twitter/TwitterConfiguration.java
+++ b/credential/src/main/java/io/syndesis/credential/twitter/TwitterConfiguration.java
@@ -15,10 +15,7 @@
  */
 package io.syndesis.credential.twitter;
 
-import io.syndesis.credential.CredentialProvider;
 import io.syndesis.credential.CredentialProviderLocator;
-import io.syndesis.credential.OAuth1Applicator;
-import io.syndesis.credential.OAuth1CredentialProvider;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -28,28 +25,17 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 import org.springframework.social.twitter.connect.TwitterConnectionFactory;
 
+import static io.syndesis.credential.twitter.TwitterCredentialProviderFactory.createCredentialProvider;
+
 @Configuration
 @ConditionalOnClass(TwitterConnectionFactory.class)
 @ConditionalOnProperty(prefix = "spring.social.twitter", name = "app-id")
 @EnableConfigurationProperties(TwitterProperties.class)
-@SuppressWarnings("PMD.UseUtilityClass")
 public class TwitterConfiguration {
 
     @Autowired
     protected TwitterConfiguration(final TwitterProperties properties, final CredentialProviderLocator locator) {
-        locator.addCredentialProvider(create(properties));
-    }
-
-    public static CredentialProvider create(final TwitterProperties properties) {
-        final TwitterConnectionFactory twitter = new TwitterConnectionFactory(properties.getAppId(),
-            properties.getAppSecret());
-        final OAuth1Applicator applicator = new OAuth1Applicator(properties);
-        applicator.setConsumerKeyProperty("consumerKey");
-        applicator.setConsumerSecretProperty("consumerSecret");
-        applicator.setAccessTokenSecretProperty("accessTokenSecret");
-        applicator.setAccessTokenValueProperty("accessToken");
-
-        return new OAuth1CredentialProvider<>("twitter", twitter, applicator);
+        locator.addCredentialProvider(createCredentialProvider(properties));
     }
 
 }

--- a/credential/src/main/java/io/syndesis/credential/twitter/TwitterCredentialProviderFactory.java
+++ b/credential/src/main/java/io/syndesis/credential/twitter/TwitterCredentialProviderFactory.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential.twitter;
+
+import io.syndesis.credential.CredentialProvider;
+import io.syndesis.credential.CredentialProviderFactory;
+import io.syndesis.credential.OAuth1Applicator;
+import io.syndesis.credential.OAuth1CredentialProvider;
+
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+import org.springframework.social.twitter.connect.TwitterConnectionFactory;
+
+public final class TwitterCredentialProviderFactory implements CredentialProviderFactory {
+
+    @Override
+    public CredentialProvider create(final SocialProperties properties) {
+        return createCredentialProvider(properties);
+    }
+
+    @Override
+    public String id() {
+        return "twitter";
+    }
+
+    /* default */ static CredentialProvider createCredentialProvider(final SocialProperties properties) {
+        final TwitterConnectionFactory twitter = new TwitterConnectionFactory(properties.getAppId(),
+            properties.getAppSecret());
+        final OAuth1Applicator applicator = new OAuth1Applicator(properties);
+        applicator.setConsumerKeyProperty("consumerKey");
+        applicator.setConsumerSecretProperty("consumerSecret");
+        applicator.setAccessTokenSecretProperty("accessTokenSecret");
+        applicator.setAccessTokenValueProperty("accessToken");
+
+        return new OAuth1CredentialProvider<>("twitter", twitter, applicator);
+    }
+
+}

--- a/credential/src/main/resources/META-INF/spring.factories
+++ b/credential/src/main/resources/META-INF/spring.factories
@@ -2,3 +2,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.syndesis.credential.CredentialConfiguration,\
 io.syndesis.credential.salesforce.SalesforceConfiguration,\
 io.syndesis.credential.twitter.TwitterConfiguration
+
+io.syndesis.credential.CredentialProviderFactory=\
+io.syndesis.credential.salesforce.SalesforceCredentialProviderFactory,\
+io.syndesis.credential.twitter.TwitterCredentialProviderFactory

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppHandler.java
@@ -34,6 +34,8 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
 import io.syndesis.core.SuppressFBWarnings;
@@ -41,6 +43,7 @@ import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.connection.ConfigurationProperty;
 import io.syndesis.model.connection.Connector;
 
+import org.springframework.boot.autoconfigure.social.SocialProperties;
 import org.springframework.stereotype.Component;
 
 /**
@@ -62,12 +65,24 @@ public class OAuthAppHandler {
     @SuppressFBWarnings(
         value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
         justification = "All fields are encode by jackson and sent to the UI")
-    public static final class OAuthApp {
+    public static final class OAuthApp extends SocialProperties {
         public String id;
         public String name;
         public String icon;
         public String clientId;
         public String clientSecret;
+
+        @Override
+        @JsonIgnore
+        public String getAppId() {
+            return clientId;
+        }
+
+        @Override
+        @JsonIgnore
+        public String getAppSecret() {
+            return clientSecret;
+        }
     }
 
     @GET


### PR DESCRIPTION
Institutes `CredentialProviderFactory` interface for creating new
`CredentialProvider` instances from, used when OAuth connector is
configured via settings page.

`CredentialProviderFactory`ies are configured through
`SpringFactoryLoader`'s `META-INF/spring.factories` and known by their
`id` property.

Now uses Credentials as a facade for registering new
`CredentialProvider`s as they are configured or bootstrapped.

Fixes an issue when trying to configure Salesforce client id/secret via
global settings.

Fixes #492