### PR TITLE
chore(tags): Set properties via tags

### DIFF
--- a/model/src/main/java/io/syndesis/model/WithProperties.java
+++ b/model/src/main/java/io/syndesis/model/WithProperties.java
@@ -15,21 +15,26 @@
  */
 package io.syndesis.model;
 
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.syndesis.model.connection.ConfigurationProperty;
 import io.syndesis.model.connection.Connector;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 public interface WithProperties {
 
     @SuppressFBWarnings("SE_BAD_FIELD")
     Map<String, ConfigurationProperty> getProperties();
+
+    Map<String, String> getConfiguredProperties();
 
     @JsonIgnore
     default Predicate<Map.Entry<String, String>> isEndpointProperty() {
@@ -108,4 +113,27 @@ public interface WithProperties {
             .filter(isSecret())
             .collect(Collectors.toMap(e -> e.getKey(), e -> valueConverter.apply(e)));
     }
+
+    /**
+     * Returns first property entry tagged with the given tag.
+     *
+     * @param tag               The looked after tag
+     * @return                  First property tagged with the supplied tag, if any
+     */
+    default Optional<Entry<String, ConfigurationProperty>> propertyEntryTaggedWith(final String tag) {
+        return getProperties().entrySet().stream().filter(entry -> entry.getValue().getTags().contains(tag))
+            .findFirst();
+    }
+
+    /**
+     * Returns first property tagged with the given tag.
+     *
+     * @param properties        The properties
+     * @param tag               The looked after tag
+     * @return                  First property tagged with the supplied tag, if any
+     */
+    default Optional<String> propertyTaggedWith(final Map<String, String> properties, final String tag) {
+        return propertyEntryTaggedWith(tag).map(entry -> properties.get(entry.getKey()));
+    }
+
 }

--- a/model/src/main/java/io/syndesis/model/connection/Connector.java
+++ b/model/src/main/java/io/syndesis/model/connection/Connector.java
@@ -51,6 +51,7 @@ public interface Connector extends WithId<Connector>, WithName, WithProperties, 
 
     List<Action> getActions();
 
+    @Override
     Map<String, String> getConfiguredProperties();
 
     @Override
@@ -62,13 +63,18 @@ public interface Connector extends WithId<Connector>, WithName, WithProperties, 
         return new Builder().createFrom(this);
     }
 
-
-    class Builder extends ImmutableConnector.Builder {
+    class Builder extends ImmutableConnector.Builder implements WithPropertiesBuilder<Builder> {
+        public Builder putOrRemoveConfiguredPropertyTaggedWith(final String tag, final String value) {
+            return putOrRemoveConfiguredPropertyTaggedWith(this, tag, value);
+        }
     }
-
 
     default Optional<Action> actionById(String id) {
         return getActions().stream().filter(a -> a.idEquals(id)).findFirst();
+    }
+
+    default Optional<String> propertyTaggedWith(final String tag) {
+        return propertyTaggedWith(getConfiguredProperties(), tag);
     }
 
 }

--- a/model/src/main/java/io/syndesis/model/connection/WithPropertiesBuilder.java
+++ b/model/src/main/java/io/syndesis/model/connection/WithPropertiesBuilder.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.connection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.syndesis.model.WithProperties;
+
+interface WithPropertiesBuilder<T extends WithPropertiesBuilder> {
+
+    WithProperties build();
+
+    /**
+     * Either sets or removes the property depending on if the given value is
+     * {@code null}.
+     *
+     * @param properties The properties
+     * @param key Property key
+     * @param value The value to set the property to, if null property will be
+     *            removed
+     * @return The previous value of the property, if any
+     */
+    default String putOrRemoveProperty(final Map<String, String> properties, final String key, final String value) {
+        if (value == null) {
+            return properties.remove(key);
+        }
+
+        return properties.put(key, value);
+    }
+
+    /**
+     * Sets property tagged with the given tag to the supplied value
+     *
+     * @param properties The properties
+     * @param tag The looked after tag
+     * @param value The value to set the property to
+     * @return The previous value of the property, if any
+     */
+    default T putOrRemoveConfiguredPropertyTaggedWith(final WithPropertiesBuilder<T> builder, final String tag,
+        final String value) {
+        final WithProperties withProperties = builder.build();
+        final Map<String, String> configuredProperties = withProperties.getConfiguredProperties();
+
+        final Map<String, String> mutableCopy = new HashMap<>(configuredProperties);
+
+        withProperties.propertyEntryTaggedWith(tag)
+            .map(entry -> putOrRemoveProperty(mutableCopy, entry.getKey(), value));
+
+        return builder.configuredProperties(mutableCopy);
+    }
+
+    T configuredProperties(Map<String, ? extends String> properties);
+}

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -116,9 +116,6 @@
   <rule ref="rulesets/java/imports.xml/UnnecessaryFullyQualifiedName">
     <priority>4</priority>
   </rule>
-  <rule ref="rulesets/java/controversial.xml/UseConcurrentHashMap">
-    <priority>5</priority>
-  </rule>
   <rule ref="rulesets/java/comments.xml/CommentContent">
     <priority>4</priority>
   </rule>


### PR DESCRIPTION
This allows properties being set via tags. Useful when the name of the
property is not known, but the tag is unique (enough) to use it to set
the property.