### PR TITLE
fix(salesforce): Declares `instanceUrl` connector property

### DIFF
--- a/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -194,6 +194,21 @@
           "defaultValue": "https://login.salesforce.com",
           "description": "URL of the Salesforce instance by default set to https://login.salesforce.com"
         },
+        "instanceUrl": {
+          "kind": "property",
+          "displayName": "Instance URL",
+          "group": "security",
+          "label": "common,security",
+          "required": false,
+          "type": "string",
+          "javaType": "java.lang.String",
+          "tags":[],
+          "deprecated": false,
+          "secret": false,
+          "componentProperty": true,
+          "defaultValue": "https://xx.salesforce.com",
+          "description": "URL of the Salesforce instance"
+        },
         "clientId": {
           "kind": "property",
           "displayName": "Client Id",


### PR DESCRIPTION
Adds the definition of `instanceUrl` property to the Salesforce
Connector.

Fixes #510