### PR TITLE
chore: Support JSON schema in filter steps

### DIFF
--- a/inspector/pom.xml
+++ b/inspector/pom.xml
@@ -62,14 +62,29 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jsonSchema</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- === Testing Dependencies ======================================================== -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
     </dependency>
 
     <dependency>

--- a/inspector/src/main/java/io/syndesis/inspector/DefaultInspectors.java
+++ b/inspector/src/main/java/io/syndesis/inspector/DefaultInspectors.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.inspector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultInspectors implements Inspectors {
+
+    private final List<Inspector> inspectors;
+
+    public DefaultInspectors(final List<Inspector> inspectors) {
+        this.inspectors = inspectors;
+    }
+
+    @Override
+    public List<String> getPaths(final String kind, final String type, final String specification,
+        final Optional<byte[]> optional) {
+        final List<String> paths = new ArrayList<>();
+
+        for (final Inspector inspector : inspectors) {
+            if (inspector.supports(kind, type, specification, optional)) {
+                paths.addAll(inspector.getPaths(kind, type, specification, optional));
+            }
+        }
+
+        return paths;
+    }
+}

--- a/inspector/src/main/java/io/syndesis/inspector/Inspector.java
+++ b/inspector/src/main/java/io/syndesis/inspector/Inspector.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.inspector;
+
+import java.util.List;
+import java.util.Optional;
+
+interface Inspector {
+
+    /**
+     * Collects recursively all possible 'path' of the given shape definition.
+     * Each item in the path corresponds to fields, fields of fields and so on.
+     *
+     * @param kind the kind of data shape
+     * @param type the type of data shape
+     * @param specification specification of data shape
+     * @param optional an live example of data
+     * @return all paths within the data shape
+     */
+    List<String> getPaths(String kind, String type, String specification, Optional<byte[]> optional);
+
+    /**
+     * Can this {@link Inspector} implementation support the given data shape.
+     *
+     * @param kind the kind of data shape
+     * @param type the type of data shape
+     * @param specification specification of data shape
+     * @param optional an live example of data
+     * @return true if it can
+     */
+    boolean supports(String kind, String type, String specification, Optional<byte[]> optional);
+}

--- a/inspector/src/main/java/io/syndesis/inspector/Inspectors.java
+++ b/inspector/src/main/java/io/syndesis/inspector/Inspectors.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) 2016 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,19 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.syndesis.inspector;
 
 import java.util.List;
+import java.util.Optional;
 
-public interface ClassInspector {
+public interface Inspectors {
 
-    /**
-     * Collects recursively all possible 'path' of the class.
-     * Each item in the path corresponds to fields, fields of fields and so on.
-     *
-     * @param className The target class name.
-     * @return
-     */
-    List<String> getPaths(String className);
+    List<String> getPaths(String kind, String type, String specification, Optional<byte[]> optional);
+
 }

--- a/inspector/src/main/java/io/syndesis/inspector/JsonSchemaInspector.java
+++ b/inspector/src/main/java/io/syndesis/inspector/JsonSchemaInspector.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.inspector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JsonSchemaInspector implements Inspector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JsonSchemaInspector.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public List<String> getPaths(final String kind, final String type, final String specification,
+        final Optional<byte[]> exemplar) {
+        final ObjectSchema schema;
+        try {
+            schema = MAPPER.readerFor(ObjectSchema.class).readValue(specification);
+        } catch (final IOException e) {
+            LOG.warn(
+                "Unable to parse the given JSON schema, increase log level to DEBUG to see the schema being parsed");
+            LOG.debug(specification);
+
+            return Collections.emptyList();
+        }
+
+        final Map<String, JsonSchema> properties = schema.getProperties();
+
+        final List<String> paths = new ArrayList<>();
+        fetchPaths(null, paths, properties);
+
+        return paths;
+    }
+
+    @Override
+    public boolean supports(final String kind, final String type, final String specification,
+        final Optional<byte[]> exemplar) {
+        return "json-schema".equals(kind) && !StringUtils.isEmpty(specification);
+    }
+
+    /* default */ static void fetchPaths(final String context, final List<String> paths, final Map<String, JsonSchema> properties) {
+        for (final Entry<String, JsonSchema> entry : properties.entrySet()) {
+            final JsonSchema subschema = entry.getValue();
+
+            String path;
+            final String key = entry.getKey();
+            if (context == null) {
+                path = key;
+            } else {
+                path = context + "." + key;
+            }
+
+            if (subschema.isValueTypeSchema()) {
+                paths.add(path);
+            } else if (subschema.isObjectSchema()) {
+                fetchPaths(path, paths, ((ObjectSchema) subschema).getProperties());
+            }
+        }
+    }
+
+}

