### PR TITLE
fix(verifier): Setup the use of JDK8 with JAX-RS client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -593,9 +593,15 @@
       </dependency>
 
       <dependency>
-          <groupId>org.jboss.resteasy</groupId>
-          <artifactId>resteasy-validator-provider-11</artifactId>
-          <version>${resteasy.version}</version>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-validator-provider-11</artifactId>
+        <version>${resteasy.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jackson2-provider</artifactId>
+        <version>${resteasy.version}</version>
       </dependency>
 
       <dependency>

--- a/verifier/pom.xml
+++ b/verifier/pom.xml
@@ -79,7 +79,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -95,7 +94,16 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
JAX-RS client used by the Verifier client was not setup with Jackson
Jdk8Module that would enable deserialization of `Optional<>` values.
Which lead to errors when deserializing verifier's response.

This creates a separate ProviderFactory and configures Jackson
ObjectMapper with the required Jdk8Module.

Fixes #578