### PR TITLE
WIP - Generated integration project should optionally use productized FIS bom #418

### DIFF
--- a/project-generator/pom.xml
+++ b/project-generator/pom.xml
@@ -152,6 +152,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorConfiguration.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.project.converter;
 
+import java.io.IOException;
 import java.util.List;
 
 import io.syndesis.connector.catalog.ConnectorCatalog;
@@ -33,7 +34,7 @@ import org.springframework.context.annotation.Configuration;
 public class ProjectGeneratorConfiguration {
 
     @Bean
-    public ProjectGenerator projectConverter(ConnectorCatalog connectorCatalog, ProjectGeneratorProperties properties, StepVisitorFactoryRegistry registry) {
+    public ProjectGenerator projectConverter(ConnectorCatalog connectorCatalog, ProjectGeneratorProperties properties, StepVisitorFactoryRegistry registry) throws IOException {
         return new DefaultProjectGenerator(connectorCatalog, properties, registry);
     }
 

--- a/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorProperties.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorProperties.java
@@ -15,6 +15,9 @@
  */
 package io.syndesis.project.converter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("generator")
@@ -22,11 +25,81 @@ public class ProjectGeneratorProperties {
 
     private Boolean secretMaskingEnabled = false;
 
+    /**
+     * Templates configuration.
+     */
+    private final Templates templates = new Templates();
+
     public Boolean isSecretMaskingEnabled() {
         return secretMaskingEnabled;
     }
 
     public void setSecretMaskingEnabled(Boolean secretMaskingEnabled) {
         this.secretMaskingEnabled = secretMaskingEnabled;
+    }
+
+    public Templates getTemplates() {
+        return templates;
+    }
+
+    public static class Templates {
+        /**
+         * The location of override templates relative to the templates dir.
+         */
+        private String overridePath;
+
+        /**
+         * Additional resources to be included, copied as is.
+         */
+        private final List<Resource> additionalResources = new ArrayList<>();
+
+        public String getOverridePath() {
+            return overridePath;
+        }
+
+        public void setOverridePath(String overridePath) {
+            this.overridePath = overridePath;
+        }
+
+        public List<Resource> getAdditionalResources() {
+            return additionalResources;
+        }
+
+        public static class Resource {
+            /**
+             * The resource source location.
+             */
+            private String source;
+
+            /**
+             * The resource location in the generated project.
+             */
+            private String destination;
+
+            public Resource() {
+                // Empty constructor for spring boot ioc
+            }
+
+            public Resource(String source, String destination) {
+                this.source = source;
+                this.destination = destination;
+            }
+
+            public String getSource() {
+                return source;
+            }
+
+            public void setSource(String source) {
+                this.source = source;
+            }
+
+            public String getDestination() {
+                return destination;
+            }
+
+            public void setDestination(String destination) {
+                this.destination = destination;
+            }
+        }
     }
 }

--- a/project-generator/src/main/resources/application-redhat.properties
+++ b/project-generator/src/main/resources/application-redhat.properties
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This profile overrides the default project generator templates to include
+# FIS 2.0 bits
+
+# Relative path were redhat specific templates are stored
+generator.templates.override-path = redhat
+
+# Additional bits for fabric8-maven-plugin and m2 repos
+generator.templates.additional-resources[0].source = deployment.yml
+generator.templates.additional-resources[0].destination = src/main/fabric8/deployment.yml
+generator.templates.additional-resources[1].source = settings.xml
+generator.templates.additional-resources[1].destination = configuration/settings.xml

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/application.properties.mustache
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/application.properties.mustache
@@ -1,0 +1,10 @@
+## name of CamelContext
+camel.springboot.name={{integration.name}}
+camel.springboot.streamCachingEnabled = true
+
+# Binding health checks to an internal port
+management.port=8081
+
+# disable all management enpoints except health
+endpoints.enabled = false
+endpoints.health.enabled = true

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/deployment.yml
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/deployment.yml
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spec:
+  template:
+    spec:
+      containers:
+        -
+          resources:
+            requests:
+              cpu: "0.2"
+            limits:
+              cpu: "1.0"

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/pom.xml.mustache
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/pom.xml.mustache
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.syndesis.integrations</groupId>
+  <artifactId>project</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <name>Syndesis Integrations :: {{name}}</name>
+  {{#description}}<description>{{description}}</description>{{/description}}
+  <packaging>jar</packaging>
+
+  <properties>
+    <spring-boot.version>@spring-boot.version@</spring-boot.version>
+    <fabric8.version>@fabric8.version@</fabric8.version>
+    <fabric8.maven.plugin.version>@fabric8.maven.plugin.version@</fabric8.maven.plugin.version>
+    <maven-surefire-plugin.version>@maven-surefire-plugin.version@</maven-surefire-plugin.version>
+    <syndesis-integration-runtime.version>@syndesis-integration-runtime.version@</syndesis-integration-runtime.version>
+    <camel-atlasmap.version>@camel-atlasmap.version@</camel-atlasmap.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-project-bom-camel-spring-boot</artifactId>
+        <version>\${fabric8.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- atlasmap runtime -->
+    <dependency>
+      <groupId>io.atlasmap</groupId>
+      <artifactId>camel-atlasmap</artifactId>
+      <version>\${camel-atlasmap.version}</version>
+    </dependency>
+
+    <!-- connectors used in this integration -->
+  {{#connectors}}
+    <dependency>
+      <groupId>{{groupId}}</groupId>
+      <artifactId>{{artifactId}}</artifactId>
+      <version>{{version}}</version>
+    </dependency>
+  {{/connectors}}
+
+    <!-- spring-boot as runtime -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <!-- Integration runtime -->
+    <dependency>
+      <groupId>io.syndesis.integration-runtime</groupId>
+      <artifactId>model</artifactId>
+      <version>\${syndesis-integration-runtime.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.integration-runtime</groupId>
+      <artifactId>runtime</artifactId>
+      <version>\${syndesis-integration-runtime.version}</version>
+    </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test</artifactId>
+      <version>\${camel.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>\${maven-surefire-plugin.version}</version>
+        <inherited>true</inherited>
+        <configuration>
+          <excludes>
+            <exclude>**/*KT.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>\${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>\${fabric8.maven.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>resource</goal>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/settings.xml
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/settings.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2016 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>fusesource.repo</id>
+      <repositories>
+        <repository>
+          <id>maven.central</id>
+          <name>Maven Central</name>
+          <url>https://repo1.maven.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+        <repository>
+          <id>redhat.ga</id>
+          <name>Red Hat General Availability Repository</name>
+          <url>https://maven.repository.redhat.com/ga</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+        <repository>
+          <id>fusesource.m2</id>
+          <name>FuseSource Community Release Repository</name>
+          <url>https://repo.fusesource.com/nexus/content/groups/public</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+        <repository>
+          <id>fusesource.ea</id>
+          <name>FuseSource Community Early Access Release Repository</name>
+          <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>maven.central</id>
+          <name>Maven Central</name>
+          <url>https://repo1.maven.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+        <pluginRepository>
+          <id>redhat.ga</id>
+          <name>Red Hat General Availability Repository</name>
+          <url>https://maven.repository.redhat.com/ga</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+        <pluginRepository>
+          <id>fusesource.m2</id>
+          <name>FuseSource Community Release Repository</name>
+          <url>https://repo.fusesource.com/nexus/content/groups/public</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+        <pluginRepository>
+          <id>fusesource.ea</id>
+          <name>FuseSource Community Early Access Release Repository</name>
+          <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>fusesource.repo</activeProfile>
+  </activeProfiles>
+
+</settings>

--- a/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-application.properties
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-application.properties
@@ -1,0 +1,10 @@
+## name of CamelContext
+camel.springboot.name=Test Integration
+camel.springboot.streamCachingEnabled = true
+
+# Binding health checks to an internal port
+management.port=8081
+
+# disable all management enpoints except health
+endpoints.enabled = false
+endpoints.health.enabled = true

--- a/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-deployment.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-deployment.yml
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spec:
+  template:
+    spec:
+      containers:
+        -
+          resources:
+            requests:
+              cpu: "0.2"
+            limits:
+              cpu: "1.0"

--- a/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-pom.xml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.syndesis.integrations</groupId>
+  <artifactId>project</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <name>Syndesis Integrations :: Test Integration</name>
+  <description>This is a test integration!</description>
+  <packaging>jar</packaging>
+
+  <properties>
+    <spring-boot.version>@spring-boot.version@</spring-boot.version>
+    <fabric8.version>@fabric8.version@</fabric8.version>
+    <fabric8.maven.plugin.version>@fabric8.maven.plugin.version@</fabric8.maven.plugin.version>
+    <maven-surefire-plugin.version>@maven-surefire-plugin.version@</maven-surefire-plugin.version>
+    <syndesis-integration-runtime.version>@syndesis-integration-runtime.version@</syndesis-integration-runtime.version>
+    <camel-atlasmap.version>@camel-atlasmap.version@</camel-atlasmap.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-project-bom-camel-spring-boot</artifactId>
+        <version>\${fabric8.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- atlasmap runtime -->
+    <dependency>
+      <groupId>io.atlasmap</groupId>
+      <artifactId>camel-atlasmap</artifactId>
+      <version>\${camel-atlasmap.version}</version>
+    </dependency>
+
+    <!-- connectors used in this integration -->
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>timer-connector</artifactId>
+      <version>@syndesis-connectors.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>http-get-connector</artifactId>
+      <version>@syndesis-connectors.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>http-post-connector</artifactId>
+      <version>@syndesis-connectors.version@</version>
+    </dependency>
+
+    <!-- spring-boot as runtime -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <!-- Integration runtime -->
+    <dependency>
+      <groupId>io.syndesis.integration-runtime</groupId>
+      <artifactId>model</artifactId>
+      <version>\${syndesis-integration-runtime.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.integration-runtime</groupId>
+      <artifactId>runtime</artifactId>
+      <version>\${syndesis-integration-runtime.version}</version>
+    </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test</artifactId>
+      <version>\${camel.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>\${maven-surefire-plugin.version}</version>
+        <inherited>true</inherited>
+        <configuration>
+          <excludes>
+            <exclude>**/*KT.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>\${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>\${fabric8.maven.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>resource</goal>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-pull-push-application.properties
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-pull-push-application.properties
@@ -1,0 +1,10 @@
+## name of CamelContext
+camel.springboot.name=Timed Pull to Post Example
+camel.springboot.streamCachingEnabled = true
+
+# Binding health checks to an internal port
+management.port=8081
+
+# disable all management enpoints except health
+endpoints.enabled = false
+endpoints.health.enabled = true

--- a/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-pull-push-pom.xml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-pull-push-pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.syndesis.integrations</groupId>
+  <artifactId>project</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <name>Syndesis Integrations :: Timed Pull to Post Example</name>
+  <description>This is an example of a Timed Pull to Post Integration</description>
+  <packaging>jar</packaging>
+
+  <properties>
+    <spring-boot.version>@spring-boot.version@</spring-boot.version>
+    <fabric8.version>@fabric8.version@</fabric8.version>
+    <fabric8.maven.plugin.version>@fabric8.maven.plugin.version@</fabric8.maven.plugin.version>
+    <maven-surefire-plugin.version>@maven-surefire-plugin.version@</maven-surefire-plugin.version>
+    <syndesis-integration-runtime.version>@syndesis-integration-runtime.version@</syndesis-integration-runtime.version>
+    <camel-atlasmap.version>@camel-atlasmap.version@</camel-atlasmap.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-project-bom-camel-spring-boot</artifactId>
+        <version>\${fabric8.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- atlasmap runtime -->
+    <dependency>
+      <groupId>io.atlasmap</groupId>
+      <artifactId>camel-atlasmap</artifactId>
+      <version>\${camel-atlasmap.version}</version>
+    </dependency>
+
+    <!-- connectors used in this integration -->
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>timer-connector</artifactId>
+      <version>@syndesis-connectors.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>http-get-connector</artifactId>
+      <version>@syndesis-connectors.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>http-post-connector</artifactId>
+      <version>@syndesis-connectors.version@</version>
+    </dependency>
+
+    <!-- spring-boot as runtime -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <!-- Integration runtime -->
+    <dependency>
+      <groupId>io.syndesis.integration-runtime</groupId>
+      <artifactId>model</artifactId>
+      <version>\${syndesis-integration-runtime.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.integration-runtime</groupId>
+      <artifactId>runtime</artifactId>
+      <version>\${syndesis-integration-runtime.version}</version>
+    </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test</artifactId>
+      <version>\${camel.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>\${maven-surefire-plugin.version}</version>
+        <inherited>true</inherited>
+        <configuration>
+          <excludes>
+            <exclude>**/*KT.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>\${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>\${fabric8.maven.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>resource</goal>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-settings.xml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/redhat/test-settings.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2016 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>fusesource.repo</id>
+      <repositories>
+        <repository>
+          <id>maven.central</id>
+          <name>Maven Central</name>
+          <url>https://repo1.maven.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+        <repository>
+          <id>redhat.ga</id>
+          <name>Red Hat General Availability Repository</name>
+          <url>https://maven.repository.redhat.com/ga</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+        <repository>
+          <id>fusesource.m2</id>
+          <name>FuseSource Community Release Repository</name>
+          <url>https://repo.fusesource.com/nexus/content/groups/public</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+        <repository>
+          <id>fusesource.ea</id>
+          <name>FuseSource Community Early Access Release Repository</name>
+          <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>maven.central</id>
+          <name>Maven Central</name>
+          <url>https://repo1.maven.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+        <pluginRepository>
+          <id>redhat.ga</id>
+          <name>Red Hat General Availability Repository</name>
+          <url>https://maven.repository.redhat.com/ga</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+        <pluginRepository>
+          <id>fusesource.m2</id>
+          <name>FuseSource Community Release Repository</name>
+          <url>https://repo.fusesource.com/nexus/content/groups/public</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+        <pluginRepository>
+          <id>fusesource.ea</id>
+          <name>FuseSource Community Early Access Release Repository</name>
+          <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>fusesource.repo</activeProfile>
+  </activeProfiles>
+
+</settings>


### PR DESCRIPTION
This PR is not to be merged but I've opened it to gather some feedback.

Now project-generator can be configured with an ``template override path`` which is the location were overriding templates are stored. In addition you can now list a number of additional resources that can be included i.e. the ``redhat`` profile includes some fabric8 bits like ``src/main/fabric8``
