### PR TITLE
refactor(filter): Remove prefix for filter options

### DIFF
--- a/core/src/test/java/io/syndesis/core/json/StringTrimmingJsonDeserializerTest.java
+++ b/core/src/test/java/io/syndesis/core/json/StringTrimmingJsonDeserializerTest.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class StringTrimmingJsonDeserializerTest {
 

--- a/core/src/test/java/io/syndesis/core/json/StringTrimmingJsonDeserializerTest.java
+++ b/core/src/test/java/io/syndesis/core/json/StringTrimmingJsonDeserializerTest.java
@@ -27,7 +27,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class StringTrimmingJsonDeserializerTest {
 

--- a/inspector/pom.xml
+++ b/inspector/pom.xml
@@ -52,6 +52,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/inspector/src/test/java/io/syndesis/inspector/DataMapperClassInspectorTest.java
+++ b/inspector/src/test/java/io/syndesis/inspector/DataMapperClassInspectorTest.java
@@ -16,15 +16,15 @@
 
 package io.syndesis.inspector;
 
+import java.nio.charset.Charset;
+import java.util.List;
+
 import com.google.common.io.Resources;
 import io.fabric8.mockwebserver.DefaultMockServer;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.web.client.RestTemplate;
-
-import java.nio.charset.Charset;
-import java.util.List;
 
 public class DataMapperClassInspectorTest {
 
@@ -45,8 +45,8 @@ public class DataMapperClassInspectorTest {
         List<String> paths = dataMapperClassInspector.getPaths("twitter4j.StatusJSONImpl");
 
         Assert.assertNotNull(paths);
-        Assert.assertTrue(paths.contains("StatusJSONImpl.id"));
-        Assert.assertTrue(paths.contains("StatusJSONImpl.logger.infoEnabled"));
+        Assert.assertTrue(paths.contains("id"));
+        Assert.assertTrue(paths.contains("logger.infoEnabled"));
     }
 
     @Test
@@ -57,7 +57,7 @@ public class DataMapperClassInspectorTest {
         List<String> paths = dataMapperClassInspector.getPaths("twitter4j.Status");
 
         Assert.assertNotNull(paths);
-        Assert.assertTrue(paths.contains("Status.id"));
+        Assert.assertTrue(paths.contains("id"));
     }
 
     @Test

--- a/model/src/main/java/io/syndesis/model/filter/FilterRule.java
+++ b/model/src/main/java/io/syndesis/model/filter/FilterRule.java
@@ -15,6 +15,9 @@
  */
 package io.syndesis.model.filter;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 
@@ -27,7 +30,7 @@ public interface FilterRule {
 
     /**
      *  Path expression within the message on which to filter. Can be part of header, body, properties
-     * The path must match the syntax used by the simple expression language as path
+     * The path is a simple dot notation to the property to filter.
      */
     String getPath();
 
@@ -47,8 +50,17 @@ public interface FilterRule {
      * Get the simple filter expression for this rule
      */
     default String getFilterExpression() {
-        return "${" + getPath() + "} " + getOp() + " '" + getValue() + "'";
+        return String.format("%s %s '%s'",
+                             convertPathToSimple(),
+                             getOp(),
+                             getValue());
+    }
 
+    default String convertPathToSimple() {
+        return String.format("${body%s}",
+                             Arrays.stream(getPath().split("\\."))
+                                   .map(s -> "[" + s + "]")
+                                   .collect(Collectors.joining()));
     }
 
     class Builder extends ImmutableFilterRule.Builder { }

--- a/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
+++ b/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
@@ -37,14 +37,14 @@ public class StepDeserializerTest {
         assertEquals(FilterPredicate.AND, FilterPredicate.valueOf(props.get("predicate").toUpperCase(Locale.US)));
         assertNotNull(props.get("rules"));
         assertEquals("rule-filter", step.getStepKind());
-        assertEquals("${body.text} == 'antman' && ${header.kind} =~ 'DC Comics'", step.getFilterExpression());
+        assertEquals("${body[text]} == 'antman' && ${body[kind]} =~ 'DC Comics'", step.getFilterExpression());
     }
 
     @Test
     public void shouldDeserializeExpressionFilterStep() throws Exception {
         ExpressionFilterStep step = readTestFilter("/filter-step.json");
         ExpressionFilterStep exprFilterStep = (ExpressionFilterStep) step;
-        String expr = "${in.body} contains '#RHSummit'";
+        String expr = "${body[text]} contains '#RHSummit'";
         assertEquals("2", exprFilterStep.getId().get());
         assertEquals("filter", exprFilterStep.getStepKind());
         assertEquals(expr, exprFilterStep.getFilterExpression());

--- a/model/src/test/resources/filter-step.json
+++ b/model/src/test/resources/filter-step.json
@@ -3,7 +3,7 @@
   "kind": "Step",
   "stepKind": "filter",
   "configuredProperties": {
-    "filter": "${in.body} contains '#RHSummit'"
+    "filter": "${body[text]} contains '#RHSummit'"
   }
 }
 

--- a/model/src/test/resources/rule-filter-step.json
+++ b/model/src/test/resources/rule-filter-step.json
@@ -4,6 +4,6 @@
   "stepKind": "rule-filter",
   "configuredProperties": {
     "predicate": "and",
-    "rules": "[{\"path\": \"body.text\",\"op\": \"==\",\"value\": \"antman\"},{\"path\": \"header.kind\",\"op\": \"=~\",\"value\": \"DC Comics\"}]"
+    "rules": "[{\"path\": \"text\",\"op\": \"==\",\"value\": \"antman\"},{\"path\": \"kind\",\"op\": \"=~\",\"value\": \"DC Comics\"}]"
   }
 }

--- a/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
@@ -283,7 +283,7 @@ public class DefaultProjectGeneratorTest {
 
         Step step3 = new SimpleStep.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(Collections.emptyMap()).build()).configuredProperties(map("httpUri", "http://localhost:8080/bye")).action(new Action.Builder().connectorId("http").camelConnectorPrefix("http-post").camelConnectorGAV("io.syndesis:http-post-connector:0.4.5").build()).build();
 
-        Step step4 = new ExpressionFilterStep.Builder().configuredProperties(map("filter", "${body.germanSecondLeagueChampion} equals 'FCN'")).build();
+        Step step4 = new ExpressionFilterStep.Builder().configuredProperties(map("filter", "${body[germanSecondLeagueChampion]} equals 'FCN'")).build();
 
         GenerateProjectRequest request = new GenerateProjectRequest.Builder()
             .gitHubUserLogin("noob")

--- a/project-generator/src/test/java/io/syndesis/project/converter/visitor/RuleFilterStepVisitorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/visitor/RuleFilterStepVisitorTest.java
@@ -39,7 +39,7 @@ public class RuleFilterStepVisitorTest {
             .build();
 
         // Reading notes: Unit tests are like personal diaries. Feel honoured when you have the chance to be part of them ;-)
-        assertEquals("${person.name} == 'Ioannis' && ${person.favoriteDrinks} contains 'Gin'", step.getFilterExpression());
+        assertEquals("${body[person][name]} == 'Ioannis' && ${body[person][favoriteDrinks]} contains 'Gin'", step.getFilterExpression());
     }
 
 }

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-filter-syndesis.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-filter-syndesis.yml
@@ -4,9 +4,9 @@ flows:
   - kind: endpoint
     uri: periodic-timer:every?period=5000
   - kind: filter
-    expression: ${in.header.counter} > '10'
+    expression: ${body[in][header][counter]} > '10'
     steps:
     - kind: endpoint
       uri: http-post?httpUri=http://localhost:8080/bye
     - kind: filter
-      expression: ${body.germanSecondLeagueChampion} equals 'FCN'
+      expression: ${body[germanSecondLeagueChampion]} equals 'FCN'

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
@@ -139,10 +139,10 @@ public class IntegrationHandler extends BaseHandler
         List<? extends Step> steps = integration.getSteps().orElse(Collections.emptyList());
         Optional<DataShape> lastOutputShape = Optional.empty();
         for (int i = 0; i < steps.size(); i++) {
-            Step step = steps.get(i);
             if (position != -1 && position == i) {
                 return lastOutputShape;
             }
+            Step step = steps.get(i);
             if (step.getAction().isPresent()) {
                 DataShape shape = step.getAction().get().getOutputDataShape();
                 if (shape != null && DataShapeKinds.JAVA.equals(shape.getKind())) {

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
@@ -25,6 +25,7 @@ import io.syndesis.dao.manager.DataManager;
 import io.syndesis.inspector.ClassInspector;
 import io.syndesis.model.connection.Action;
 import io.syndesis.model.connection.DataShape;
+import io.syndesis.model.connection.DataShapeKinds;
 import io.syndesis.model.filter.FilterOptions;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.model.integration.SimpleStep;
@@ -32,9 +33,7 @@ import io.syndesis.rest.v1.handler.integration.IntegrationHandler;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.syndesis.model.connection.DataShapeKinds.JAVA;
-import static io.syndesis.model.connection.DataShapeKinds.NONE;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,33 +46,31 @@ public class IntegrationHandlerTest {
 
     private IntegrationHandler handler;
     private ClassInspector inspector;
-    private Validator validator;
-    private DataManager manager;
 
     @Before
-    public void setup() {
-        manager = mock(DataManager.class);
-        validator = mock(Validator.class);
+    public void setUp() {
+        DataManager manager = mock(DataManager.class);
+        Validator validator = mock(Validator.class);
         inspector = mock(ClassInspector.class);
         handler = new IntegrationHandler(manager, validator, inspector);
     }
 
     @Test
-    public void filterOptions_simple() {
+    public void filterOptionsSimple() {
         when(inspector.getPaths("twitter4j.Status")).thenReturn(Arrays.asList("paramA", "paramB"));
         Integration integration =
-            createIntegrationFromDataShapes(dataShape(JAVA, "twitter4j.Status"),null,dataShape(NONE));
+            createIntegrationFromDataShapes(dataShape(DataShapeKinds.JAVA, "twitter4j.Status"), null, dataShape(DataShapeKinds.NONE));
 
         FilterOptions options = handler.getFilterOptions(integration, -1);
         assertThat(options.getPaths()).hasSize(2).contains("paramA","paramB");
     }
 
     @Test
-    public void filterOptions_multipleOutputShapes() {
+    public void filterOptionsMultipleOutputShapes() {
         when(inspector.getPaths("twitter4j.Status")).thenReturn(Arrays.asList("paramA", "paramB"));
         when(inspector.getPaths("blubber.bla")).thenReturn(Arrays.asList("paramY", "paramZ"));
         Integration integration =
-            createIntegrationFromDataShapes(dataShape(JAVA, "blubber.bla"),null, dataShape(JAVA, "twitter4j.Status"));
+            createIntegrationFromDataShapes(dataShape(DataShapeKinds.JAVA, "blubber.bla"),null, dataShape(DataShapeKinds.JAVA, "twitter4j.Status"));
 
         assertThat(handler.getFilterOptions(integration, -1).getPaths())
             .hasSize(2).contains("paramA", "paramB");
@@ -83,9 +80,9 @@ public class IntegrationHandlerTest {
     }
 
     @Test
-    public void filterOptions_noOutputShape() {
+    public void filterOptionsNoOutputShape() {
         Integration integration =
-            createIntegrationFromDataShapes(dataShape(NONE), null);
+            createIntegrationFromDataShapes(dataShape(DataShapeKinds.NONE), null);
 
         FilterOptions options = handler.getFilterOptions(integration, -1);
         assertThat(options.getPaths()).isEmpty();

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
@@ -1,0 +1,99 @@
+package io.syndesis.rest.v1.handler;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.validation.Validator;
+
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.inspector.ClassInspector;
+import io.syndesis.model.connection.Action;
+import io.syndesis.model.connection.DataShape;
+import io.syndesis.model.filter.FilterOptions;
+import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.SimpleStep;
+import io.syndesis.rest.v1.handler.integration.IntegrationHandler;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.syndesis.model.connection.DataShapeKinds.JAVA;
+import static io.syndesis.model.connection.DataShapeKinds.NONE;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author roland
+ * @since 29.08.17
+ */
+public class IntegrationHandlerTest {
+
+
+    private IntegrationHandler handler;
+    private ClassInspector inspector;
+    private Validator validator;
+    private DataManager manager;
+
+    @Before
+    public void setup() {
+        manager = mock(DataManager.class);
+        validator = mock(Validator.class);
+        inspector = mock(ClassInspector.class);
+        handler = new IntegrationHandler(manager, validator, inspector);
+    }
+
+    @Test
+    public void filterOptions_simple() {
+        when(inspector.getPaths("twitter4j.Status")).thenReturn(Arrays.asList("paramA", "paramB"));
+        Integration integration =
+            createIntegrationFromDataShapes(dataShape(JAVA, "twitter4j.Status"),null,dataShape(NONE));
+
+        FilterOptions options = handler.getFilterOptions(integration, -1);
+        assertThat(options.getPaths()).hasSize(2).contains("paramA","paramB");
+    }
+
+    @Test
+    public void filterOptions_multipleOutputShapes() {
+        when(inspector.getPaths("twitter4j.Status")).thenReturn(Arrays.asList("paramA", "paramB"));
+        when(inspector.getPaths("blubber.bla")).thenReturn(Arrays.asList("paramY", "paramZ"));
+        Integration integration =
+            createIntegrationFromDataShapes(dataShape(JAVA, "blubber.bla"),null, dataShape(JAVA, "twitter4j.Status"));
+
+        assertThat(handler.getFilterOptions(integration, -1).getPaths())
+            .hasSize(2).contains("paramA", "paramB");
+
+        assertThat(handler.getFilterOptions(integration, 1).getPaths())
+            .hasSize(2).contains("paramY","paramZ");
+    }
+
+    @Test
+    public void filterOptions_noOutputShape() {
+        Integration integration =
+            createIntegrationFromDataShapes(dataShape(NONE), null);
+
+        FilterOptions options = handler.getFilterOptions(integration, -1);
+        assertThat(options.getPaths()).isEmpty();
+    }
+
+    private Integration createIntegrationFromDataShapes(DataShape... dataShapes) {
+        return new Integration.Builder().steps(steps(dataShapes)).build();
+    }
+
+    private List<SimpleStep> steps(DataShape ... dataShapes) {
+        List<SimpleStep> ret = new ArrayList<>();
+        for (DataShape shape : dataShapes) {
+            Action action = new Action.Builder().outputDataShape(shape).build();
+            ret.add(new SimpleStep.Builder().action(action).build());
+        }
+        return ret;
+    }
+
+    private DataShape dataShape(String kind) {
+        return dataShape(kind, null);
+    }
+
+    private DataShape dataShape(String kind, String type) {
+        return new DataShape.Builder().kind(kind).type(type).build();
+    }
+}

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.syndesis.rest.v1.handler;
 
 import java.util.ArrayList;


### PR DESCRIPTION
This is not needed since only the latest output shape is used now for filtering.

Still: only java types are supported for the fields (see ClassInspector). This queries the atlasmap service internally.

Fixes #517.