### PR TITLE
fix: The API HTML documentation are not accessible on OpenShift

### DIFF
--- a/rest/src/main/java/io/syndesis/rest/v1/ApiDocumentationEndpoint.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/ApiDocumentationEndpoint.java
@@ -15,15 +15,27 @@
  */
 package io.syndesis.rest.v1;
 
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
+import java.io.InputStream;
 
-/**
- * Configured in spring.factories so that this configuration is automatically picked
- * up when included in the classpath.
- */
-@Configuration
-@ComponentScan
-public class V1Configuration {
+import static java.util.concurrent.TimeUnit.HOURS;
 
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import io.swagger.annotations.ApiOperation;
+
+import org.springframework.stereotype.Component;
+
+@CacheFor(value = 1, unit = HOURS)
+@Path("/index.html")
+@Component
+public class ApiDocumentationEndpoint {
+
+    @GET
+    @Produces("text/html")
+    @ApiOperation(value = "Get the REST API documentation")
+    public InputStream doGet() {
+        return ApiDocumentationEndpoint.class.getResourceAsStream("/static/index.html");
+    }
 }

--- a/runtime/src/main/java/io/syndesis/runtime/KeycloakConfiguration.java
+++ b/runtime/src/main/java/io/syndesis/runtime/KeycloakConfiguration.java
@@ -113,6 +113,7 @@ public class KeycloakConfiguration extends KeycloakWebSecurityConfigurerAdapter 
             .exceptionHandling().authenticationEntryPoint(authenticationEntryPoint()).and().authorizeRequests()
             .antMatchers(HttpMethod.OPTIONS).permitAll()
             .antMatchers("/api/v1/swagger.*").permitAll()
+            .antMatchers("/api/v1/index.html").permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/credentials/callback").permitAll()
             .antMatchers("/api/v1/**").authenticated()
             .anyRequest().permitAll();

--- a/runtime/src/test/java/io/syndesis/runtime/APIDocsITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/APIDocsITCase.java
@@ -60,7 +60,7 @@ public class APIDocsITCase extends BaseITCase {
 
     @Test
     public void testSwaggerDocsIndex() {
-        ResponseEntity<String> response = restTemplate().getForEntity("/index.html", String.class);
+        ResponseEntity<String> response = restTemplate().getForEntity("/api/v1/index.html", String.class);
         assertThat(response.getStatusCode()).as("swagger docs index.html response code").isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().length()).as("swagger index.html length").isPositive();
         assertThat(response.getBody()).as("swagger index.html example path").contains("/connectors/{id}");
@@ -68,7 +68,7 @@ public class APIDocsITCase extends BaseITCase {
 
     @Test
     public void testSwaggerDocsIndexWithToken() {
-        ResponseEntity<String> response = get("/index.html", String.class);
+        ResponseEntity<String> response = get("/api/v1/index.html", String.class);
         assertThat(response.getStatusCode()).as("swagger docs index.html response code").isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().length()).as("swagger index.html length").isPositive();
         assertThat(response.getBody()).as("swagger index.html example path").contains("/connectors/{id}");


### PR DESCRIPTION
This makes the HTML documentation available on the `/api/v1/index.html`
address (in addition to `/index.html`). The issue being is that the
route on OpenShift is defined to the `/api/v1` so `/index.html` cannot
be served from the backend.

Fixes #525