### PR TITLE
fix(oauth): Fixes cookie path and JSON deserialization

### DIFF
--- a/credential/pom.xml
+++ b/credential/pom.xml
@@ -92,6 +92,11 @@
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
 

--- a/credential/src/main/java/io/syndesis/credential/CredentialFlowStateHelper.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialFlowStateHelper.java
@@ -37,6 +37,7 @@ final class CredentialFlowStateHelper {
 
     /* default */ static void removeCookie(final HttpServletResponse response, final String cookieName) {
         final Cookie removal = new Cookie(cookieName, "");
+        removal.setPath("/");
         removal.setMaxAge(0);
         removal.setHttpOnly(true);
         removal.setSecure(true);
@@ -72,7 +73,8 @@ final class CredentialFlowStateHelper {
             LOG.debug("Unable to restore flow state from HTTP cookie: {}", cookie, e);
         }
 
-        // remove cookies that can't be restored or have mismatched name/value
+        // remove cookies that can't be restored or have mismatched
+        // name/value
         removeCookie(response, cookie.getName());
 
         return null;

--- a/credential/src/main/java/io/syndesis/credential/CredentialModule.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialModule.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.springframework.social.oauth1.OAuthToken;
+
+public final class CredentialModule extends SimpleModule {
+
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    private static final class OAuthTokenDeserializer extends JsonDeserializer<OAuthToken> {
+        @Override
+        public OAuthToken deserialize(final JsonParser p, final DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+            final Map<String, String> values = new HashMap<>();
+            String fieldName;
+            while ((fieldName = p.nextFieldName()) != null) {
+                final String nextValue = p.nextTextValue();
+                values.put(fieldName, nextValue);
+            }
+
+            return new OAuthToken(values.get("value"), values.get("secret"));
+        }
+    }
+
+    public CredentialModule() {
+        addDeserializer(OAuthToken.class, new OAuthTokenDeserializer());
+    }
+}

--- a/credential/src/test/java/io/syndesis/credential/CredentialFlowStateHelperTest.java
+++ b/credential/src/test/java/io/syndesis/credential/CredentialFlowStateHelperTest.java
@@ -154,6 +154,7 @@ public class CredentialFlowStateHelperTest {
 
     private Cookie removalOf(final String name) {
         final Cookie removal = new Cookie(name, "");
+        removal.setPath("/");
         removal.setMaxAge(0);
         removal.setHttpOnly(true);
         removal.setSecure(true);

--- a/credential/src/test/java/io/syndesis/credential/CredentialModuleTest.java
+++ b/credential/src/test/java/io/syndesis/credential/CredentialModuleTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.credential;
+
+import java.io.IOException;
+import java.net.URI;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+import org.springframework.social.oauth1.OAuthToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CredentialModuleTest {
+
+    @Test
+    public void shouldDeserializeFromJson() throws IOException {
+        final String json = "{\"type\":\"OAUTH1\",\"accessToken\":{\"value\":\"access-token-value\",\"secret\":\"access-token-secret\"},\"token\":{\"value\":\"token-value\",\"secret\":\"token-secret\"},\"verifier\":\"verifier\",\"key\":\"key\",\"providerId\":\"twitter\",\"returnUrl\":\"https://localhost:4200/connections/create/configure-fields?state=create-connection&connectorId=twitter\"}";
+
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new CredentialModule());
+
+        final OAuth1CredentialFlowState flowState = mapper.readerFor(CredentialFlowState.class).readValue(json);
+
+        final OAuth1CredentialFlowState expected = new OAuth1CredentialFlowState.Builder()
+            .accessToken(new OAuthToken("access-token-value", "access-token-secret"))
+            .token(new OAuthToken("token-value", "token-secret")).verifier("verifier").key("key").providerId("twitter")
+            .returnUrl(URI.create(
+                "https://localhost:4200/connections/create/configure-fields?state=create-connection&connectorId=twitter"))
+            .build();
+
+        assertThat(flowState).isEqualToIgnoringGivenFields(expected, "accessToken", "token");
+        assertThat(flowState.getAccessToken()).isEqualToComparingFieldByField(expected.getAccessToken());
+        assertThat(flowState.getToken()).isEqualToComparingFieldByField(expected.getToken());
+    }
+
+}

--- a/model/src/main/java/io/syndesis/model/filter/RuleFilterStep.java
+++ b/model/src/main/java/io/syndesis/model/filter/RuleFilterStep.java
@@ -46,7 +46,7 @@ public interface RuleFilterStep extends FilterStep {
 
             FilterPredicate predicate = getPredicate(props.get("predicate"));
             List<FilterRule> rules = extractRules(props.get("rules"));
-            if (rules != null && rules.size() > 0) {
+            if (rules != null && !rules.isEmpty()) {
                 return rules
                     .stream()
                     .map(FilterRule::getFilterExpression)
@@ -59,7 +59,7 @@ public interface RuleFilterStep extends FilterStep {
 
     default List<FilterRule> extractRules(String rulesString) {
         try {
-            if (rulesString == null || rulesString.length() == 0) {
+            if (rulesString == null || rulesString.isEmpty()) {
                 return null;
             }
             return Json.mapper().readValue(rulesString,new TypeReference<List<FilterRule>>(){});

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorCredentialHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorCredentialHandler.java
@@ -68,8 +68,7 @@ public class ConnectorCredentialHandler {
             absoluteTo(httpRequest, request.getReturnUrl()));
 
         final CredentialFlowState flowState = acquisitionFlow.state().get();
-        final NewCookie conservativeCookie = state.persist(flowState.persistenceKey(), "/", flowState);
-        final NewCookie cookie = new NewCookie(conservativeCookie.getName(), conservativeCookie.getValue());
+        final NewCookie cookie = state.persist(flowState.persistenceKey(), "/", flowState);
 
         final AcquisitionResponse acquisitionResponse = AcquisitionResponse.Builder.from(acquisitionFlow)
             .state(State.Builder.cookie(cookie.toString())).build();

--- a/rest/src/main/java/io/syndesis/rest/v1/state/ClientSideState.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/state/ClientSideState.java
@@ -41,6 +41,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
+import io.syndesis.credential.CredentialModule;
+
 /**
  * Persists given state on the client with these properties:
  * <ul>
@@ -69,7 +71,7 @@ public final class ClientSideState {
 
     private static final int IV_LEN = 16;
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new CredentialModule());
 
     private final BiFunction<Class<?>, byte[], Object> deserialization;
 
@@ -122,7 +124,7 @@ public final class ClientSideState {
     }
 
     public NewCookie persist(final String key, final String path, final Object value) {
-        return new NewCookie(key, protect(value), path, null, null, NewCookie.DEFAULT_MAX_AGE, true, true);
+        return new NewCookie(key, protect(value), path, null, null, NewCookie.DEFAULT_MAX_AGE, true, false);
     }
 
     public <T> T restoreFrom(final Cookie cookie, final Class<T> type) {
@@ -229,7 +231,7 @@ public final class ClientSideState {
         try {
             return reader.readValue(pickle);
         } catch (final IOException e) {
-            throw new IllegalArgumentException("Unable to serialize given pickle to value", e);
+            throw new IllegalArgumentException("Unable to deserialize given pickle to value", e);
         }
     }
 

--- a/rest/src/test/java/io/syndesis/rest/v1/state/ClientSideStateTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/state/ClientSideStateTest.java
@@ -118,7 +118,7 @@ public class ClientSideStateTest {
         assertThat(cookie.getValue())
             .isEqualTo("pzSOjcNui9-HWS_Qk1Pwpg|MTM0NzI2NTk1NQ|dGlk|tL3lJPf2nUSFMN6dtVXJTw|uea1fgC67RmOxfpNz8gMbnPWfDA");
         assertThat(cookie.getPath()).isEqualTo("/path");
-        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.isHttpOnly()).isFalse();
         assertThat(cookie.isSecure()).isTrue();
     }
 


### PR DESCRIPTION
Reverts to a _conservative_ version of cookie (with the Path, HttpOnly
and Secure parameters set), the cookie should traverse back and forth
when set from UI and received on OAuth callback.

Adds Jackson module specific to
`org.springframework.social.oauth1.OAuthToken` deserialization.

Fixes #503