### PR TITLE
fic(filter): Changed back to simple for storing the expression

### DIFF
--- a/dao/src/main/resources/io/syndesis/dao/demo-data.json
+++ b/dao/src/main/resources/io/syndesis/dao/demo-data.json
@@ -114,7 +114,7 @@
           "id": "2",
           "stepKind": "filter",
           "configuredProperties": {
-            "filter": "in.body contains \"#RHSummit\""
+            "filter": "${body.text} contains \"#RHSummit\""
             }
         },{
           "id": "3",

--- a/model/src/main/java/io/syndesis/model/filter/FilterRule.java
+++ b/model/src/main/java/io/syndesis/model/filter/FilterRule.java
@@ -15,9 +15,6 @@
  */
 package io.syndesis.model.filter;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 
@@ -57,10 +54,7 @@ public interface FilterRule {
     }
 
     default String convertPathToSimple() {
-        return String.format("${body%s}",
-                             Arrays.stream(getPath().split("\\."))
-                                   .map(s -> "[" + s + "]")
-                                   .collect(Collectors.joining()));
+        return String.format("${body.%s}",getPath());
     }
 
     class Builder extends ImmutableFilterRule.Builder { }

--- a/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
+++ b/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
@@ -37,14 +37,14 @@ public class StepDeserializerTest {
         assertEquals(FilterPredicate.AND, FilterPredicate.valueOf(props.get("predicate").toUpperCase(Locale.US)));
         assertNotNull(props.get("rules"));
         assertEquals("rule-filter", step.getStepKind());
-        assertEquals("${body[text]} == 'antman' && ${body[kind]} =~ 'DC Comics'", step.getFilterExpression());
+        assertEquals("${body.text} == 'antman' && ${body.kind} =~ 'DC Comics'", step.getFilterExpression());
     }
 
     @Test
     public void shouldDeserializeExpressionFilterStep() throws Exception {
         ExpressionFilterStep step = readTestFilter("/filter-step.json");
         ExpressionFilterStep exprFilterStep = (ExpressionFilterStep) step;
-        String expr = "${body[text]} contains '#RHSummit'";
+        String expr = "${body.text} contains '#RHSummit'";
         assertEquals("2", exprFilterStep.getId().get());
         assertEquals("filter", exprFilterStep.getStepKind());
         assertEquals(expr, exprFilterStep.getFilterExpression());

--- a/model/src/test/resources/filter-step.json
+++ b/model/src/test/resources/filter-step.json
@@ -3,7 +3,7 @@
   "kind": "Step",
   "stepKind": "filter",
   "configuredProperties": {
-    "filter": "${body[text]} contains '#RHSummit'"
+    "filter": "${body.text} contains '#RHSummit'"
   }
 }
 

--- a/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
@@ -283,7 +283,7 @@ public class DefaultProjectGeneratorTest {
 
         Step step3 = new SimpleStep.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(Collections.emptyMap()).build()).configuredProperties(map("httpUri", "http://localhost:8080/bye")).action(new Action.Builder().connectorId("http").camelConnectorPrefix("http-post").camelConnectorGAV("io.syndesis:http-post-connector:0.4.5").build()).build();
 
-        Step step4 = new ExpressionFilterStep.Builder().configuredProperties(map("filter", "${body[germanSecondLeagueChampion]} equals 'FCN'")).build();
+        Step step4 = new ExpressionFilterStep.Builder().configuredProperties(map("filter", "${body.germanSecondLeagueChampion} equals 'FCN'")).build();
 
         GenerateProjectRequest request = new GenerateProjectRequest.Builder()
             .gitHubUserLogin("noob")

--- a/project-generator/src/test/java/io/syndesis/project/converter/visitor/RuleFilterStepVisitorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/visitor/RuleFilterStepVisitorTest.java
@@ -39,7 +39,7 @@ public class RuleFilterStepVisitorTest {
             .build();
 
         // Reading notes: Unit tests are like personal diaries. Feel honoured when you have the chance to be part of them ;-)
-        assertEquals("${body[person][name]} == 'Ioannis' && ${body[person][favoriteDrinks]} contains 'Gin'", step.getFilterExpression());
+        assertEquals("${body.person.name} == 'Ioannis' && ${body.person.favoriteDrinks} contains 'Gin'", step.getFilterExpression());
     }
 
 }

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-filter-syndesis.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-filter-syndesis.yml
@@ -4,9 +4,9 @@ flows:
   - kind: endpoint
     uri: periodic-timer:every?period=5000
   - kind: filter
-    expression: ${body[in][header][counter]} > '10'
+    expression: ${body.in.header.counter} > '10'
     steps:
     - kind: endpoint
       uri: http-post?httpUri=http://localhost:8080/bye
     - kind: filter
-      expression: ${body[germanSecondLeagueChampion]} equals 'FCN'
+      expression: ${body.germanSecondLeagueChampion} equals 'FCN'


### PR DESCRIPTION
I mean simple with '.' notation to reach attributes. These would
be converted on the fly to '[..]' OGNL map access when a JSON document is moved through the route.