### PR TITLE
chore(metadata): Limits dynamic action paramete...

### DIFF
--- a/model/src/main/java/io/syndesis/model/connection/Action.java
+++ b/model/src/main/java/io/syndesis/model/connection/Action.java
@@ -29,13 +29,14 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.model.Kind;
 import io.syndesis.model.WithId;
 import io.syndesis.model.WithName;
+import io.syndesis.model.WithTags;
 
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = Action.Builder.class)
 @JsonIgnoreProperties(value = {"properties", "inputDataShape", "outputDataShape"}, allowGetters = true)
-public interface Action extends WithId<Action>, WithName, Serializable {
+public interface Action extends WithId<Action>, WithName, WithTags, Serializable {
 
     @Override
     default Kind getKind() {

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
@@ -83,6 +83,10 @@ public class ConnectionActionHandler {
 
         final ActionDefinition defaultDefinition = action.getDefinition();
 
+        if (!action.getTags().contains("dynamic")) {
+            return defaultDefinition;
+        }
+
         final String connectorId = connector.getId().get();
 
         final Map<String, String> parameters = new HashMap<>(Optional.ofNullable(properties).orElseGet(HashMap::new));

--- a/runtime/src/test/java/io/syndesis/runtime/action/ActionSuggestionsITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/action/ActionSuggestionsITCase.java
@@ -88,7 +88,8 @@ public class ActionSuggestionsITCase extends BaseITCase {
     private static final String CREATE_OR_UPDATE_ACTION_ID = "io.syndesis:salesforce-create-or-update-connector:latest";
 
     private static final Action DEFAULT_CREATE_OR_UPDATE_ACTION = new Action.Builder()
-        .id(ActionSuggestionsITCase.CREATE_OR_UPDATE_ACTION_ID)
+        .id(ActionSuggestionsITCase.CREATE_OR_UPDATE_ACTION_ID)//
+        .addTag("dynamic")//
         .definition(new ActionDefinition.Builder()
             .withActionDefinitionStep("Select Salesforce object", "Select Salesforce object type to create",
                 b -> b.putProperty("sObjectName", _DEFAULT_SALESFORCE_OBJECT_NAME))


### PR DESCRIPTION
...rs and dynamic data shapes to tagged actions

Adds tags to Action's and checks if the action is tagged with `dynamic`
to return either the definition contained in the database or the
definition enriched by invoking the _verifier_ to fetch additional
action property values or dynamic data shapes.

Fixes #586