### PR TITLE
feat(credentials): Mark connections as derived

### DIFF
--- a/credential/src/main/java/io/syndesis/credential/Credentials.java
+++ b/credential/src/main/java/io/syndesis/credential/Credentials.java
@@ -65,7 +65,11 @@ public final class Credentials {
     public Connection apply(final Connection updatedConnection, final CredentialFlowState flowState) {
         final CredentialProvider credentialProvider = providerFrom(flowState);
 
-        return credentialProvider.applyTo(updatedConnection, flowState);
+        @SuppressWarnings("PMD.CloseResource")
+        final Connection withDerivedFlag = new Connection.Builder().createFrom(updatedConnection).isDerived(true)
+            .build();
+
+        return credentialProvider.applyTo(withDerivedFlag, flowState);
     }
 
     public CredentialFlowState finishAcquisition(final CredentialFlowState flowState, final URI baseUrl) {

--- a/model/src/main/java/io/syndesis/model/connection/Connection.java
+++ b/model/src/main/java/io/syndesis/model/connection/Connection.java
@@ -67,6 +67,14 @@ public interface Connection extends WithId<Connection>, WithTags, WithName, Seri
 
     Optional<Date> getCreatedDate();
 
+    /**
+     * A flag denoting that the some of connection properties were derived.
+     * Ostensibly used to mark the {@link #getConfiguredProperties()} being
+     * set by the OAuth flow so that the UI can alternate between full edit
+     * and reconnect OAuth views.
+     */
+    boolean isDerived();
+
     @Override
     default Connection withId(String id) {
         return new Builder().createFrom(this).id(id).build();

--- a/model/src/test/java/io/syndesis/model/connection/ConnectionTest.java
+++ b/model/src/test/java/io/syndesis/model/connection/ConnectionTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.connection;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConnectionTest {
+
+    @Test
+    public void byDefaultDerivedShouldBeFalse() {
+        @SuppressWarnings("PMD.CloseResource")
+        Connection connection = new Connection.Builder().build();
+
+        assertThat(connection.isDerived()).isFalse();
+    }
+
+}

--- a/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
@@ -137,6 +137,7 @@ public class CredentialITCase extends BaseITCase {
         assertThat(connectionResponse.hasBody()).as("Should contain created connection").isTrue();
 
         final Connection createdConnection = connectionResponse.getBody();
+        assertThat(createdConnection.isDerived()).isTrue();
         assertThat(createdConnection.getConfiguredProperties()).containsOnly(entry("accessToken", "token"),
             entry("clientId", "appId"), entry("clientSecret", "appSecret"));
     }


### PR DESCRIPTION
This adds a flag `derived` to Connections, derived Connections are those
that did not get their `configuredProperties` from user input but from
other means, such as OAuth dance performed by Credentials. Credentials
will also set this flag to `true` for Connections that pass successfully
through the OAuth acquisition flow and are saved at that point.

Once set the flag remains set until the UI chooses to reset it to
`false`, which it might if we ever decide to offer editing derived
Connections.

Fixes #513