### PR TITLE
fix(github): generate e-mail address for users ...

### DIFF
--- a/github/src/test/java/io/syndesis/github/GitHubServiceITCase.java
+++ b/github/src/test/java/io/syndesis/github/GitHubServiceITCase.java
@@ -30,6 +30,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,11 +71,12 @@ public class GitHubServiceITCase {
     public TestName testName = new TestName();
 
     @Before
-    public void before() throws IOException {
+    public void before() {
 
         authToken = System.getProperties().getProperty("github.oauth.token");
 
-        Assertions.assertThat(authToken).isNotNull().isNotBlank();
+        Assume.assumeNotNull(authToken);
+        Assume.assumeFalse("GitHub OAuth token needs to be specified in Java system property `github.oauth.token`", authToken.isEmpty());
 
         client = new KeycloakProviderTokenAwareGitHubClient();
 
@@ -112,7 +114,10 @@ public class GitHubServiceITCase {
     @After
     public void after() {
         SecurityContextHolder.getContext().setAuthentication(null);
-        webserver.shutdown();
+
+        if (webserver != null) {
+            webserver.shutdown();
+        }
     }
 
     @Test


### PR DESCRIPTION
...that elected not to show their e-mail address publicly

If a GitHub user has chosen not to display the e-mail address in public
then API will not return the e-mail address. For this case we need to
use a GitHub provided no-reply e-mail address.

Fixes #522