### PR TITLE
fix(validation): revises RestEasy validations

### DIFF
--- a/runtime/src/main/java/io/syndesis/runtime/Application.java
+++ b/runtime/src/main/java/io/syndesis/runtime/Application.java
@@ -24,6 +24,7 @@ import io.syndesis.rest.v1.state.ClientSideState;
 import io.syndesis.rest.v1.state.ClientSideStateProperties;
 import io.syndesis.rest.v1.state.StaticEdition;
 
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,13 +91,16 @@ public class Application extends SpringBootServletInitializer {
     }
 
     @Bean
-    public Validator localValidatorFactoryBean(final MessageSource messageSource, final ResourcePatternResolver resolver) throws IOException {
+    public Validator localValidatorFactoryBean(final ResteasyProviderFactory factory, final MessageSource messageSource, final ResourcePatternResolver resolver) throws IOException {
         final LocalValidatorFactoryBean localValidatorFactoryBean = new LocalValidatorFactoryBean();
         localValidatorFactoryBean.setValidationMessageSource(messageSource);
 
         final Resource[] mappings = resolver.getResources("classpath*:/META-INF/validation/*.xml");
         localValidatorFactoryBean.setMappingLocations(mappings);
 
+        factory.register(new ValidatorContextResolver(localValidatorFactoryBean));
+
         return localValidatorFactoryBean;
     }
+
 }

--- a/runtime/src/main/java/io/syndesis/runtime/ValidatorContextResolver.java
+++ b/runtime/src/main/java/io/syndesis/runtime/ValidatorContextResolver.java
@@ -24,18 +24,14 @@ import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
 import javax.validation.executable.ExecutableType;
 import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Provider;
 
 import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
 import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
 import org.jboss.resteasy.plugins.validation.GeneralValidatorImpl;
 import org.jboss.resteasy.spi.validation.GeneralValidator;
-import org.springframework.stereotype.Component;
 
-@Component
-@Provider
-public class ValidatorContextResolver implements ContextResolver<GeneralValidator> {
+class ValidatorContextResolver implements ContextResolver<GeneralValidator> {
 
     private final ValidatorFactory validatorFactory;
 

--- a/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,1 +1,0 @@
-io.syndesis.runtime.ValidatorContextResolver


### PR DESCRIPTION
Removes the Service locator file from `META-INF/services` so that the
`ValidatorContextResolver` is not registered automatically to every
RestEasy provider instances, which is an issue with clients, and
registers `ValidatorContextResolver` only with the REST backend
`ResteasyProviderFactory` auto configured with Spring Boot.

Fixes #543