### PR TITLE
fix(metadata): Adds backward compatibility for action properties

### DIFF
--- a/model/src/main/java/io/syndesis/model/connection/Action.java
+++ b/model/src/main/java/io/syndesis/model/connection/Action.java
@@ -16,7 +16,14 @@
 package io.syndesis.model.connection;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.syndesis.model.Kind;
@@ -27,6 +34,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = Action.Builder.class)
+@JsonIgnoreProperties(value = "properties", allowGetters = true)
 public interface Action extends WithId<Action>, WithName, Serializable {
 
     @Override
@@ -54,6 +62,15 @@ public interface Action extends WithId<Action>, WithName, Serializable {
     class Builder extends ImmutableAction.Builder {
     }
 
-    ActionDefinition definition();
+    ActionDefinition getDefinition();
 
+    @Deprecated
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    default Map<String, ConfigurationProperty> getProperties() {
+        return Optional.ofNullable(getDefinition())
+            .map(definition -> definition.getPropertyDefinitionSteps().stream()
+                .flatMap(step -> step.getProperties().entrySet().stream())
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue)))
+            .orElse(Collections.emptyMap());
+    }
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
@@ -55,7 +55,7 @@ public class ConnectionActionHandler {
 
         final Optional<Action> action = actions.stream().filter(a -> a.idEquals(id)).findAny();
 
-        return action.map(Action::definition).orElseThrow(() -> new EntityNotFoundException("Action with id: " + id));
+        return action.map(Action::getDefinition).orElseThrow(() -> new EntityNotFoundException("Action with id: " + id));
     }
 
 }


### PR DESCRIPTION
With #535 action properties were moved from being directly accessible on
`Action` to a `ActionDefinition` and grouped together within
`ActionDefinitionStep`s. In order to keep backward compatibility we
could expose action properties directly on Action also.