### PR TITLE
fix(metadata): Ignore unknown connector properties

### DIFF
--- a/model/src/main/java/io/syndesis/model/connection/ActionDefinition.java
+++ b/model/src/main/java/io/syndesis/model/connection/ActionDefinition.java
@@ -61,7 +61,7 @@ public interface ActionDefinition extends Serializable {
             return this;
         }
 
-        public Builder withConfigurationProperty(final String propertyName,
+        public Builder replaceConfigurationProperty(final String propertyName,
             final Consumer<ConfigurationProperty.Builder> configurationPropertyConfigurator) {
             final ActionDefinition definition = build();
             final List<ActionDefinitionStep> steps = definition.getPropertyDefinitionSteps();
@@ -79,7 +79,8 @@ public interface ActionDefinition extends Serializable {
             }
 
             if (step == null) {
-                throw new IllegalArgumentException("Unknown property: " + propertyName);
+                // found no property to replace, lets just ignore it
+                return this;
             }
 
             final ConfigurationProperty configurationProperty = step.getProperties().get(propertyName);

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
@@ -102,7 +102,7 @@ public class ConnectionActionHandler {
             .post(Entity.entity(parameters, MediaType.APPLICATION_JSON), ActionPropertySuggestions.class);
 
         final Map<String, List<ActionPropertySuggestion>> actionPropertySuggestions = suggestions.value();
-        actionPropertySuggestions.forEach((k, vals) -> enriched.withConfigurationProperty(k,
+        actionPropertySuggestions.forEach((k, vals) -> enriched.replaceConfigurationProperty(k,
             b -> b.addAllEnum(vals.stream().map(s -> PropertyValue.Builder.from(s))::iterator)));
 
         return enriched.build();

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -129,13 +129,13 @@ public class ConnectionActionHandlerTest {
 
         final ActionDefinition enrichedDefinitioin = new ActionDefinition.Builder()
             .createFrom(createOrUpdateSalesforceObjectDefinition)
-            .withConfigurationProperty("sObjectName",
+            .replaceConfigurationProperty("sObjectName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Contact", "Contact")))
-            .withConfigurationProperty("sObjectIdName",
+            .replaceConfigurationProperty("sObjectIdName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("ID", "Contact ID")))
-            .withConfigurationProperty("sObjectIdName",
+            .replaceConfigurationProperty("sObjectIdName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Email", "Email")))
-            .withConfigurationProperty("sObjectIdName",
+            .replaceConfigurationProperty("sObjectIdName",
                 c -> c.addEnum(
                     ConfigurationProperty.PropertyValue.Builder.of("TwitterScreenName__c", "Twitter Screen Name")))
             .build();
@@ -166,7 +166,7 @@ public class ConnectionActionHandlerTest {
 
         final ActionDefinition enrichedDefinitioin = new ActionDefinition.Builder()
             .createFrom(createOrUpdateSalesforceObjectDefinition)
-            .withConfigurationProperty("sObjectName",
+            .replaceConfigurationProperty("sObjectName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Account", "Account"),
                     ConfigurationProperty.PropertyValue.Builder.of("Contact", "Contact")))
             .build();


### PR DESCRIPTION
If the metadata call to `syndesis-verifier` returns a property that's
not part of the connector's properties we should not throw an exception.

Also renames the method to `replaceConfigurationProperty` from
`withConfigurationProperty` as that method does not add a property to
the `ActionDescriptor` but replaces it.

Fixes #583