### PR TITLE
fix(validation): Don't detect updated unique properties as non unique

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -122,6 +122,12 @@
       <artifactId>assertj-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/dao/src/main/java/io/syndesis/dao/manager/DataAccessObject.java
+++ b/dao/src/main/java/io/syndesis/dao/manager/DataAccessObject.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.dao.manager;
 
+import java.util.Set;
+
 import io.syndesis.model.ListResult;
 import io.syndesis.model.WithId;
 
@@ -40,13 +42,13 @@ public interface DataAccessObject<T extends WithId<T>> {
     T fetch(String id);
 
     /**
-     * Determines existence of a object having a property with the given value.
+     * Fetches all ids that have the specified property with the given value.
      *
      * @param property      The name of the property.
      * @param propertyValue The value of the property.
-     * @return              True if object with such property-value pair exists.
+     * @return              All identifiers with specified property and value combination.
      */
-    boolean existsWithPropertyValue(String property, String propertyValue);
+    Set<String> fetchIdsByPropertyValue(String property, String propertyValue);
 
     /**
      * Fetches a {@link ListResult} containing all entities.

--- a/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
+++ b/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -161,8 +162,8 @@ public class DataManager implements DataAccessObjectRegistry {
         return value;
     }
 
-    public <T extends WithId<T>> boolean existsWithPropertyValue(Class<T> model, String property, String value) {
-        return doWithDataAccessObject(model, d -> d.existsWithPropertyValue(property, value));
+    public <T extends WithId<T>> Set<String> fetchIdsByPropertyValue(Class<T> model, String property, String value) {
+        return doWithDataAccessObject(model, d -> d.fetchIdsByPropertyValue(property, value));
     }
 
     public <T extends WithId<T>> T create(final T entity) {

--- a/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
@@ -17,6 +17,7 @@ package io.syndesis.dao;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Optional;
 
 import io.syndesis.core.Json;
@@ -131,16 +132,16 @@ public class DataManagerTest {
     }
 
     @Test
-    public void shouldAscertainIfPropertyValuePairExists() {
+    public void shouldFetchIdsByPropertyValuePairs() {
         @SuppressWarnings("unchecked")
         final DataAccessObject<Connector> connectorDao = mock(DataAccessObject.class);
         when(connectorDao.getType()).thenReturn(Connector.class);
         dataManager.registerDataAccessObject(connectorDao);
 
-        when(connectorDao.existsWithPropertyValue("prop", "exists")).thenReturn(true);
-        when(connectorDao.existsWithPropertyValue("prop", "not")).thenReturn(false);
+        when(connectorDao.fetchIdsByPropertyValue("prop", "exists")).thenReturn(Collections.singleton("id"));
+        when(connectorDao.fetchIdsByPropertyValue("prop", "not")).thenReturn(Collections.emptySet());
 
-        assertThat(dataManager.existsWithPropertyValue(Connector.class, "prop", "exists")).isTrue();
-        assertThat(dataManager.existsWithPropertyValue(Connector.class, "prop", "not")).isFalse();
+        assertThat(dataManager.fetchIdsByPropertyValue(Connector.class, "prop", "exists")).containsOnly("id");
+        assertThat(dataManager.fetchIdsByPropertyValue(Connector.class, "prop", "not")).isEmpty();
     }
 }

--- a/dao/src/test/java/io/syndesis/dao/validation/UniquePropertyValidatorTest.java
+++ b/dao/src/test/java/io/syndesis/dao/validation/UniquePropertyValidatorTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.dao.validation;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import javax.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
+import javax.validation.ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext;
+
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.model.connection.Connection;
+import io.syndesis.model.validation.UniqueProperty;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class UniquePropertyValidatorTest {
+
+    @Parameter(0)
+    public Connection connection;
+
+    @Parameter(1)
+    public boolean validity;
+
+    private final UniquePropertyValidator validator = new UniquePropertyValidator();
+
+    public UniquePropertyValidatorTest() {
+        validator.initialize(Connection.class.getAnnotation(UniqueProperty.class));
+    }
+
+    @Before
+    public void setupMocks() {
+        validator.dataManager = mock(DataManager.class);
+
+        when(validator.dataManager.fetchIdsByPropertyValue(Connection.class, "name", "Existing"))
+            .thenReturn(new HashSet<>(Arrays.asList("same")));
+    }
+
+    @Test
+    public void shouldAscertainPropertyUniqueness() {
+        final HibernateConstraintValidatorContext context = mock(HibernateConstraintValidatorContext.class);
+        when(context.unwrap(HibernateConstraintValidatorContext.class)).thenReturn(context);
+        when(context.addExpressionVariable(eq("nonUnique"), anyString())).thenReturn(context);
+        when(context.getDefaultConstraintMessageTemplate()).thenReturn("template");
+        final ConstraintViolationBuilder builder = mock(ConstraintViolationBuilder.class);
+        when(context.buildConstraintViolationWithTemplate("template")).thenReturn(builder);
+        when(builder.addPropertyNode(anyString())).thenReturn(mock(NodeBuilderCustomizableContext.class));
+
+        assertThat(validator.isValid(connection, context)).isEqualTo(validity);
+    }
+
+    @Parameters
+    public static Iterable<Object[]> parameters() {
+
+        final Connection existingNameNoId = new Connection.Builder().name("Existing").build();
+
+        final Connection existingNameWithSameId = new Connection.Builder().name("Existing").id("same").build();
+
+        final Connection existingNameWithDifferentId = new Connection.Builder().name("Existing").id("different")
+            .build();
+
+        final Connection uniqueNameNoId = new Connection.Builder().name("Unique").build();
+
+        return Arrays.asList(//
+            new Object[] {existingNameNoId, false}, //
+            new Object[] {existingNameWithSameId, true}, //
+            new Object[] {existingNameWithDifferentId, false}, //
+            new Object[] {uniqueNameNoId, true}//
+        );
+    }
+}

--- a/jsondb/src/main/java/io/syndesis/jsondb/JsonDB.java
+++ b/jsondb/src/main/java/io/syndesis/jsondb/JsonDB.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -42,7 +43,11 @@ public interface JsonDB {
      */
     boolean exists(String path);
 
-    boolean existsPropertyValue(String collectionPath, String property, String value);
+    /**
+     * Fetches all paths that hold the property with the given value.
+     * The returned paths are in the form of {@code /<collection>/:<id>}.
+     */
+    Set<String> fetchIdsByPropertyValue(String collectionPath, String property, String value);
 
     /**
      * Generates a sortable unique id as described at:

--- a/jsondb/src/main/java/io/syndesis/jsondb/dao/JsonDbDao.java
+++ b/jsondb/src/main/java/io/syndesis/jsondb/dao/JsonDbDao.java
@@ -18,6 +18,8 @@ package io.syndesis.jsondb.dao;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
@@ -82,8 +84,9 @@ public abstract class JsonDbDao<T extends WithId<T>> implements DataAccessObject
     }
 
     @Override
-    public boolean existsWithPropertyValue(final String property, final String propertyValue) {
-        return jsondb.existsPropertyValue(getCollectionPath(), property.replace('.', '/'), propertyValue);
+    public Set<String> fetchIdsByPropertyValue(final String property, final String propertyValue) {
+        return jsondb.fetchIdsByPropertyValue(getCollectionPath(), property.replace('.', '/'), propertyValue)
+            .stream().map(path -> path.substring(path.indexOf(':') + 1)).collect(Collectors.toSet());
     }
 
     @Override

--- a/jsondb/src/test/java/io/syndesis/jsondb/impl/JsonDBTest.java
+++ b/jsondb/src/test/java/io/syndesis/jsondb/impl/JsonDBTest.java
@@ -360,8 +360,8 @@ public class JsonDBTest {
     public void shouldAscertainPropertyPairExistence() {
         jsondb.set("/pair/:id", "{\"key\": \"value\"}");
 
-        assertThat(jsondb.existsPropertyValue("/pair", "key", "value")).isTrue();
-        assertThat(jsondb.existsPropertyValue("/pair", "key", "nope")).isFalse();
+        assertThat(jsondb.fetchIdsByPropertyValue("/pair", "key", "value")).containsOnly("/pair/:id");
+        assertThat(jsondb.fetchIdsByPropertyValue("/pair", "key", "nope")).isEmpty();
     }
 
     private String load(String file) throws IOException {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -766,6 +766,9 @@
   </rule>
   <rule ref="rulesets/java/imports.xml/TooManyStaticImports">
     <priority>5</priority>
+    <properties>
+      <property name="maximumStaticImports" value="7" />
+    </properties>
   </rule>
   <rule ref="rulesets/java/design.xml/UncommentedEmptyMethodBody">
     <priority>3</priority>

--- a/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
@@ -163,6 +163,10 @@ public abstract class BaseITCase {
         return http(HttpMethod.POST, url, body, responseClass, token, new HttpHeaders(), expectedStatus);
     }
 
+    protected <T> ResponseEntity<T> put(String url, Object body, Class<T> responseClass, String token, HttpStatus expectedStatus) {
+        return http(HttpMethod.PUT, url, body, responseClass, token, new HttpHeaders(), expectedStatus);
+    }
+
     protected <T> ResponseEntity<T> http(HttpMethod method, String url, Object body, Class<T> responseClass, String token, HttpStatus expectedStatus) {
         return http(method, url, body, responseClass, token, new HttpHeaders(), expectedStatus);
     }

--- a/runtime/src/test/java/io/syndesis/runtime/ConnectionsITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/ConnectionsITCase.java
@@ -16,6 +16,7 @@
 package io.syndesis.runtime;
 
 import java.util.List;
+import java.util.UUID;
 
 import io.syndesis.model.connection.Connection;
 import io.syndesis.rest.v1.operations.Violation;
@@ -33,6 +34,8 @@ public class ConnectionsITCase extends BaseITCase {
     private final static ParameterizedTypeReference<List<Violation>> RESPONSE_TYPE = new ParameterizedTypeReference<List<Violation>>() {
         // defining type parameters
     };
+
+    private final String id = UUID.randomUUID().toString();
 
     @Test
     public void emptyNamesShouldNotBeAllowed() {
@@ -71,9 +74,19 @@ public class ConnectionsITCase extends BaseITCase {
 
     @Before
     public void preexistingConnection() {
-        final Connection connection = new Connection.Builder().name("Existing connection").build();
+        final Connection connection = new Connection.Builder().name("Existing connection").id(id).build();
 
         dataManager.create(connection);
+    }
+
+    @Test
+    public void shouldAllowConnectionUpdateWithExistingName() {
+        final Connection connection = new Connection.Builder().name("Existing connection").id(id).build();
+
+        final ResponseEntity<Void> got = put("/api/v1/connections/" + id, connection, Void.class,
+            tokenRule.validToken(), HttpStatus.NO_CONTENT);
+
+        assertThat(got.getBody()).isNull();
     }
 
     @Test
@@ -107,5 +120,4 @@ public class ConnectionsITCase extends BaseITCase {
         assertThat(got.getBody()).containsExactly(new Violation.Builder().property("create.obj.name")
             .error("UniqueProperty").message("Value 'Existing connection' is not unique").build());
     }
-
 }


### PR DESCRIPTION
The unique validation would look for a presence of a value and solely
based on that would declare it unique or non-unique. The problem with
that is, of course, that updates no longer work as it would detect it's
own value in the database and declare it non-unique. So one could create
but not update without changing the name.
This changes the lookup to return all IDs that have that unique property
with the specified value, and then if the ID of the object is contained
in those will not declare that value as non-unique.

Fixes #552