### PR TITLE
chore: String trimming JSON

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,6 +48,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
@@ -89,9 +94,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <!-- for @SkipNull test -->
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
     </dependency>
 
   </dependencies>

--- a/core/src/main/java/io/syndesis/core/Json.java
+++ b/core/src/main/java/io/syndesis/core/Json.java
@@ -21,16 +21,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
+import io.syndesis.core.json.SyndesisModule;
+
 /**
  * JSON helper class.
  */
 public final class Json {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-        .registerModule(new Jdk8Module())
+        .registerModules(new Jdk8Module(), new SyndesisModule())
         .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
-        .configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true)
-        .configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+        .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
+        .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
 
     private Json() {
     }

--- a/core/src/main/java/io/syndesis/core/immutable/SkipNulls.java
+++ b/core/src/main/java/io/syndesis/core/immutable/SkipNulls.java
@@ -13,18 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.model;
+package io.syndesis.core.immutable;
 
-import java.util.SortedSet;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import io.syndesis.core.immutable.SkipNulls;
-
-import org.immutables.value.Value;
-
-public interface WithTags {
-
-    @Value.NaturalOrder
-    @SkipNulls
-    SortedSet<String> getTags();
-
+/**
+ * Directs Immutables not to add {@code null} values to collections. When this
+ * annotation is added to a collection type parameter it will generate a builder
+ * that will ignore {@code null} values being added to a collection.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+@Documented
+public @interface SkipNulls {
+    // tag annotation
 }

--- a/core/src/main/java/io/syndesis/core/json/StringTrimmingJsonDeserializer.java
+++ b/core/src/main/java/io/syndesis/core/json/StringTrimmingJsonDeserializer.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.core.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+/**
+ * Trims JSON strings and converts any empty strings to {@code null}.
+ */
+class StringTrimmingJsonDeserializer extends JsonDeserializer<String> {
+
+    @Override
+    public String deserialize(final JsonParser parser, final DeserializationContext ctxt)
+        throws IOException, JsonProcessingException {
+        final boolean hasStringValue = parser.hasToken(JsonToken.VALUE_STRING);
+
+        if (!hasStringValue) {
+            return null;
+        }
+
+        final String text = parser.getText();
+
+        final String trimmed = text.trim();
+
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+
+        return trimmed;
+    }
+
+}

--- a/core/src/main/java/io/syndesis/core/json/SyndesisModule.java
+++ b/core/src/main/java/io/syndesis/core/json/SyndesisModule.java
@@ -13,18 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.model;
+package io.syndesis.core.json;
 
-import java.util.SortedSet;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
-import io.syndesis.core.immutable.SkipNulls;
+public final class SyndesisModule extends SimpleModule {
 
-import org.immutables.value.Value;
+    private static final long serialVersionUID = 1L;
 
-public interface WithTags {
-
-    @Value.NaturalOrder
-    @SkipNulls
-    SortedSet<String> getTags();
-
+    public SyndesisModule() {
+        final StringTrimmingJsonDeserializer stringDeserializer = new StringTrimmingJsonDeserializer();
+        addDeserializer(String.class, stringDeserializer);
+    }
 }

--- a/core/src/test/java/io/syndesis/core/immutable/SkipNullsTest.java
+++ b/core/src/test/java/io/syndesis/core/immutable/SkipNullsTest.java
@@ -13,18 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.model;
+package io.syndesis.core.immutable;
 
-import java.util.SortedSet;
-
-import io.syndesis.core.immutable.SkipNulls;
+import java.util.Set;
 
 import org.immutables.value.Value;
+import org.junit.Test;
 
-public interface WithTags {
+import static org.assertj.core.api.Assertions.assertThat;
 
-    @Value.NaturalOrder
-    @SkipNulls
-    SortedSet<String> getTags();
+public class SkipNullsTest {
 
+    @Value.Immutable
+    public interface TestValue {
+        @SkipNulls
+        Set<String> noNulls();
+    }
+
+    @Test
+    public void shouldNotHoldNullValues() {
+        final TestValue testValue = ImmutableTestValue.builder().addNoNulls(null, "value").build();
+
+        assertThat(testValue.noNulls()).containsExactly("value");
+    }
 }

--- a/core/src/test/java/io/syndesis/core/json/StringTrimmingJsonDeserializerTest.java
+++ b/core/src/test/java/io/syndesis/core/json/StringTrimmingJsonDeserializerTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.core.json;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringTrimmingJsonDeserializerTest {
+
+    private static final DeserializationContext NOT_USED = null;
+
+    private final JsonDeserializer<String> deserializer = new StringTrimmingJsonDeserializer();
+
+    @Test
+    public void shouldTrim() throws JsonProcessingException, IOException {
+        assertThat(deserializer.deserialize(parserWithString(" a bc \\t"), NOT_USED)).isEqualTo("a bc");
+    }
+
+    @Test
+    public void shouldTrimNullsToNull() throws JsonProcessingException, IOException {
+        assertThat(deserializer.deserialize(parserWithString(null), NOT_USED)).isNull();
+    }
+
+    @Test
+    public void shouldTrimToNull() throws JsonProcessingException, IOException {
+        assertThat(deserializer.deserialize(parserWithString(" "), NOT_USED)).isNull();
+        assertThat(deserializer.deserialize(parserWithString(""), NOT_USED)).isNull();
+        assertThat(deserializer.deserialize(parserWithString(" \\t \\t"), NOT_USED)).isNull();
+    }
+
+    private JsonParser parserWithString(final String value) throws JsonParseException, IOException {
+        final JsonParser parser = new ObjectMapper().getFactory()
+            .createParser(Optional.ofNullable(value).map(v -> "[\"" + v + "\"]").orElse("[null]"));
+        parser.nextToken();// array
+        parser.nextToken();// string
+
+        return parser;
+    }
+}

--- a/dao/src/main/resources/io/syndesis/dao/demo-data.json
+++ b/dao/src/main/resources/io/syndesis/dao/demo-data.json
@@ -2,7 +2,7 @@
   {
     "kind": "connection",
     "data": {
-      "id": 1,
+      "id": "1",
       "name": "Twitter Example",
       "description": "Twitter Connection",
       "createdDate": 1492095344060,
@@ -10,17 +10,17 @@
       "icon": "fa-twitter",
       "connectorId": "twitter",
       "configuredProperties": {
-        "accessToken": "",
-        "accessTokenSecret": "",
-        "consumerKey": "",
-        "consumerSecret": ""
+        "accessToken": "twitter-access-token",
+        "accessTokenSecret": "twitter-access-token-secret",
+        "consumerKey": "twitter-consumer-key",
+        "consumerSecret": "twitter-consumer-secret"
       }
     }
   },
   {
     "kind": "connection",
     "data": {
-      "id": 2,
+      "id": "2",
       "name": "Salesforce Example",
       "description": "Salesforce Connection",
       "createdDate": 1492095344060,
@@ -30,16 +30,16 @@
       "connectorId": "salesforce",
       "configuredProperties": {
         "loginUrl": "https://login.salesforce.com",
-        "clientId": "",
-        "clientSecret": "",
-        "refreshToken": ""
+        "clientId": "salesforce-client-id",
+        "clientSecret": "salesforce-client-secret",
+        "refreshToken": "salesforce-refresh-token"
       }
     }
   },
   {
     "kind": "connection",
     "data": {
-      "id": 3,
+      "id": "3",
       "name": "HTTP Example",
       "description": "HTTP Connection",
       "createdDate": 1492095344060,
@@ -53,7 +53,7 @@
   {
     "kind": "connection",
     "data": {
-      "id": 4,
+      "id": "4",
       "name": "Timer Example",
       "description": "Timer Connection",
       "createdDate": 1492095344060,
@@ -81,16 +81,16 @@
           "id": "1",
           "stepKind": "endpoint",
           "connection": {
-            "id": 1,
+            "id": "1",
             "name": "Twitter Example",
             "description": "Twitter Connection",
             "icon": "fa-twitter",
             "connectorId": "twitter",
             "configuredProperties": {
-              "accessToken": "",
-              "accessTokenSecret": "",
-              "consumerKey": "",
-              "consumerSecret": ""
+              "accessToken": "twitter-access-token",
+              "accessTokenSecret": "twitter-access-token-secret",
+              "consumerKey": "twitter-consumer-key",
+              "consumerSecret": "twitter-consumer-secret"
             }
           },
           "action": {
@@ -128,16 +128,16 @@
           "id": "4",
           "stepKind": "endpoint",
           "connection": {
-            "id": 2,
+            "id": "2",
             "connectorId": "salesforce",
             "description": "Salesforce Connection",
             "icon": "fa-puzzle-piece",
             "name": "Salesforce Example",
             "configuredProperties": {
               "loginUrl": "https://login.salesforce.com",
-              "clientId": "",
-              "clientSecret": "",
-              "refreshToken": ""
+              "clientId": "salesforce-client-id",
+              "clientSecret": "salesforce-client-secret",
+              "refreshToken": "salesforce-refresh-token"
             }
           },
           "action": {
@@ -181,7 +181,7 @@
           "id": "5",
           "stepKind": "endpoint",
           "connection": {
-            "id": 4,
+            "id": "4",
             "name": "Timer Example",
             "description": "Timer Connection",
             "icon": "fa-globe",
@@ -231,7 +231,7 @@
           "id": "7",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -273,7 +273,7 @@
           "id": "8",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -332,7 +332,7 @@
           "id": "5",
           "stepKind": "endpoint",
           "connection": {
-            "id": 4,
+            "id": "4",
             "name": "Timer Example",
             "description": "Timer Connection",
             "icon": "fa-globe",
@@ -382,7 +382,7 @@
           "id": "7",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -424,7 +424,7 @@
           "id": "8",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -483,7 +483,7 @@
           "id": "5",
           "stepKind": "endpoint",
           "connection": {
-            "id": 4,
+            "id": "4",
             "name": "Timer Example",
             "description": "Timer Connection",
             "icon": "fa-globe",
@@ -533,7 +533,7 @@
           "id": "7",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -575,7 +575,7 @@
           "id": "8",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -634,7 +634,7 @@
           "id": "5",
           "stepKind": "endpoint",
           "connection": {
-            "id": 4,
+            "id": "4",
             "name": "Timer Example",
             "description": "Timer Connection",
             "icon": "fa-globe",
@@ -684,7 +684,7 @@
           "id": "7",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -726,7 +726,7 @@
           "id": "8",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -785,7 +785,7 @@
           "id": "5",
           "stepKind": "endpoint",
           "connection": {
-            "id": 4,
+            "id": "4",
             "name": "Timer Example",
             "description": "Timer Connection",
             "icon": "fa-globe",
@@ -835,7 +835,7 @@
           "id": "7",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -877,7 +877,7 @@
           "id": "8",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -936,7 +936,7 @@
           "id": "5",
           "stepKind": "endpoint",
           "connection": {
-            "id": 4,
+            "id": "4",
             "name": "Timer Example",
             "description": "Timer Connection",
             "icon": "fa-globe",
@@ -986,7 +986,7 @@
           "id": "7",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",
@@ -1028,7 +1028,7 @@
           "id": "8",
           "stepKind": "endpoint",
           "connection": {
-            "id": 3,
+            "id": "3",
             "name": "HTTP Example",
             "description": "HTTP Connection",
             "icon": "fa-globe",

--- a/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
@@ -102,7 +102,7 @@ public class DataManagerTest {
         Integration integration = dataManager.fetch(Integration.class, "1");
         Assert.assertEquals("Example Integration", "Twitter to Salesforce Example", integration.getName());
         Assert.assertEquals(4, integration.getSteps().get().size());
-        Assert.assertTrue(integration.getTags().get().contains("example"));
+        Assert.assertTrue(integration.getTags().contains("example"));
 
         //making sure we can deserialize Enums such as StatusType
         Integration int2 = new Integration.Builder().createFrom(integration).desiredStatus(Integration.Status.Activated).build();

--- a/model/src/main/java/io/syndesis/model/TagFinder.java
+++ b/model/src/main/java/io/syndesis/model/TagFinder.java
@@ -30,10 +30,8 @@ public class TagFinder {
     public TagFinder add(ListResult<? extends WithTags> items) {
         if (items.getItems()!=null) {
             for (WithTags item : items.getItems()) {
-                if (item.getTags().isPresent()) {
-                    for (String tag: item.getTags().get()) {
-                        tags.add(tag);
-                    }
+                for (String tag: item.getTags()) {
+                    tags.add(tag);
                 }
             }
         }

--- a/model/src/main/java/io/syndesis/model/WithName.java
+++ b/model/src/main/java/io/syndesis/model/WithName.java
@@ -15,8 +15,15 @@
  */
 package io.syndesis.model;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import io.syndesis.model.validation.AllValidations;
+
 public interface WithName {
 
+    @NotNull(groups = AllValidations.class)
+    @Size(min = 1, groups = AllValidations.class)
     String getName();
 
 }

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-integration.json
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-integration.json
@@ -15,7 +15,7 @@
           "description": "Timer Connection",
           "icon": "fa-globe",
           "name": "Timer Example",
-          "id": 4
+          "id": "4"
         },
         "action": {
           "connectorId": "http",
@@ -52,7 +52,7 @@
           "description": "HTTP Connection",
           "icon": "fa-globe",
           "name": "HTTP Example",
-          "id": 3
+          "id": "3"
         },
         "action": {
           "connectorId": "http",
@@ -97,7 +97,7 @@
           "description": "HTTP Connection",
           "icon": "fa-globe",
           "name": "HTTP Example",
-          "id": 3
+          "id": "3"
         },
         "action": {
           "connectorId": "http",

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionHandler.java
@@ -34,7 +34,7 @@ import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.Kind;
 import io.syndesis.model.connection.Connection;
 import io.syndesis.model.connection.Connector;
-import io.syndesis.model.validation.UniquenessRequired;
+import io.syndesis.model.validation.AllValidations;
 import io.syndesis.rest.v1.handler.BaseHandler;
 import io.syndesis.rest.v1.operations.Creator;
 import io.syndesis.rest.v1.operations.Deleter;
@@ -87,7 +87,7 @@ public class ConnectionHandler extends BaseHandler
     }
 
     @Override
-    public Connection create(@ConvertGroup(from = Default.class, to = UniquenessRequired.class) final Connection connection) {
+    public Connection create(@ConvertGroup(from = Default.class, to = AllValidations.class) final Connection connection) {
         final Date rightNow = new Date();
         final Connection updatedConnection = new Connection.Builder().createFrom(connection).createdDate(rightNow)
             .lastUpdated(rightNow).build();
@@ -109,7 +109,7 @@ public class ConnectionHandler extends BaseHandler
     }
 
     @Override
-    public void update(final String id, final Connection connection) {
+    public void update(final String id, @ConvertGroup(from = Default.class, to = AllValidations.class) final Connection connection) {
         final Connection updatedConnection = new Connection.Builder().createFrom(connection).lastUpdated(new Date())
             .build();
         Updater.super.update(id, updatedConnection);

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/setup/OAuthAppHandler.java
@@ -16,7 +16,6 @@
 package io.syndesis.rest.v1.handler.setup;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -150,7 +149,7 @@ public class OAuthAppHandler {
 
     private static boolean isOauthConnector(Connector connector) {
         return connector.getProperties().values().stream().anyMatch(x -> {
-                return x.getTags().orElse(Collections.emptySortedSet()).contains("oauth-client-id");
+                return x.getTags().contains("oauth-client-id");
             }
         );
     }
@@ -160,7 +159,7 @@ public class OAuthAppHandler {
             return null;
         }
         for (Map.Entry<String,ConfigurationProperty> entry : connector.getProperties().entrySet()) {
-            if( entry.getValue().getTags().orElse(Collections.emptySortedSet()).contains(name) ) {
+            if( entry.getValue().getTags().contains(name) ) {
                 return connector.getConfiguredProperties().get(entry.getKey());
             }
         }
@@ -169,7 +168,7 @@ public class OAuthAppHandler {
 
     private static void setPropertyTaggedAs(Connector connector, Map<String, String> configuredProperties, String name, String value) {
         for (Map.Entry<String,ConfigurationProperty> entry : connector.getProperties().entrySet()) {
-            if( entry.getValue().getTags().orElse(Collections.emptySortedSet()).contains(name) ) {
+            if( entry.getValue().getTags().contains(name) ) {
                 configuredProperties.put(entry.getKey(), value);
                 return;
             }

--- a/runtime/src/test/java/io/syndesis/runtime/JsonHandlingITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/JsonHandlingITCase.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.runtime;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.UUID;
+
+import io.syndesis.model.integration.Integration;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonHandlingITCase extends BaseITCase {
+
+    private final String id = UUID.randomUUID().toString();
+
+    @After
+    public void removeIntegration() {
+        dataManager.getDataAccessObject(Integration.class).delete(id);
+    }
+
+    @Test
+    public void valuesGivenInJsonShouldBeTrimmedToNull() {
+        final SortedSet<String> tags = new TreeSet<>();
+        tags.add("");
+        tags.add(" tag");
+        tags.add("\tTaggy McTagface\t");
+
+        final Integration integration = new Integration.Builder().id(id).name("  some-name\t").description("")
+            .tags(tags).desiredStatus(Integration.Status.Draft).build();
+        post("/api/v1/integrations", integration, Integration.class);
+
+        final ResponseEntity<Integration> result = get("/api/v1/integrations/" + id, Integration.class);
+        final Integration created = result.getBody();
+        assertThat(created.getName()).isEqualTo("some-name");
+        assertThat(created.getDescription()).isNotPresent();
+        assertThat(created.getTags()).containsExactly("Taggy McTagface", "tag");
+
+    }
+}


### PR DESCRIPTION
Problem: When handling user generated input strings can be often
specified with padding whitespace, semantically humans consider those
strings with and without padding whitespace the same but computers
consider them different. Having a consistent string representation helps
with eliminating edge cases when searching or sorting.

Solution: With this all strings parsed from JSON are trimmed. Any empty
strings after trimming are set to `null`.

Introduces new Jackson module `SyndesisModule` that registers a
deserializer to perform trim-to-null on strings. As strings can appear
in collections any collection field in the model that does not tolerate
`null` strings, or does not wish to contain any `null` strings must
handle accepting `null` strings. For Immutables this is done by marking
the interface method with `@SkipNulls`.

Switches `tags` in `WithTags` from `Optional<SortedSet<String>>` to
`SortedSet<String>`.

Enforces minimal length for named models (those extending `WithName`) of
1 character and perhibits `null` names.