### PR TITLE
fix(oauth): Adds more detailed status of OAuth ...

### DIFF
--- a/rest/src/main/java/io/syndesis/rest/v1/handler/credential/CallbackStatus.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/credential/CallbackStatus.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.credential;
+
+final class CallbackStatus {
+
+    private final String connectorId;
+
+    private final String message;
+
+    private final Status status;
+
+    enum Status {
+        FAILURE, SUCCESS
+    }
+
+    private CallbackStatus(final Status status, final String connectorId, final String message) {
+        this.status = status;
+        this.connectorId = connectorId;
+        this.message = message;
+    }
+
+    public String getConnectorId() {
+        return connectorId;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public static CallbackStatus failure(final String connectorId, final String message) {
+        return new CallbackStatus(Status.FAILURE, connectorId, message);
+    }
+
+    public static CallbackStatus success(final String connectorId, final String message) {
+        return new CallbackStatus(Status.SUCCESS, connectorId, message);
+    }
+
+    @Override
+    public String toString() {
+        return "Connector: " + connectorId + ", status: " + status + ", message: " + message;
+    }
+}

--- a/rest/src/main/java/io/syndesis/rest/v1/util/Urls.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/util/Urls.java
@@ -49,6 +49,17 @@ public final class Urls {
         }
     }
 
+    public static URI appHome(final HttpServletRequest httpRequest) {
+        final URI current = currentUri(httpRequest);
+
+        try {
+            return new URI(current.getScheme(), null, current.getHost(), current.getPort(), null, null, null);
+        } catch (final URISyntaxException e) {
+            throw new IllegalArgumentException(
+                "Unable to generate app home URI based on the current (`" + current + "`)", e);
+        }
+    }
+
     public static URI apiBase(final HttpServletRequest httpRequest) {
         final URI current = currentUri(httpRequest);
 

--- a/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/credential/CredentialITCase.java
@@ -218,7 +218,7 @@ public class CredentialITCase extends BaseITCase {
             .isEqualTo(HttpStatus.TEMPORARY_REDIRECT);
         assertThat(callbackResponse.hasBody()).as("Should not contain HTTP body").isFalse();
         assertThat(callbackResponse.getHeaders().getLocation().toString())
-            .matches("http.?://localhost:[0-9]*/api/v1/ui#state");
+            .matches("http.?://localhost:[0-9]*/api/v1/ui#%7B%22connectorId%22:%22test-provider%22,%22message%22:%22Successfully%20authorized%20Syndesis's%20access%22,%22status%22:%22SUCCESS%22%7D");
 
         final List<String> receivedCookies = callbackResponse.getHeaders().get("Set-Cookie");
         assertThat(receivedCookies).hasSize(1);


### PR DESCRIPTION
...callback in the fragment

This would help the UI know if OAuth authorization succeeded or not. The
fragment of the given `returnUrl` is now ignored and replaced with a URL
encoded JSON that resembles something like:

    #%7B%22connectorId%22:%22test-provider%22,%22message%22:%22Successfully%20authorized%20Syndesis's%20access%22,%22status%22:%22SUCCESS%22%7D

(for successful authorization). Which translates to the following JSON:

    {
      "connectorId: "test-provider", // can be "twitter" or "salesforce"
      "message": "Successfully authorized Syndesis's access",
      "status": "SUCCESS"
    }

Status can also be "FAILURE" indication, well, failure in authorization,
the message offers a bit more detail.

Note(1): connectorId JSON property can be `null`, for instance if the
callback was invoked without `cred-` cookies, in that case there is no
flow to look for connectorId.

Note(2): The redirect might lead to the root of the application (i.e to
`/`) for the same reason.

Fixes #514