### PR TITLE
fix(server): Configures the use of X-Forwarded ...

### DIFF
--- a/runtime/src/main/resources/application.yml
+++ b/runtime/src/main/resources/application.yml
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+server:
+  useForwardHeaders: true
+
 cors:
   allowedOrigins: "*"
 


### PR DESCRIPTION
... headers

When the backend is behind OpenShift router (HAProxy) it should set
proxy (X-Forwarded-*) headers[1] and Undertow should consider them. This
is to help with HttpServletRequest::getScheme returning `https` instead
of `http`.

[1] https://github.com/openshift/origin/issues/4549