### PR TITLE
feature(rest): Integration name uniqueness validation

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -85,6 +85,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.el</artifactId>
       <scope>test</scope>

--- a/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -22,6 +22,9 @@ import io.syndesis.model.WithName;
 import io.syndesis.model.WithTags;
 import io.syndesis.model.connection.Connection;
 import io.syndesis.model.user.User;
+import io.syndesis.model.validation.UniqueProperty;
+import io.syndesis.model.validation.UniquenessRequired;
+
 import org.immutables.value.Value;
 
 import java.io.Serializable;
@@ -32,6 +35,7 @@ import java.util.Optional;
 
 @Value.Immutable
 @JsonDeserialize(builder = Integration.Builder.class)
+@UniqueProperty(value = "name", groups = UniquenessRequired.class)
 public interface Integration extends WithId<Integration>, WithTags, WithName, Serializable {
 
     enum Status { Draft, Pending, Activated, Deactivated, Deleted}

--- a/model/src/test/java/io/syndesis/model/integration/IntegrationTest.java
+++ b/model/src/test/java/io/syndesis/model/integration/IntegrationTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.integration;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import io.syndesis.model.validation.UniqueProperty;
+import io.syndesis.model.validation.UniquenessRequired;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IntegrationTest {
+
+    private final Validator validator;
+
+    public static class UniqnenessValidator implements ConstraintValidator<UniqueProperty, Object> {
+
+        private static final AtomicBoolean VALID = new AtomicBoolean(true);
+
+        @Override
+        public void initialize(final UniqueProperty constraintAnnotation) {
+            // nop
+        }
+
+        @Override
+        public boolean isValid(final Object value, final ConstraintValidatorContext context) {
+            return VALID.get();
+        }
+    }
+
+    public IntegrationTest() {
+        final DefaultConstraintMapping mapping = new DefaultConstraintMapping();
+        mapping.constraintDefinition(UniqueProperty.class).validatedBy(UniqnenessValidator.class);
+        final ValidatorFactory validatorFactory = Validation.byProvider(HibernateValidator.class).configure()
+            .addMapping(mapping).buildValidatorFactory();
+
+        validator = validatorFactory.getValidator();
+    }
+
+    @Test
+    public void shouldNotifyOfUniquenessConstraintViolation() {
+        UniqnenessValidator.VALID.set(false);
+
+        final Set<ConstraintViolation<Integration>> violations = validator.validate(new Integration.Builder().build(),
+            UniquenessRequired.class);
+
+        assertThat(violations).hasSize(1);
+    }
+
+    @Test
+    public void shouldValidateForNameUniqueness() {
+        UniqnenessValidator.VALID.set(true);
+
+        final Set<ConstraintViolation<Integration>> violations = validator.validate(new Integration.Builder().build(),
+            UniquenessRequired.class);
+
+        assertThat(violations).isEmpty();
+    }
+
+}


### PR DESCRIPTION
**Please review PRs #495 and #499 this PR is based on**

Builds upon #475 and #476 to add name uniqueness validation when
creating Integrations and provides REST API for uniqueness validation at
`POST` to `/api/v1/integrations/validation` akin to how it operates for
Connections.

Fixes #411