### PR TITLE
Maintain the integration history without breaking the api.

### DIFF
--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
@@ -79,8 +79,6 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
             return new StatusUpdate(integration.getCurrentStatus().orElse(null), "No token present");
         }
 
-        IntegrationRevision revision = IntegrationRevision.fromIntegration(integration);
-
         if (isTokenExpired(integration)) {
             LOG.info("{} : Token is expired", getLabel(integration));
             return new StatusUpdate(integration.getCurrentStatus().orElse(null), "Token is expired");
@@ -88,6 +86,8 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
         String token = storeToken(integration);
 
         Properties applicationProperties = extractApplicationPropertiesFrom(integration);
+
+        IntegrationRevision revision = IntegrationRevision.fromIntegration(integration);
 
         OpenShiftDeployment deployment = OpenShiftDeployment
             .builder()

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/DeactivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/DeactivateHandler.java
@@ -50,6 +50,7 @@ public class DeactivateHandler implements StatusChangeHandlerProvider.StatusChan
         OpenShiftDeployment deployment = OpenShiftDeployment
             .builder()
             .name(integration.getName())
+            .revisionId(integration.getDeployedRevisionId().orElse(1))
             .replicas(0)
             .token(token)
             .build();

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/DeleteHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/DeleteHandler.java
@@ -45,6 +45,7 @@ public class DeleteHandler implements StatusChangeHandlerProvider.StatusChangeHa
         OpenShiftDeployment deployment = OpenShiftDeployment
             .builder()
             .name(integration.getName())
+            .revisionId(integration.getDeployedRevisionId().orElse(1))
             .token(token)
             .build();
 

--- a/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -33,6 +33,7 @@ import java.math.BigInteger;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Value.Immutable
 @JsonDeserialize(builder = Integration.Builder.class)
@@ -51,7 +52,7 @@ public interface Integration extends WithId<Integration>, WithTags, WithName, Se
      * The items in this list should be versioned and are not meant to be mutated.
      * @return
      */
-    List<IntegrationRevision> getRevisions();
+    Set<IntegrationRevision> getRevisions();
 
     Optional<IntegrationRevision> getDraftRevision();
 

--- a/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.model.integration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.model.Kind;
 import io.syndesis.model.WithId;
@@ -43,6 +44,27 @@ public interface Integration extends WithId<Integration>, WithTags, WithName, Se
     @Override
     default Kind getKind() {
         return Kind.Integration;
+    }
+
+    /**
+     * The list of versioned revisions.
+     * The items in this list should be versioned and are not meant to be mutated.
+     * @return
+     */
+    List<IntegrationRevision> getRevisions();
+
+    Optional<IntegrationRevision> getDraftRevision();
+
+    Optional<Integer> getDeployedRevisionId();
+
+
+    @JsonIgnore
+    default Optional<IntegrationRevision> getDeployedRevision() {
+        return getDeployedRevisionId().map(i -> getRevisions()
+            .stream()
+            .filter(r -> r.getVersion().isPresent() && i.equals(r.getVersion().get()))
+            .findFirst()
+            .orElse(null));
     }
 
     Optional<String> getConfiguration();
@@ -76,6 +98,15 @@ public interface Integration extends WithId<Integration>, WithTags, WithName, Se
     Optional<Date> getCreatedDate();
 
     Optional<BigInteger> getTimesUsed();
+
+    @JsonIgnore
+    default Optional<IntegrationStatus> getStatus() {
+        Optional<IntegrationRevision> deployedRevision = getDeployedRevision();
+
+        return Optional.of(new IntegrationStatus.Builder()
+            .currentState(deployedRevision.map(r -> r.getCurrentState()).orElse(IntegrationRevisionState.Pending))
+            .build());
+    }
 
     @Override
     default Integration withId(String id) {

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.model.integration;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+@Value.Immutable
+@JsonDeserialize(builder = IntegrationRevision.Builder.class)
+public interface IntegrationRevision {
+
+    /**
+     * The revision number. This is unique per {@link Integration}.
+     * Once an {@IntegrationRevision} gets a version, it should not be mutated anymore.
+     * @return
+     */
+    Optional<Integer> getVersion();
+
+    /**
+     * The version of the integration revision which was the origin of this revision.
+     * @return 0 if this is the first revision of an integration, the parent version otherwise.
+     */
+    Integer getParentVersion();
+
+
+    IntegrationRevisionSpec getSpec();
+
+    /**
+     * The desired state of the revision.
+     * @return
+     */
+    IntegrationRevisionState getTargetState();
+
+    /**
+     * The current state of the revision.
+     * @return
+     */
+    IntegrationRevisionState getCurrentState();
+
+    /**
+     * Message describing the currentState further (e.g. error message)
+     * @return
+     */
+    Optional<String> getCurrentMessage();
+
+
+    /**
+     * Message which should become the currentMessage after reconciliation
+     * @return
+     */
+    Optional<String> getTargetMessage();
+
+    /**
+     * Returns that {@link IntegrationRevisionState}.
+     * The state is either the `desired state` or `pending`.
+     * @return true, if current state is matching with target, false otherwise.
+     */
+    @JsonIgnore
+    default boolean isPending() {
+        return getTargetState() != getCurrentState();
+    }
+
+    default IntegrationRevision withVersion(Integer version) {
+        return new IntegrationRevision.Builder().createFrom(this).version(version).build();
+    }
+
+    default IntegrationRevision withCurrentState(IntegrationRevisionState state) {
+        return new IntegrationRevision.Builder().createFrom(this).currentState(state).build();
+    }
+
+    default IntegrationRevision withCurrentState(IntegrationRevisionState state, String message) {
+        return new IntegrationRevision.Builder().createFrom(this)
+            .currentState(state)
+            .currentMessage(message)
+            .build();
+    }
+
+    default IntegrationRevision withTargetState(IntegrationRevisionState state) {
+        return new IntegrationRevision.Builder().createFrom(this).targetState(state).build();
+    }
+
+    default IntegrationRevision.Builder newIntegrationRevisionBuilder() {
+        return new IntegrationRevision.Builder()
+            .currentState(IntegrationRevisionState.Draft)
+            .targetState(IntegrationRevisionState.Draft)
+            .createFrom(this).version(Optional.empty())
+            .parentVersion(this.getVersion().orElse(0));
+    }
+
+    class Builder extends ImmutableIntegrationRevision.Builder {
+    }
+
+}

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
@@ -104,6 +104,27 @@ public interface IntegrationRevision {
             .parentVersion(this.getVersion().orElse(0));
     }
 
+    static IntegrationRevision fromIntegration(Integration integration) {
+        int version = integration.getRevisions()
+            .stream()
+            .map(i -> i.getVersion().orElse(0))
+            .reduce(Integer::max)
+            .orElse(0);
+
+        return new IntegrationRevision.Builder()
+            .version(version + 1)
+            .parentVersion(version)
+            .spec(new IntegrationRevisionSpec.Builder()
+                        .configuration(integration.getConfiguration())
+                        .connections(integration.getConnections())
+                        .steps(integration.getSteps())
+                        .build())
+            .currentState(IntegrationRevisionState.from(integration.getCurrentStatus().get()))
+            .currentMessage(integration.getStatusMessage())
+            .targetState(IntegrationRevisionState.from(integration.getDesiredStatus().get()))
+            .build();
+    }
+
     class Builder extends ImmutableIntegrationRevision.Builder {
     }
 

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionSpec.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionSpec.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.model.integration;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.syndesis.model.connection.Connection;
+import org.immutables.value.Value;
+
+import java.util.List;
+import java.util.Optional;
+
+@Value.Immutable
+@JsonDeserialize(builder = IntegrationRevisionSpec.Builder.class)
+public interface IntegrationRevisionSpec {
+
+    Optional<String> getConfiguration();
+
+    Optional<List<Connection>> getConnections();
+
+    Optional<List<? extends Step>> getSteps();
+
+    class Builder extends ImmutableIntegrationRevisionSpec.Builder {
+    }
+
+}

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionState.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionState.java
@@ -43,5 +43,20 @@ public enum IntegrationRevisionState {
     /**
      * The {@link IntegrationRevision} is in peding state. (Desired != Actual).
      */
-    Pending,
+    Pending;
+
+
+    @Deprecated //Temporary method for compatibility reasons. Eventually Integration.Status will go away, so will this method.
+    public static IntegrationRevisionState from(Integration.Status status) {
+        switch (status) {
+            case Activated:
+                return IntegrationRevisionState.Active;
+            case Deactivated:
+                return IntegrationRevisionState.Inactive;
+            case Deleted:
+                return Undeployed;
+            default:
+                return Pending;
+        }
+    }
 }

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionState.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionState.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.model.integration;
+
+public enum IntegrationRevisionState {
+    /**
+     * Initial state of an {@link IntegrationRevision}. The IntegrationRevision is not yet deployed.
+     */
+    Draft,
+
+    /**
+     * {@link IntegrationRevision} is deployed and running.
+     */
+    Active,
+    /**
+     * {@link IntegrationRevision} is deployed but is not running.
+     */
+    Inactive,
+    /**
+     * IntegrationRevision has been un-deployed.
+     */
+    Undeployed,
+
+    /**
+     * The {@link IntegrationRevision} is deployed but in an error state.
+     */
+    Error,
+
+    /**
+     * The {@link IntegrationRevision} is in peding state. (Desired != Actual).
+     */
+    Pending,
+}

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationStatus.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationStatus.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.model.integration;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+@Value.Immutable
+@JsonDeserialize(builder = IntegrationStatus.Builder.class)
+public interface IntegrationStatus {
+
+    /**
+     * The desired state of the revision.
+     * @return
+     */
+    IntegrationRevisionState getTargetState();
+
+    /**
+     * The current state of the revision.
+     * @return
+     */
+    IntegrationRevisionState getCurrentState();
+
+    /**
+     * Message describing the currentState further (e.g. error message)
+     * @return
+     */
+    Optional<String> getCurrentMessage();
+
+
+    /**
+     * Message which should become the currentMessage after reconciliation
+     * @return
+     */
+    Optional<String> getTargetMessage();
+
+
+    class Builder extends ImmutableIntegrationStatus.Builder {
+    }
+}

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftDeployment.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftDeployment.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.client.RequestConfigBuilder;
 @Value.Immutable
 public interface OpenShiftDeployment {
     String getName();
+    Integer getRevisionId();
     Optional<Integer> getReplicas();
     Optional<String> getToken();
     Optional<String> getGitRepository();

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
@@ -17,6 +17,8 @@ package io.syndesis.openshift;
 
 public interface OpenShiftService {
 
+    String REVISION_ID_ANNOTATION = "syndesis.io/revision-id";
+
     /**
      * Creates the deployment (Deployment and Build configurations, Image Streams etc)
      * @param d A description of the deployment to create.

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
@@ -39,6 +39,7 @@ import io.syndesis.model.filter.FilterOptions;
 import io.syndesis.model.filter.Op;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.model.integration.Integration.Status;
+import io.syndesis.model.integration.IntegrationRevision;
 import io.syndesis.model.validation.AllValidations;
 import io.syndesis.rest.v1.handler.BaseHandler;
 import io.syndesis.rest.v1.operations.Creator;
@@ -102,11 +103,16 @@ public class IntegrationHandler extends BaseHandler
 
     @Override
     public void update(String id, @ConvertGroup(from = Default.class, to = AllValidations.class) Integration integration) {
+        Integration existing = Getter.super.get(id);
+
         Integration updatedIntegration = new Integration.Builder()
             .createFrom(integration)
+            .deployedRevisionId(existing.getDeployedRevisionId())
             .token(Tokens.getAuthenticationToken())
             .lastUpdated(new Date())
             .currentStatus(determineCurrentStatus(integration))
+            .addRevision(IntegrationRevision.fromIntegration(existing))
+            .addRevision(existing.getRevisions().toArray(new IntegrationRevision[existing.getRevisions().size()]))
             .build();
 
         Updater.super.update(id, updatedIntegration);

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/tests/TestSupportHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/tests/TestSupportHandler.java
@@ -92,6 +92,7 @@ public class TestSupportHandler {
             OpenShiftDeployment deployment = OpenShiftDeployment
                 .builder()
                 .name(i.getName())
+                .revisionId(1)
                 .token(Tokens.getAuthenticationToken())
                 .build();
 


### PR DESCRIPTION
This is a subset of https://github.com/syndesisio/syndesis-rest/pull/493, but including only changes that doesn't affect actual the API. Also, keeps behavioral changes to the bare minimum.