--- a/inspector/src/test/java/io/syndesis/inspector/DataMapperClassInspectorTest.java
+++ b/inspector/src/test/java/io/syndesis/inspector/DataMapperClassInspectorTest.java
@@ -42,7 +42,7 @@ public class DataMapperClassInspectorTest {
         mockServer.expect().get().withPath("/v2/atlas/java/class?className=twitter4j.StatusJSONImpl").andReturn(200, Resources.toString(getClass().getResource("/twitter4j.StatusJSONImpl.json"), Charset.defaultCharset())).always();
         mockServer.expect().get().withPath("/v2/atlas/java/class?className=twitter4j.Logger").andReturn(200, Resources.toString(getClass().getResource("/twitter4j.Logger.json"), Charset.defaultCharset())).always();
         mockServer.expect().get().withPath("/v2/atlas/java/class?className=twitter4j.LoggerFactory").andReturn(200, Resources.toString(getClass().getResource("/twitter4j.LoggerFactory.json"), Charset.defaultCharset())).always();
-        List<String> paths = dataMapperClassInspector.getPaths("twitter4j.StatusJSONImpl");
+        List<String> paths = dataMapperClassInspector.getPaths("java", "twitter4j.StatusJSONImpl", null, null);
 
         Assert.assertNotNull(paths);
         Assert.assertTrue(paths.contains("id"));
@@ -54,7 +54,7 @@ public class DataMapperClassInspectorTest {
         DataMapperClassInspector dataMapperClassInspector = new DataMapperClassInspector(infinispan.getCaches(), new RestTemplate(), config);
         mockServer.expect().get().withPath("/v2/atlas/java/class?className=twitter4j.Status").andReturn(200, Resources.toString(getClass().getResource("/twitter4j.Status.json"), Charset.defaultCharset())).always();
 
-        List<String> paths = dataMapperClassInspector.getPaths("twitter4j.Status");
+        List<String> paths = dataMapperClassInspector.getPaths("java", "twitter4j.Status", null, null);
 
         Assert.assertNotNull(paths);
         Assert.assertTrue(paths.contains("id"));

--- a/inspector/src/test/java/io/syndesis/inspector/JsonSchemaInspectorTest.java
+++ b/inspector/src/test/java/io/syndesis/inspector/JsonSchemaInspectorTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.inspector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonSchemaInspectorTest {
+
+    @Test
+    public void shouldCollectPathsFromJsonSchema() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectSchema schema = mapper.readValue(
+            JsonSchemaInspectorTest.class.getResourceAsStream("/salesforce.Contact.jsonschema"), ObjectSchema.class);
+
+        final ArrayList<String> paths = new ArrayList<>();
+        JsonSchemaInspector.fetchPaths(null, paths, schema.getProperties());
+
+        assertThat(paths).contains("Id", "IsDeleted", "MasterRecordId", "AccountId", "LastName", "FirstName",
+            "OtherAddress.latitude", "MailingAddress.city");
+    }
+
+}

--- a/inspector/src/test/resources/salesforce.Contact.jsonschema
+++ b/inspector/src/test/resources/salesforce.Contact.jsonschema
@@ -1,0 +1,422 @@
+{
+  "id": "urn:jsonschema:org:apache:camel:component:salesforce:dto:Contact",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Contact",
+  "type": "object",
+  "properties": {
+    "Id": {
+      "type": "string",
+      "required": true,
+      "readonly": true,
+      "description": "idLookup",
+      "title": "Contact ID"
+    },
+    "IsDeleted": {
+      "type": "boolean",
+      "required": true,
+      "readonly": true,
+      "title": "Deleted"
+    },
+    "MasterRecordId": {
+      "type": "string",
+      "readonly": true,
+      "title": "Master Record ID"
+    },
+    "AccountId": {
+      "type": "string",
+      "readonly": false,
+      "title": "Account ID"
+    },
+    "LastName": {
+      "type": "string",
+      "required": true,
+      "readonly": false,
+      "title": "Last Name"
+    },
+    "FirstName": {
+      "type": "string",
+      "readonly": false,
+      "title": "First Name"
+    },
+    "Salutation": {
+      "type": "string",
+      "readonly": false,
+      "title": "Salutation",
+      "enum": [
+        "Dr.",
+        "Mrs.",
+        "Mr.",
+        "Ms.",
+        "Prof."
+      ]
+    },
+    "Name": {
+      "type": "string",
+      "required": true,
+      "readonly": true,
+      "title": "Full Name"
+    },
+    "OtherStreet": {
+      "type": "string",
+      "readonly": false,
+      "title": "Other Street"
+    },
+    "OtherCity": {
+      "type": "string",
+      "readonly": false,
+      "title": "Other City"
+    },
+    "OtherState": {
+      "type": "string",
+      "readonly": false,
+      "title": "Other State/Province"
+    },
+    "OtherPostalCode": {
+      "type": "string",
+      "readonly": false,
+      "title": "Other Zip/Postal Code"
+    },
+    "OtherCountry": {
+      "type": "string",
+      "readonly": false,
+      "title": "Other Country"
+    },
+    "OtherLatitude": {
+      "type": "number",
+      "readonly": false,
+      "title": "Other Latitude"
+    },
+    "OtherLongitude": {
+      "type": "number",
+      "readonly": false,
+      "title": "Other Longitude"
+    },
+    "OtherAddress": {
+      "type": "object",
+      "id": "urn:jsonschema:org:apache:camel:component:salesforce:api:dto:Address",
+      "readonly": true,
+      "title": "Mailing Address",
+      "properties": {
+        "latitude": {
+          "type": "number"
+        },
+        "longitude": {
+          "type": "number"
+        },
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "countryCode": {
+          "type": "string"
+        },
+        "postalCode": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "stateCode": {
+          "type": "string"
+        },
+        "street": {
+          "type": "string"
+        },
+        "geocodeAccuracy": {
+          "type": "string"
+        }
+      }
+    },
+    "MailingStreet": {
+      "type": "string",
+      "readonly": false,
+      "title": "Mailing Street"
+    },
+    "MailingCity": {
+      "type": "string",
+      "readonly": false,
+      "title": "Mailing City"
+    },
+    "MailingState": {
+      "type": "string",
+      "readonly": false,
+      "title": "Mailing State/Province"
+    },
+    "MailingPostalCode": {
+      "type": "string",
+      "readonly": false,
+      "title": "Mailing Zip/Postal Code"
+    },
+    "MailingCountry": {
+      "type": "string",
+      "readonly": false,
+      "title": "Mailing Country"
+    },
+    "MailingLatitude": {
+      "type": "number",
+      "readonly": false,
+      "title": "Mailing Latitude"
+    },
+    "MailingLongitude": {
+      "type": "number",
+      "readonly": false,
+      "title": "Mailing Longitude"
+    },
+    "MailingAddress": {
+      "type": "object",
+      "id": "urn:jsonschema:org:apache:camel:component:salesforce:api:dto:Address",
+      "readonly": true,
+      "title": "Mailing Address",
+      "properties": {
+        "latitude": {
+          "type": "number"
+        },
+        "longitude": {
+          "type": "number"
+        },
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "countryCode": {
+          "type": "string"
+        },
+        "postalCode": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "stateCode": {
+          "type": "string"
+        },
+        "street": {
+          "type": "string"
+        },
+        "geocodeAccuracy": {
+          "type": "string"
+        }
+      }
+    },
+    "Phone": {
+      "type": "string",
+      "readonly": false,
+      "title": "Business Phone"
+    },
+    "Fax": {
+      "type": "string",
+      "readonly": false,
+      "title": "Business Fax"
+    },
+    "MobilePhone": {
+      "type": "string",
+      "readonly": false,
+      "title": "Mobile Phone"
+    },
+    "HomePhone": {
+      "type": "string",
+      "readonly": false,
+      "title": "Home Phone"
+    },
+    "OtherPhone": {
+      "type": "string",
+      "readonly": false,
+      "title": "Other Phone"
+    },
+    "AssistantPhone": {
+      "type": "string",
+      "readonly": false,
+      "title": "Asst. Phone"
+    },
+    "ReportsToId": {
+      "type": "string",
+      "readonly": false,
+      "title": "Reports To ID"
+    },
+    "Email": {
+      "type": "string",
+      "readonly": false,
+      "description": "idLookup",
+      "title": "Email"
+    },
+    "Title": {
+      "type": "string",
+      "readonly": false,
+      "title": "Title"
+    },
+    "Department": {
+      "type": "string",
+      "readonly": false,
+      "title": "Department"
+    },
+    "AssistantName": {
+      "type": "string",
+      "readonly": false,
+      "title": "Assistant's Name"
+    },
+    "LeadSource": {
+      "type": "string",
+      "readonly": false,
+      "title": "Lead Source",
+      "enum": [
+        "Phone Inquiry",
+        "Purchased List",
+        "Partner Referral",
+        "Web",
+        "Other"
+      ]
+    },
+    "Birthdate": {
+      "type": "string",
+      "readonly": false,
+      "title": "Birthdate",
+      "format": "date-time"
+    },
+    "Description": {
+      "type": "string",
+      "readonly": false,
+      "title": "Contact Description"
+    },
+    "OwnerId": {
+      "type": "string",
+      "required": true,
+      "readonly": false,
+      "title": "Owner ID"
+    },
+    "CreatedDate": {
+      "type": "string",
+      "required": true,
+      "readonly": true,
+      "title": "Created Date",
+      "format": "date-time"
+    },
+    "CreatedById": {
+      "type": "string",
+      "required": true,
+      "readonly": true,
+      "title": "Created By ID"
+    },
+    "LastModifiedDate": {
+      "type": "string",
+      "required": true,
+      "readonly": true,
+      "title": "Last Modified Date",
+      "format": "date-time"
+    },
+    "LastModifiedById": {
+      "type": "string",
+      "required": true,
+      "readonly": true,
+      "title": "Last Modified By ID"
+    },
+    "SystemModstamp": {
+      "type": "string",
+      "required": true,
+      "readonly": true,
+      "title": "System Modstamp",
+      "format": "date-time"
+    },
+    "LastActivityDate": {
+      "type": "string",
+      "readonly": true,
+      "title": "Last Activity",
+      "format": "date-time"
+    },
+    "LastCURequestDate": {
+      "type": "string",
+      "readonly": true,
+      "title": "Last Stay-in-Touch Request Date",
+      "format": "date-time"
+    },
+    "LastCUUpdateDate": {
+      "type": "string",
+      "readonly": true,
+      "title": "Last Stay-in-Touch Save Date",
+      "format": "date-time"
+    },
+    "LastViewedDate": {
+      "type": "string",
+      "readonly": true,
+      "title": "Last Viewed Date",
+      "format": "date-time"
+    },
+    "LastReferencedDate": {
+      "type": "string",
+      "readonly": true,
+      "title": "Last Referenced Date",
+      "format": "date-time"
+    },
+    "EmailBouncedReason": {
+      "type": "string",
+      "readonly": false,
+      "title": "Email Bounced Reason"
+    },
+    "EmailBouncedDate": {
+      "type": "string",
+      "readonly": false,
+      "title": "Email Bounced Date",
+      "format": "date-time"
+    },
+    "IsEmailBounced": {
+      "type": "boolean",
+      "required": true,
+      "readonly": true,
+      "title": "Is Email Bounced"
+    },
+    "PhotoUrl": {
+      "type": "string",
+      "readonly": true,
+      "title": "Photo URL"
+    },
+    "Jigsaw": {
+      "type": "string",
+      "readonly": false,
+      "title": "Data.com Key"
+    },
+    "JigsawContactId": {
+      "type": "string",
+      "readonly": true,
+      "title": "Jigsaw Contact ID"
+    },
+    "CleanStatus": {
+      "type": "string",
+      "readonly": false,
+      "title": "Clean Status",
+      "enum": [
+        "SelectMatch",
+        "Matched",
+        "Skipped",
+        "Inactive",
+        "Different",
+        "Pending",
+        "Acknowledged",
+        "NotFound"
+      ]
+    },
+    "zregvart__Level__c": {
+      "type": "string",
+      "readonly": false,
+      "title": "Level",
+      "enum": [
+        "Secondary",
+        "Tertiary",
+        "Primary"
+      ]
+    },
+    "zregvart__Languages__c": {
+      "type": "string",
+      "readonly": false,
+      "title": "Languages"
+    },
+    "zregvart__TwitterScreenName__c": {
+      "type": "string",
+      "readonly": false,
+      "description": "unique,idLookup",
+      "title": "TwitterScreenName"
+    }
+  }
+}

--- a/model/src/main/java/io/syndesis/model/connection/DataShapeKinds.java
+++ b/model/src/main/java/io/syndesis/model/connection/DataShapeKinds.java
@@ -20,5 +20,6 @@ package io.syndesis.model.connection;
 public class DataShapeKinds {
     public static final String ANY = "any";
     public static final String JAVA = "java";
+    public static final String JSON_SCHEMA = "json-schema";
     public static final String NONE = "none";
 }

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
@@ -15,21 +15,16 @@
  */
 package io.syndesis.rest.v1.handler;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Optional;
 
 import javax.validation.Validator;
 
 import io.syndesis.dao.manager.DataManager;
-import io.syndesis.inspector.ClassInspector;
-import io.syndesis.model.connection.Action;
-import io.syndesis.model.connection.ActionDefinition;
+import io.syndesis.inspector.Inspectors;
 import io.syndesis.model.connection.DataShape;
 import io.syndesis.model.connection.DataShapeKinds;
 import io.syndesis.model.filter.FilterOptions;
-import io.syndesis.model.integration.Integration;
-import io.syndesis.model.integration.SimpleStep;
 import io.syndesis.rest.v1.handler.integration.IntegrationHandler;
 
 import org.junit.Before;
@@ -47,19 +42,19 @@ public class IntegrationHandlerTest {
 
 
     private IntegrationHandler handler;
-    private ClassInspector inspector;
+    private Inspectors inspectors;
 
     @Before
     public void setUp() {
         DataManager manager = mock(DataManager.class);
         Validator validator = mock(Validator.class);
-        inspector = mock(ClassInspector.class);
-        handler = new IntegrationHandler(manager, validator, inspector);
+        inspectors = mock(Inspectors.class);
+        handler = new IntegrationHandler(manager, validator, inspectors);
     }
 
     @Test
     public void filterOptionsSimple() {
-        when(inspector.getPaths("twitter4j.Status")).thenReturn(Arrays.asList("paramA", "paramB"));
+        when(inspectors.getPaths(DataShapeKinds.JAVA, "twitter4j.Status", null, Optional.empty())).thenReturn(Arrays.asList("paramA", "paramB"));
         DataShape dataShape = dataShape(DataShapeKinds.JAVA, "twitter4j.Status");
 
         FilterOptions options = handler.getFilterOptions(dataShape);


### PR DESCRIPTION
This adds JSON schema support for filter steps. It does not invoke the
datamapper to inspect the schema as is the case with class inspections,
but instead parses the JSON schema and introspects in-process.