### PR TITLE
chore: use `json-schema` as datashape for JSON ...

### DIFF
--- a/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -305,7 +305,7 @@
           "tags": [ "dynamic" ],
           "definition": {
             "inputDataShape": {
-               "kind": "json"
+               "kind": "json-schema"
             },
             "outputDataShape": {
                "kind": "java",
@@ -487,7 +487,7 @@
           "tags": [ "dynamic" ],
           "definition": {
             "inputDataShape": {
-               "kind": "json"
+               "kind": "json-schema"
             },
             "outputDataShape": {
                "kind": "none"
@@ -522,7 +522,7 @@
           "tags": [ "dynamic" ],
           "definition": {
             "inputDataShape": {
-               "kind": "json"
+               "kind": "json-schema"
             },
             "outputDataShape": {
                "kind": "none"
@@ -557,7 +557,7 @@
           "tags": [ "dynamic" ],
           "definition": {
             "inputDataShape": {
-               "kind": "json"
+               "kind": "json-schema"
             },
             "outputDataShape": {
                "kind": "java",
@@ -1345,7 +1345,7 @@
           "tags": [ "dynamic" ],
           "definition": {
             "inputDataShape": {
-               "kind" : "json"
+               "kind" : "json-schema"
             },
             "outputDataShape": {
                "kind" : "none"

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
@@ -118,13 +118,13 @@ public class ConnectionActionHandler {
 
         final Object input = dynamicActionMetadata.inputSchema();
         if (shouldEnrichDataShape(defaultDefinition.getInputDataShape(), input)) {
-            enriched.inputDataShape(new DataShape.Builder().type(typeFrom(input)).kind("json")
+            enriched.inputDataShape(new DataShape.Builder().type(typeFrom(input)).kind("json-schema")
                 .specification(specificationFrom(input)).build());
         }
 
         final Object output = dynamicActionMetadata.outputSchema();
         if (shouldEnrichDataShape(defaultDefinition.getOutputDataShape(), output)) {
-            enriched.outputDataShape(new DataShape.Builder().type(typeFrom(output)).kind("json")
+            enriched.outputDataShape(new DataShape.Builder().type(typeFrom(output)).kind("json-schema")
                 .specification(specificationFrom(output)).build());
         }
 
@@ -140,7 +140,7 @@ public class ConnectionActionHandler {
         if (maybeExistingDataShape.isPresent() && received != null) {
             final DataShape existingDataShape = maybeExistingDataShape.get();
 
-            return "json".equals(existingDataShape.getKind()) && existingDataShape.getSpecification() == null;
+            return "json-schema".equals(existingDataShape.getKind()) && existingDataShape.getSpecification() == null;
         }
 
         return false;

--- a/runtime/src/test/java/io/syndesis/runtime/action/DynamicActionDefinitionITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/action/DynamicActionDefinitionITCase.java
@@ -92,7 +92,7 @@ public class DynamicActionDefinitionITCase extends BaseITCase {
         .id(DynamicActionDefinitionITCase.CREATE_OR_UPDATE_ACTION_ID)//
         .addTag("dynamic")//
         .definition(new ActionDefinition.Builder()//
-            .inputDataShape(new DataShape.Builder().kind("json").build())
+            .inputDataShape(new DataShape.Builder().kind("json-schema").build())
             .outputDataShape(new DataShape.Builder().kind("java")
                 .type("org.apache.camel.component.salesforce.api.dto.CreateSObjectResult").build())
             .withActionDefinitionStep("Select Salesforce object", "Select Salesforce object type to create",
@@ -181,7 +181,7 @@ public class DynamicActionDefinitionITCase extends BaseITCase {
             ActionDefinition.class, tokenRule.validToken(), headers, HttpStatus.OK);
 
         final ActionDefinition firstEnrichment = new ActionDefinition.Builder()//
-            .inputDataShape(new DataShape.Builder().kind("json").build())
+            .inputDataShape(new DataShape.Builder().kind("json-schema").build())
             .outputDataShape(new DataShape.Builder().kind("java")
                 .type("org.apache.camel.component.salesforce.api.dto.CreateSObjectResult").build())
             .withActionDefinitionStep("Select Salesforce object", "Select Salesforce object type to create",
@@ -209,7 +209,7 @@ public class DynamicActionDefinitionITCase extends BaseITCase {
         final ActionDefinition secondResponseBody = secondResponse.getBody();
         assertThat(secondResponseBody).isEqualToIgnoringGivenFields(secondEnrichment, "inputDataShape");
         assertThat(secondResponseBody.getInputDataShape()).hasValueSatisfying(input -> {
-            assertThat(input.getKind()).isEqualTo("json");
+            assertThat(input.getKind()).isEqualTo("json-schema");
             assertThat(input.getType()).isEqualTo("Contact");
             assertThat(input.getSpecification()).isNotEmpty();
         });


### PR DESCRIPTION
...schema based dynamic shape

We currently support JSON schema as dynamic shape, our kind should
reflect that as `json` could/will be used for data shapes that are given
as example i.e. without schema.

Fixes #597