### PR TITLE
chore(metadata): Adds support for dynamic action properties

### DIFF
--- a/model/src/main/java/io/syndesis/model/connection/ActionPropertySuggestions.java
+++ b/model/src/main/java/io/syndesis/model/connection/ActionPropertySuggestions.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.connection;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import io.syndesis.model.connection.ActionPropertySuggestions.Deserializer;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(using = Deserializer.class)
+public interface ActionPropertySuggestions {
+
+    @Value.Immutable
+    @JsonDeserialize(builder = ActionPropertySuggestion.Builder.class)
+    interface ActionPropertySuggestion {
+
+        @SuppressWarnings("PMD.UseUtilityClass")
+        final class Builder extends ImmutableActionPropertySuggestion.Builder {
+
+            /* default */ static ActionPropertySuggestion of(final String value, final String displayValue) {
+                return new ActionPropertySuggestion.Builder().value(value).displayValue(displayValue).build();
+            }
+
+        }
+
+        String displayValue();
+
+        String value();
+
+    }
+
+    final class Builder extends ImmutableActionPropertySuggestions.Builder {
+
+        /* default */ Builder putValue(final String property, final ActionPropertySuggestion suggestion1,
+            final ActionPropertySuggestion... others) {
+            final List<ActionPropertySuggestion> propertySuggestions = new ArrayList<>(1 + others.length);
+            propertySuggestions.add(suggestion1);
+            propertySuggestions.addAll(Arrays.asList(others));
+
+            putValue(property, propertySuggestions);
+
+            return this;
+        }
+
+    }
+
+    final class Deserializer extends JsonDeserializer<ActionPropertySuggestions> {
+
+        private static final TypeReference<Map<String, List<ActionPropertySuggestion>>> TYPE = new TypeReference<Map<String, List<ActionPropertySuggestion>>>() {
+            // type token pattern
+        };
+
+        @Override
+        public ActionPropertySuggestions deserialize(final JsonParser p, final DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+            final Map<String, List<ActionPropertySuggestion>> suggestions = p.readValueAs(TYPE);
+
+            return new Builder().putAllValue(suggestions).build();
+        }
+
+    }
+
+    @JsonValue
+    Map<String, List<ActionPropertySuggestion>> value();
+
+}

--- a/model/src/main/java/io/syndesis/model/connection/Connector.java
+++ b/model/src/main/java/io/syndesis/model/connection/Connector.java
@@ -66,4 +66,9 @@ public interface Connector extends WithId<Connector>, WithName, WithProperties, 
     class Builder extends ImmutableConnector.Builder {
     }
 
+
+    default Optional<Action> actionById(String id) {
+        return getActions().stream().filter(a -> a.idEquals(id)).findFirst();
+    }
+
 }

