### PR TITLE
fix(credentials): Error handling in OAuth flows

### DIFF
--- a/credential/pom.xml
+++ b/credential/pom.xml
@@ -111,6 +111,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
@@ -118,11 +123,6 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- === Supported services ============================================================== -->

--- a/credential/src/main/java/io/syndesis/credential/CredentialFlowState.java
+++ b/credential/src/main/java/io/syndesis/credential/CredentialFlowState.java
@@ -16,11 +16,11 @@
 package io.syndesis.credential;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -39,6 +39,12 @@ public interface CredentialFlowState {
 
     interface Builder {
 
+        @FunctionalInterface
+        interface Restorer
+            extends BiFunction<List<javax.ws.rs.core.Cookie>, Class<CredentialFlowState>, Set<CredentialFlowState>> {
+            // inherits BiFunction::apply
+        }
+
         CredentialFlowState build();
 
         Builder key(String key);
@@ -51,10 +57,8 @@ public interface CredentialFlowState {
 
         Builder withAll(CredentialFlowState state);
 
-        static Stream<CredentialFlowState> restoreFrom(
-            final BiFunction<javax.ws.rs.core.Cookie, Class<CredentialFlowState>, CredentialFlowState> restore,
-            final HttpServletRequest request, final HttpServletResponse response) {
-            return CredentialFlowStateHelper.restoreFrom(restore, request, response);
+        static Set<CredentialFlowState> restoreFrom(final Restorer restorer, final HttpServletRequest request) {
+            return CredentialFlowStateHelper.restoreFrom(restorer, request);
         }
 
     }

--- a/credential/src/main/java/io/syndesis/credential/OAuth1CredentialFlowState.java
+++ b/credential/src/main/java/io/syndesis/credential/OAuth1CredentialFlowState.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.Converter;
 
+import org.apache.commons.lang3.StringUtils;
 import org.immutables.value.Value;
 import org.springframework.social.oauth1.OAuthToken;
 
@@ -85,6 +86,10 @@ public interface OAuth1CredentialFlowState extends CredentialFlowState {
     @Override
     default CredentialFlowState updateFrom(final HttpServletRequest request) {
         final String verifier = request.getParameter("oauth_verifier");
+
+        if (StringUtils.isEmpty(verifier)) {
+            throw new IllegalArgumentException("Did not receive OAuth oauth_verifier in request parameters");
+        }
 
         return new OAuth1CredentialFlowState.Builder().createFrom(this).verifier(verifier).build();
     }

--- a/credential/src/main/java/io/syndesis/credential/OAuth2CredentialFlowState.java
+++ b/credential/src/main/java/io/syndesis/credential/OAuth2CredentialFlowState.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.Converter;
 
+import org.apache.commons.lang3.StringUtils;
 import org.immutables.value.Value;
 import org.springframework.social.oauth1.OAuthToken;
 import org.springframework.social.oauth2.AccessGrant;
@@ -89,6 +90,10 @@ public interface OAuth2CredentialFlowState extends CredentialFlowState {
     @Override
     default CredentialFlowState updateFrom(final HttpServletRequest request) {
         final String code = request.getParameter("code");
+
+        if (StringUtils.isEmpty(code)) {
+            throw new IllegalArgumentException("Did not receive OAuth code in request parameters");
+        }
 
         return new OAuth2CredentialFlowState.Builder().createFrom(this).code(code).build();
     }

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -138,9 +138,9 @@
     <priority>3</priority>
   </rule>
   <rule ref="rulesets/java/junit.xml/JUnitTestContainsTooManyAsserts">
-    <priority>3</priority>
+    <priority>5</priority>
     <properties>
-      <property name="maximumAsserts" value="3" />
+      <property name="maximumAsserts" value="5" />
     </properties>
   </rule>
   <rule ref="rulesets/java/strings.xml/InefficientEmptyStringCheck">


### PR DESCRIPTION
This changes the way credential state cookies are handled so when the
flow is unsuccessful most recent state is considered to contain
providerId (connectorId) and returnUrl. That makes the UI receive proper
callback.

Fixes #557, #464, #509