--- a/model/src/test/java/io/syndesis/model/connection/ActionPropertySuggestionsTest.java
+++ b/model/src/test/java/io/syndesis/model/connection/ActionPropertySuggestionsTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.connection;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static io.syndesis.model.connection.ActionPropertySuggestions.ActionPropertySuggestion.Builder.of;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ActionPropertySuggestionsTest {
+
+    private final static JsonNode JSON = parse("/action-property-suggestions.json");
+
+    private final static ObjectMapper MAPPER = new ObjectMapper();
+
+    private final static ActionPropertySuggestions SUGGESTIONS = new ActionPropertySuggestions.Builder()
+        .putValue("property1", of("1value1", "1displayValue1"), of("1value2", "1displayValue2"))
+        .putValue("property2", of("2value1", "2displayValue1"), of("2value2", "2displayValue2")).build();
+
+    @Test
+    public void shouldDeserialize() throws IOException {
+        final ActionPropertySuggestions deserialized = MAPPER.readerFor(ActionPropertySuggestions.class)
+            .<ActionPropertySuggestions>readValue(JSON);
+        assertThat(deserialized).isEqualTo(SUGGESTIONS);
+    }
+
+    @Test
+    public void shouldSerialize() {
+        final JsonNode serialized = MAPPER.valueToTree(SUGGESTIONS);
+        assertThat(serialized).isEqualTo(JSON);
+    }
+
+    private static JsonNode parse(final String path) {
+        try {
+            return new ObjectMapper().readTree(ActionPropertySuggestionsTest.class.getResourceAsStream(path));
+        } catch (final IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+}

--- a/model/src/test/resources/action-property-suggestions.json
+++ b/model/src/test/resources/action-property-suggestions.json
@@ -1,0 +1,22 @@
+{
+  "property1": [
+    {
+      "displayValue": "1displayValue1",
+      "value": "1value1"
+    },
+    {
+      "displayValue": "1displayValue2",
+      "value": "1value2"
+    }
+  ],
+  "property2": [
+    {
+      "displayValue": "2displayValue1",
+      "value": "2value1"
+    },
+    {
+      "displayValue": "2displayValue2",
+      "value": "2value2"
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -696,6 +696,14 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>3.0.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock-standalone</artifactId>
+        <version>2.7.1</version>
+        <scope>test</scope>
       </dependency>
 
     </dependencies>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -431,6 +431,23 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <configuration>
+          <ignoredDependencies>
+            <!-- spring-cloud-starter BOM excludes all wiremock dependencies, so we bring in
+                 wiremock-standalone, which packages duplicate classes/resources already
+                 present in other dependencies. It's used only in tests so let's ignore it
+                 completely -->
+            <dependency>
+              <groupId>com.github.tomakehurst</groupId>
+              <artifactId>wiremock-standalone</artifactId>
+            </dependency>
+          </ignoredDependencies>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 
@@ -717,6 +734,11 @@
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <scope>test</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock-standalone</artifactId>
     </dependency>
 
   </dependencies>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -217,7 +217,14 @@
             <goals>
               <goal>reserve-network-port</goal>
             </goals>
-            <phase>pre-integration-test</phase>
+            <!--
+                phase used to be `pre-integration-test` which is a
+                proper phase for this, but it ended up being invoked
+                after process-exec-maven-plugin defined below, so the
+                reserved ports would not be defined, moving it to a
+                prior phase helped the issue
+            -->
+            <phase>process-test-resources</phase>
             <configuration>
               <portNames>
                 <portName>server.port</portName>

--- a/runtime/src/test/java/io/syndesis/runtime/action/ActionSuggestionsITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/action/ActionSuggestionsITCase.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.runtime.action;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import io.syndesis.model.connection.Action;
+import io.syndesis.model.connection.ActionDefinition;
+import io.syndesis.model.connection.ActionPropertySuggestions;
+import io.syndesis.model.connection.ActionPropertySuggestions.ActionPropertySuggestion;
+import io.syndesis.model.connection.ConfigurationProperty;
+import io.syndesis.model.connection.Connection;
+import io.syndesis.model.connection.Connector;
+import io.syndesis.runtime.BaseITCase;
+import io.syndesis.runtime.action.ActionSuggestionsITCase.TestConfigurationInitializer;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ContextConfiguration(initializers = TestConfigurationInitializer.class)
+@SuppressWarnings({"PMD.TooManyStaticImports", "PMD.ExcessiveImports"})
+public class ActionSuggestionsITCase extends BaseITCase {
+
+    private static final String CREATE_OR_UPDATE_ACTION_ID = "io.syndesis:salesforce-create-or-update-connector:latest";
+
+    @ClassRule
+    public static final WireMockRule WIREMOCK = new WireMockRule(wireMockConfig().dynamicPort());
+
+    private static final Action CREATE_OR_UPDATE_ACTION = new Action.Builder().id(CREATE_OR_UPDATE_ACTION_ID)
+        .definition(new ActionDefinition.Builder()
+            .withActionDefinitionStep("Select Salesforce object", "Select Salesforce object type to create",
+                b -> b.putProperty("sObjectName",
+                    new ConfigurationProperty.Builder()//
+                        .kind("parameter")//
+                        .displayName("Salesforce object type")//
+                        .group("common")//
+                        .required(true)//
+                        .type("string")//
+                        .javaType("java.lang.String")//
+                        .componentProperty(false)//
+                        .description("Salesforce object type to create")//
+                        .build()))
+            .withActionDefinitionStep("Select Identifier property",
+                "Select Salesforce property that will hold the uniquely identifying value of this object",
+                b -> b.putProperty("sObjectIdName",
+                    new ConfigurationProperty.Builder()//
+                        .kind("parameter")//
+                        .displayName("Identifier field name")//
+                        .group("common")//
+                        .required(true)//
+                        .type("string")//
+                        .javaType("java.lang.String")//
+                        .componentProperty(false)//
+                        .description("Unique field to hold the identifier value")//
+                        .build()))
+            .build())
+        .build();
+
+    private final ActionPropertySuggestion account = new ActionPropertySuggestion.Builder().value("Account")
+        .displayValue("Accounts").build();
+
+    private final String connectionId = UUID.randomUUID().toString();
+
+    private final ActionPropertySuggestion contact = new ActionPropertySuggestion.Builder().value("Contact")
+        .displayValue("Contacts").build();
+
+    private final ActionPropertySuggestion email = new ActionPropertySuggestion.Builder().value("Email")
+        .displayValue("E-mail address").build();
+
+    private final ActionPropertySuggestion id = new ActionPropertySuggestion.Builder().value("Id")
+        .displayValue("Identifier").build();
+
+    private final ActionPropertySuggestion twitterScreenName = new ActionPropertySuggestion.Builder()
+        .value("TwitterScreenName__c").displayValue("Twitter Screen Name").build();
+
+    public static class TestConfigurationInitializer
+        implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(final ConfigurableApplicationContext applicationContext) {
+            final ConfigurableEnvironment environment = applicationContext.getEnvironment();
+            environment.getPropertySources().addFirst(new MapPropertySource("test-source",
+                Collections.singletonMap("verifier.service", "localhost:" + WIREMOCK.port())));
+        }
+
+    }
+
+    @Before
+    public void setupConnection() {
+        dataManager.create(new Connection.Builder().id(connectionId).connectorId("salesforce")
+            .putConfiguredProperty("clientId", "a-client-id").build());
+
+        final Connector existingSalesforceConnector = dataManager.fetch(Connector.class, "salesforce");
+
+        final Connector withCreateOrUpdateAction = new Connector.Builder().createFrom(existingSalesforceConnector)
+            .addAction(CREATE_OR_UPDATE_ACTION).build();
+
+        dataManager.update(withCreateOrUpdateAction);
+    }
+
+    @Before
+    public void setupMocks() {
+        stubFor(WireMock.post(urlEqualTo("/api/v1/action/properties/salesforce"))//
+            .withHeader("Accept", equalTo("application/json"))//
+            .withRequestBody(equalToJson("{\"clientId\":\"a-client-id\",\"sObjectName\":null,\"sObjectIdName\":null}"))
+            .willReturn(aResponse()//
+                .withStatus(200)//
+                .withHeader("Content-Type", "application/json")//
+                .withBody(read("/verifier-response-salesforce-no-properties.json"))));
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/action/properties/salesforce"))//
+            .withHeader("Accept", equalTo("application/json"))//
+            .withRequestBody(
+                equalToJson("{\"clientId\":\"a-client-id\",\"sObjectName\":\"Contact\",\"sObjectIdName\":null}"))
+            .willReturn(aResponse()//
+                .withStatus(200)//
+                .withHeader("Content-Type", "application/json")//
+                .withBody(read("/verifier-response-salesforce-type-contact.json"))));
+    }
+
+    @Test
+    public void shouldOfferDynamicActionPropertySuggestions() {
+        final ResponseEntity<ActionPropertySuggestions> firstResponse = get(
+            "/api/v1/connections/" + connectionId + "/actions/" + CREATE_OR_UPDATE_ACTION_ID + "/properties",
+            ActionPropertySuggestions.class);
+
+        final ActionPropertySuggestions firstSuggestion = new ActionPropertySuggestions.Builder()
+            .putValue("sObjectName", Arrays.asList(account, contact)).build();
+        assertThat(firstResponse.getBody()).isEqualTo(firstSuggestion);
+
+        final ResponseEntity<ActionPropertySuggestions> secondResponse = get("/api/v1/connections/" + connectionId
+            + "/actions/" + CREATE_OR_UPDATE_ACTION_ID + "/properties?sObjectName=Contact",
+            ActionPropertySuggestions.class);
+
+        final ActionPropertySuggestions secondSuggestion = new ActionPropertySuggestions.Builder()
+            .putValue("sObjectIdName", Arrays.asList(id, email, twitterScreenName)).build();
+        assertThat(secondResponse.getBody()).isEqualTo(secondSuggestion);
+    }
+
+    private static String read(final String path) {
+        try {
+            return String.join("",
+                Files.readAllLines(Paths.get(ActionSuggestionsITCase.class.getResource(path).toURI())));
+        } catch (IOException | URISyntaxException e) {
+            throw new IllegalArgumentException("Unable to read from path: " + path, e);
+        }
+    }
+}

--- a/runtime/src/test/resources/verifier-response-salesforce-no-properties.json
+++ b/runtime/src/test/resources/verifier-response-salesforce-no-properties.json
@@ -1,0 +1,12 @@
+{
+  "sObjectName": [
+    {
+      "value": "Account",
+      "displayValue": "Accounts"
+    },
+    {
+      "value": "Contact",
+      "displayValue": "Contacts"
+    }
+  ]
+}

--- a/runtime/src/test/resources/verifier-response-salesforce-type-contact.json
+++ b/runtime/src/test/resources/verifier-response-salesforce-type-contact.json
@@ -1,0 +1,16 @@
+{
+  "sObjectIdName": [
+    {
+      "value": "Id",
+      "displayValue": "Identifier"
+    },
+    {
+      "value": "Email",
+      "displayValue": "E-mail address"
+    },
+    {
+      "value": "TwitterScreenName__c",
+      "displayValue": "Twitter Screen Name"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `/api/v1/connections/{connectionId}/actions/{actionId}/properties`
endpoint that responds to GET request and in the query parameters
expects any action property - value pairs that have been selected by the
user and offers suggestions as to values of other action properties.

The implementation delegates to `syndesis-verifier` and the endpoint
created in syndesision/syndesis-verifier#18[1] that in turn delegates
to Camel Metadata extension.

[1] https://github.com/syndesisio/syndesis-verifier/pull/18