### PR TITLE
chore: Sync connectors with syndesis-rest

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -83,8 +83,8 @@
     </dependency>
 
     <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
     </dependency>
 
     <dependency>
@@ -95,8 +95,8 @@
     <dependency>
       <!-- For @javax.annotation.Nullable in DataManager to declare optional constructor arg -->
       <!-- That gut feeling,  that there should be a better solution -->
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <!-- === Test ============================================================================ -->
@@ -125,6 +125,24 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-catalog</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-catalog-maven</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-catalog-connector</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/dao/src/main/resources/io/syndesis/dao/demo-data.json
+++ b/dao/src/main/resources/io/syndesis/dao/demo-data.json
@@ -835,5 +835,510 @@
         }
       ]
     }
+  },
+  {
+    "kind": "connector",
+    "data": {
+      "id": "linkedin",
+      "name": "LinkedIn",
+      "description": "Connect and interact with your professional social network",
+      "icon": "fa-puzzle-piece",
+      "configuredProperties": {},
+      "properties": {},
+      "actions": [
+        {
+          "id": "io.syndesis:linkedin-get-connections-connector:latest",
+          "name": "Get Connections",
+          "description": "Get all LinkedIn connections",
+          "camelConnectorGAV": "io.syndesis:linkedin-connections-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "linkedin-connections",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "none"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        },
+        {
+          "id": "io.syndesis:linkedin-add-invite-connector:latest",
+          "name": "Send Invite",
+          "description": "Send out a LinkedIn Invite",
+          "camelConnectorGAV": "io.syndesis:linkedin-invite-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "linkedin-invite",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "none"
+            },
+            "propertyDefinitionSteps": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "kind": "connector",
+    "data": {
+      "id": "servicenow",
+      "name": "ServiceNow",
+      "description": "Cloud-based IT Service Management",
+      "icon": "fa-puzzle-piece",
+      "configuredProperties": {},
+      "properties": {},
+      "actions": [
+        {
+          "id": "io.syndesis:servicenow-connector:latest",
+          "name": "service-now",
+          "description": "Provides access to all of ServiceNow REST API",
+          "camelConnectorGAV": "io.syndesis:servicenow-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "servicenow",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "kind": "connector",
+    "data": {
+      "id": "github",
+      "name": "GitHub",
+      "description": "Manage code on GitHub through commits, pull requests, tags, and more",
+      "icon": "fa-puzzle-piece",
+      "configuredProperties": {},
+      "properties": {},
+      "actions": [
+        {
+          "id": "io.syndesis:github-pullrequest-connector:latest",
+          "name": "github-pullrequest",
+          "description": "Create a GitHub PullRequest",
+          "camelConnectorGAV": "io.syndesis:github-pullrequest-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "github-pullrequest",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            }
+          }
+        },
+        {
+          "id": "io.syndesis:github-tag-connector:latest",
+          "name": "github-tag",
+          "description": "Create a GitHub Tag",
+          "camelConnectorGAV": "io.syndesis:github-tag-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "github-tag",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            }
+          }
+        },
+        {
+          "id": "io.syndesis:github-commit-connector:latest",
+          "name": "github-commit",
+          "description": "Performs a GitHub Commit",
+          "camelConnectorGAV": "io.syndesis:github-commit-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "github-commit",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "kind": "connector",
+    "data": {
+      "id": "gmail",
+      "name": "GMail",
+      "description": "Send and receive email using Google's Gmail service",
+      "icon": "fa-puzzle-piece",
+      "configuredProperties": {},
+      "properties": {},
+      "actions": [
+        {
+          "id": "io.syndesis:gmail-send:latest",
+          "name": "GMail Send",
+          "description": "Send an email",
+          "camelConnectorGAV": "io.syndesis:gmail-send-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "gmail-send",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        },
+        {
+          "id": "io.syndesis:gmail-list:latest",
+          "name": "GMail List",
+          "description": "List incoming messages",
+          "camelConnectorGAV": "io.syndesis:gmail-list-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "gmail-list",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        },
+        {
+          "id": "io.syndesis:gmail-get:latest",
+          "name": "GMail Get",
+          "description": "Get email message",
+          "camelConnectorGAV": "io.syndesis:gmail-get-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "gmail-get",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        },
+        {
+          "id": "io.syndesis:gmail-delete:latest",
+          "name": "GMail Delete",
+          "description": "Delete email message",
+          "camelConnectorGAV": "io.syndesis:gmail-delete-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "gmail-delete",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "kind": "connector",
+    "data": {
+      "id": "facebook",
+      "name": "Facebook",
+      "description": "Access Facebook social network features such as posts, users, checkins, etc",
+      "icon": "fa-puzzle-piece",
+      "configuredProperties": {},
+      "properties": {},
+      "actions": [
+        {
+          "id": "io.syndesis:facebook-post-connector:latest",
+          "name": "Post",
+          "description": "Creates a post to Facebook",
+          "camelConnectorGAV": "io.syndesis:facebook-post-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "facebook-post",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        },
+        {
+          "id": "io.syndesis:facebook-like-connector:latest",
+          "name": "Like",
+          "description": "Like something on Facebook",
+          "camelConnectorGAV": "io.syndesis:facebook-like-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "facebook-like",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "kind": "connector",
+    "data": {
+      "id": "jms",
+      "name": "Messaging",
+      "description": "Produce and consume messages for event-driven interaction",
+      "icon": "fa-puzzle-piece",
+      "configuredProperties": {},
+      "properties": {},
+      "actions": [
+        {
+          "id": "io.syndesis:jms-producer-connector:latest",
+          "name": "Message Producer",
+          "description": "Drop a message on a Queue",
+          "camelConnectorGAV": "io.syndesis:jms-producer-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "jms-producer",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            }
+          }
+        },
+        {
+          "id": "io.syndesis:jms-consumer-connector:latest",
+          "name": "Message Consumer",
+          "description": "Takes a message off a Queue",
+          "camelConnectorGAV": "io.syndesis:jms-consumer-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "jms-consumer",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "kind": "connector",
+    "data": {
+      "id": "ftp",
+      "name": "File Transfer",
+      "description": "Remote, secure file transfer",
+      "icon": "fa-puzzle-piece",
+      "configuredProperties": {},
+      "properties": {},
+      "actions": [
+        {
+          "id": "io.syndesis:ftp-connector:latest",
+          "name": "File Transport",
+          "description": "FTP/SFTP/FPTS file transfer",
+          "camelConnectorGAV": "io.syndesis:ftp-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "ftp",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "kind": "connector",
+    "data": {
+      "id": "day-trade",
+      "name": "Day Trade",
+      "description": "Day Trade API connector",
+      "icon": "fa-usd",
+      "configuredProperties": {},
+      "properties": {
+        "host": {
+          "kind": "property",
+          "displayName": "Host",
+          "group": "producer",
+          "label": "producer",
+          "required": true,
+          "type": "string",
+          "javaType": "java.lang.String",
+          "tags":[],
+          "deprecated": false,
+          "secret": false,
+          "componentProperty": false,
+          "description": "Host and port of HTTP service to use (override host in swagger schema)"
+        },
+        "api_key": {
+          "kind": "property",
+          "displayName": "API Key",
+          "group": "producer",
+          "label": "producer",
+          "required": true,
+          "type": "string",
+          "javaType": "java.lang.String",
+          "tags":[],
+          "deprecated": false,
+          "secret": true,
+          "componentProperty": false,
+          "description": "The API Key used to access the service"
+        }
+      },
+      "actions": [
+        {
+          "name": "Place Trade",
+          "description": "Place trade on Day Trade API server",
+          "id": "io.syndesis:day-trade-place-connector:latest",
+          "camelConnectorGAV": "io.syndesis:day-trade-place-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "day-trade-place",
+          "definition": {
+            "inputDataShape": {
+              "kind": "java",
+              "type": "io.syndesis.connector.daytrade.Trade"
+            },
+            "outputDataShape": {
+              "kind": "none"
+            },
+            "propertyDefinitionSteps": []
+          }
+        },
+        {
+          "name": "Retrieve Trade",
+          "description": "Retrieve a trade on Day Trade API server",
+          "id": "io.syndesis:day-trade-place-connector:latest",
+          "camelConnectorGAV": "io.syndesis:day-trade-place-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "day-trade-place",
+          "definition": {
+            "inputDataShape": {
+              "kind": "java",
+              "type": "io.syndesis.connector.daytrade.Trade"
+            },
+            "outputDataShape": {
+              "kind": "java",
+              "type": "io.syndesis.connector.daytrade.Trade"
+            },
+            "propertyDefinitionSteps": []
+          }
+        },
+        {
+          "name": "Get Latest Trade",
+          "description": "Get the latest trade on Day Trade API server",
+          "id": "io.syndesis:day-trade-place-connector:latest",
+          "camelConnectorGAV": "io.syndesis:day-trade-place-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "day-trade-place",
+          "definition": {
+            "inputDataShape": {
+              "kind": "none"
+            },
+            "outputDataShape": {
+              "kind": "java",
+              "type": "io.syndesis.connector.daytrade.Trade"
+            },
+            "propertyDefinitionSteps": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "kind": "connector",
+    "data": {
+      "id": "http",
+      "name": "HTTP",
+      "description": "Interact with APIs and plain HTTP endpoints",
+      "icon": "fa-globe",
+      "configuredProperties": {},
+      "properties": {},
+      "actions": [
+        {
+          "id": "io.syndesis:http-get-connector:latest",
+          "name": "HTTP GET",
+          "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
+          "camelConnectorGAV": "io.syndesis:http-get-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "http-get-connector",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "none"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": [{
+              "name": "HTTP Endpoint",
+              "description": "Specify HTTP address to fetch the data from",
+              "properties": {
+                "httpUri": {
+                  "kind": "path",
+                  "displayName": "Http Uri",
+                  "group": "producer",
+                  "label": "producer",
+                  "required": true,
+                  "type": "string",
+                  "javaType": "java.net.URI",
+                  "tags":[],
+                  "deprecated": false,
+                  "secret": false,
+                  "componentProperty": false,
+                  "description": "The url of the HTTP endpoint to call."
+                }
+              }
+            }]
+          }
+        },
+        {
+          "id": "io.syndesis:http-post-connector:latest",
+          "name": "HTTP POST",
+          "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
+          "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "http-post-connector",
+          "definition": {
+            "inputDataShape": {
+               "kind" : "any"
+            },
+            "outputDataShape": {
+               "kind" : "any"
+            },
+            "propertyDefinitionSteps": [{
+              "name": "HTTP Endpoint",
+              "description": "Specify HTTP address to send the data to",
+              "properties": {
+                "httpUri": {
+                  "kind": "path",
+                  "displayName": "Http Uri",
+                  "group": "producer",
+                  "label": "producer",
+                  "required": true,
+                  "type": "string",
+                  "javaType": "java.net.URI",
+                  "tags":[],
+                  "deprecated": false,
+                  "secret": false,
+                  "componentProperty": false,
+                  "description": "The url of the HTTP endpoint to call."
+                }
+              }
+            }]
+          }
+        }
+      ]
+    }
   }
 ]

--- a/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -359,7 +359,7 @@
                   "kind": "parameter",
                   "displayName": "SObject Id Name",
                   "group": "common",
-                  "required": false,
+                  "required": true,
                   "type": "string",
                   "javaType": "java.lang.String",
                   "tags":[],
@@ -450,7 +450,7 @@
                   "kind": "parameter",
                   "displayName": "SObject Id Name",
                   "group": "common",
-                  "required": false,
+                  "required": true,
                   "type": "string",
                   "javaType": "java.lang.String",
                   "tags":[],
@@ -540,7 +540,7 @@
                   "kind": "parameter",
                   "displayName": "SObject Id Name",
                   "group": "common",
-                  "required": false,
+                  "required": true,
                   "type": "string",
                   "javaType": "java.lang.String",
                   "tags":[],
@@ -549,6 +549,114 @@
                   "componentProperty": false,
                   "defaultValue": "",
                   "description": "SObject external ID field name"
+                }
+              }
+            }]
+          }
+        },{
+          "id": "io.syndesis:salesforce-on-create-connector:latest",
+          "name": "On create",
+          "description": "Get notified when an Salesforce record is created",
+          "camelConnectorGAV": "io.syndesis:salesforce-on-create-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "salesforce-on-create",
+          "tags": [ "dynamic" ],
+          "definition": {
+            "inputDataShape": {
+               "kind": "none"
+            },
+            "outputDataShape": {
+               "kind": "java",
+               "type": "io.syndesis.connector.salesforce.AnyObject"
+            },
+            "propertyDefinitionSteps": [{
+              "name": "Object name",
+              "description": "Specify the Salesforce object name",
+              "properties": {
+                "sObjectName": {
+                  "kind": "parameter",
+                  "displayName": "Object name",
+                  "group": "common",
+                  "required": true,
+                  "type": "string",
+                  "javaType": "java.lang.String",
+                  "tags":[],
+                  "deprecated": false,
+                  "secret": false,
+                  "componentProperty": false,
+                  "defaultValue": "Contact",
+                  "description": "Name of the Salesforce object"
+                }
+              }
+            }]
+          }
+        },{
+          "id": "io.syndesis:salesforce-on-update-connector:latest",
+          "name": "On update",
+          "description": "Get notified when an Salesforce record is updated",
+          "camelConnectorGAV": "io.syndesis:salesforce-on-update-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "salesforce-on-update",
+          "tags": [ "dynamic" ],
+          "definition": {
+            "inputDataShape": {
+               "kind": "none"
+            },
+            "outputDataShape": {
+               "kind": "java",
+               "type": "io.syndesis.connector.salesforce.AnyObject"
+            },
+            "propertyDefinitionSteps": [{
+              "name": "Object name",
+              "description": "Specify the Salesforce object name",
+              "properties": {
+                "sObjectName": {
+                  "kind": "parameter",
+                  "displayName": "Object name",
+                  "group": "common",
+                  "required": true,
+                  "type": "string",
+                  "javaType": "java.lang.String",
+                  "tags":[],
+                  "deprecated": false,
+                  "secret": false,
+                  "componentProperty": false,
+                  "defaultValue": "Contact",
+                  "description": "Name of the Salesforce object"
+                }
+              }
+            }]
+          }
+        },{
+          "id": "io.syndesis:salesforce-on-delete-connector:latest",
+          "name": "On delete",
+          "description": "Get notified when an Salesforce record is deleted",
+          "camelConnectorGAV": "io.syndesis:salesforce-on-delete-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "salesforce-on-delete",
+          "tags": [ "dynamic" ],
+          "definition": {
+            "inputDataShape": {
+               "kind": "none"
+            },
+            "outputDataShape": {
+               "kind": "java",
+               "type": "io.syndesis.connector.salesforce.AnyObject"
+            },
+            "propertyDefinitionSteps": [{
+              "name": "Object name",
+              "description": "Specify the Salesforce object name",
+              "properties": {
+                "sObjectName": {
+                  "kind": "parameter",
+                  "displayName": "Object name",
+                  "group": "common",
+                  "required": true,
+                  "type": "string",
+                  "javaType": "java.lang.String",
+                  "tags":[],
+                  "deprecated": false,
+                  "secret": false,
+                  "componentProperty": false,
+                  "defaultValue": "Contact",
+                  "description": "Name of the Salesforce object"
                 }
               }
             }]
@@ -807,7 +915,7 @@
                   "kind": "path",
                   "displayName": "Template",
                   "group": "producer",
-                  "required": false,
+                  "required": true,
                   "type": "string",
                   "javaType": "java.lang.String",
                   "tags":[],

--- a/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -71,7 +71,7 @@
           "description": "Search for tweets that mention you",
           "id": "io.syndesis:twitter-mention-connector:latest",
           "camelConnectorGAV": "io.syndesis:twitter-mention-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "twitter-mention",
+          "camelConnectorPrefix": "twitter-mention-connector",
           "definition": {
             "inputDataShape": {
                "kind": "none"
@@ -103,29 +103,29 @@
               "properties": {
                 "filterOld": {
                   "kind": "parameter",
-                  "displayName": "Filter already polled tweets",
+                  "displayName": "Ignore tweets previously found",
                   "group": "filter",
                   "label": "consumer,filter",
-                  "required": false,
                   "type": "boolean",
                   "javaType": "boolean",
                   "tags":[],
                   "deprecated": false,
                   "secret": false,
                   "defaultValue": true,
+                  "componentProperty": false,
                   "description": "Filter out old tweets that have previously been polled"
                 },
                 "keywords": {
-                  "kind": "parameter",
+                  "kind": "path",
                   "displayName": "Keywords",
-                  "group": "filter",
-                  "label": "consumer,filter",
+                  "group": "common",
                   "required": true,
                   "type": "string",
                   "javaType": "java.lang.String",
                   "tags":[],
                   "deprecated": false,
                   "secret": false,
+                  "componentProperty": false,
                   "description": "Multiple search values can be separated with comma"
                 },
                 "delay": {
@@ -133,13 +133,13 @@
                   "displayName": "Delay",
                   "group": "scheduler",
                   "label": "consumer,scheduler",
-                  "required": false,
                   "type": "integer",
                   "javaType": "long",
                   "tags":[],
                   "deprecated": false,
                   "secret": false,
                   "defaultValue": 5000,
+                  "componentProperty": false,
                   "description": "Milliseconds before the next poll"
                 }
               }
@@ -171,22 +171,7 @@
           "secret": false,
           "componentProperty": true,
           "defaultValue": "https://login.salesforce.com",
-          "description": "URL of the Salesforce instance by default set to https://login.salesforce.com"
-        },
-        "instanceUrl": {
-          "kind": "property",
-          "displayName": "Instance URL",
-          "group": "security",
-          "label": "common,security",
-          "required": false,
-          "type": "string",
-          "javaType": "java.lang.String",
-          "tags":[],
-          "deprecated": false,
-          "secret": false,
-          "componentProperty": true,
-          "defaultValue": "",
-          "description": "URL of the Salesforce instance"
+          "description": "URL of the Salesforce instance used for authentication by default set to https://login.salesforce.com"
         },
         "clientId": {
           "kind": "property",
@@ -198,7 +183,7 @@
           "javaType": "java.lang.String",
           "tags":["oauth-client-id"],
           "deprecated": false,
-          "secret": true,
+          "secret": false,
           "componentProperty": true,
           "description": "OAuth Consumer Key of the connected app configured in the Salesforce instance setup. Typically a connected app needs to be configured but one can be provided by installing a package."
         },
@@ -240,7 +225,7 @@
           "javaType": "java.lang.String",
           "tags":[],
           "deprecated": false,
-          "secret": true,
+          "secret": false,
           "componentProperty": true,
           "description": "Username used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows."
         },
@@ -261,42 +246,6 @@
       },
       "actions": [
         {
-          "id": "io.syndesis:salesforce-upsert-contact-connector:latest",
-          "name": "Create/Update Contact",
-          "description": "Create or Update a Salesforce Contact",
-          "camelConnectorGAV": "io.syndesis:salesforce-upsert-contact-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "salesforce-upsert-contact",
-          "tags": [ "dynamic" ],
-          "definition": {
-            "inputDataShape": {
-               "kind" : "java",
-               "type" : "io.syndesis.connector.salesforce.Contact"
-            },
-            "outputDataShape": {
-               "kind" : "none"
-            },
-            "propertyDefinitionSteps": [{
-              "name": "Unique field",
-              "description": "Specify field to hold the identifying value",
-              "properties": {
-                "sObjectIdName": {
-                  "kind": "parameter",
-                  "displayName": "SObject Id Name",
-                  "group": "common",
-                  "required": false,
-                  "type": "string",
-                  "javaType": "java.lang.String",
-                  "tags":[],
-                  "deprecated": false,
-                  "secret": false,
-                  "componentProperty": false,
-                  "defaultValue": "TwitterScreenName__c",
-                  "description": "SObject external ID field name"
-                }
-              }
-            }]
-          }
-        },{
           "id": "io.syndesis:salesforce-create-sobject-connector:latest",
           "name": "Create Salesforce object",
           "description": "Create Salesforce Object",
@@ -424,6 +373,42 @@
             }]
           }
         },{
+          "id": "io.syndesis:salesforce-get-sobject-connector:latest",
+          "name": "Fetch Salesforce object by ID",
+          "description": "Fetch Salesforce object by its ID",
+          "camelConnectorGAV": "io.syndesis:salesforce-get-sobject-connector:@syndesis-connectors.version@",
+          "camelConnectorPrefix": "salesforce-get-sobject",
+          "tags": [ "dynamic" ],
+          "definition": {
+            "inputDataShape": {
+               "kind": "java",
+               "type": "io.syndesis.connector.salesforce.ExternalIdToGet"
+            },
+            "outputDataShape": {
+               "kind": "none"
+            },
+            "propertyDefinitionSteps": [{
+              "name": "Object name",
+              "description": "Specify the Salesforce object name",
+              "properties": {
+                "sObjectName": {
+                  "kind": "parameter",
+                  "displayName": "Object name",
+                  "group": "common",
+                  "required": true,
+                  "type": "string",
+                  "javaType": "java.lang.String",
+                  "tags":[],
+                  "deprecated": false,
+                  "secret": false,
+                  "componentProperty": false,
+                  "defaultValue": "Contact",
+                  "description": "Name of the Salesforce object"
+                }
+              }
+            }]
+          }
+        },{
           "id": "io.syndesis:salesforce-get-sobject-with-id-connector:latest",
           "name": "Fetch Salesforce object by unique ID",
           "description": "Fetch Salesforce object by unique ID",
@@ -474,41 +459,6 @@
                   "componentProperty": false,
                   "defaultValue": "",
                   "description": "SObject external ID field name"
-                }
-              }
-            }]
-          }
-        },{
-          "id": "io.syndesis:salesforce-update-sobject-connector:latest",
-          "name": "Update Salesforce object",
-          "description": "Update Salesforce Object",
-          "camelConnectorGAV": "io.syndesis:salesforce-update-sobject-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "salesforce-update-sobject",
-          "tags": [ "dynamic" ],
-          "definition": {
-            "inputDataShape": {
-               "kind": "json-schema"
-            },
-            "outputDataShape": {
-               "kind": "none"
-            },
-            "propertyDefinitionSteps": [{
-              "name": "Object name",
-              "description": "Specify the Salesforce object name",
-              "properties": {
-                "sObjectName": {
-                  "kind": "parameter",
-                  "displayName": "Object name",
-                  "group": "common",
-                  "required": true,
-                  "type": "string",
-                  "javaType": "java.lang.String",
-                  "tags":[],
-                  "deprecated": false,
-                  "secret": false,
-                  "componentProperty": false,
-                  "defaultValue": "Contact",
-                  "description": "Name of the Salesforce object"
                 }
               }
             }]
@@ -610,89 +560,6 @@
   {
     "kind": "connector",
     "data": {
-      "id": "http",
-      "name": "HTTP",
-      "description": "Interact with APIs and plain HTTP endpoints",
-      "icon": "fa-globe",
-      "configuredProperties": {},
-      "properties": {},
-      "actions": [
-        {
-          "id": "io.syndesis:http-get-connector:latest",
-          "name": "HTTP GET",
-          "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
-          "camelConnectorGAV": "io.syndesis:http-get-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "http-get-connector",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "none"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": [{
-              "name": "HTTP Endpoint",
-              "description": "Specify HTTP address to fetch the data from",
-              "properties": {
-                "httpUri": {
-                  "kind": "path",
-                  "displayName": "Http Uri",
-                  "group": "producer",
-                  "label": "producer",
-                  "required": true,
-                  "type": "string",
-                  "javaType": "java.net.URI",
-                  "tags":[],
-                  "deprecated": false,
-                  "secret": false,
-                  "componentProperty": false,
-                  "description": "The url of the HTTP endpoint to call."
-                }
-              }
-            }]
-          }
-        },
-        {
-          "id": "io.syndesis:http-post-connector:latest",
-          "name": "HTTP POST",
-          "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
-          "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "http-post-connector",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": [{
-              "name": "HTTP Endpoint",
-              "description": "Specify HTTP address to send the data to",
-              "properties": {
-                "httpUri": {
-                  "kind": "path",
-                  "displayName": "Http Uri",
-                  "group": "producer",
-                  "label": "producer",
-                  "required": true,
-                  "type": "string",
-                  "javaType": "java.net.URI",
-                  "tags":[],
-                  "deprecated": false,
-                  "secret": false,
-                  "componentProperty": false,
-                  "description": "The url of the HTTP endpoint to call."
-                }
-              }
-            }]
-          }
-        }
-      ]
-    }
-  },
-  {
-    "kind": "connector",
-    "data": {
       "id": "timer",
       "name": "Timer",
       "description": "Timer Connector",
@@ -705,7 +572,7 @@
           "name": "Periodic Timer",
           "description": "Set a timer that fires at intervals that you specify",
           "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "periodic-timer",
+          "camelConnectorPrefix": "periodic-timer-connector",
           "definition": {
             "inputDataShape": {
                "kind" : "none"
@@ -758,22 +625,8 @@
           "tags":[],
           "deprecated": false,
           "secret": false,
-          "componentProperty": false,
+          "componentProperty": true,
           "description": "Host and port of HTTP service to use (override host in swagger schema)"
-        },
-        "api_key": {
-          "kind": "property",
-          "displayName": "API Key",
-          "group": "producer",
-          "label": "producer",
-          "required": true,
-          "type": "string",
-          "javaType": "java.lang.String",
-          "tags":[],
-          "deprecated": false,
-          "secret": true,
-          "componentProperty": false,
-          "description": "The API Key used to access the service"
         }
       },
       "actions": [
@@ -834,428 +687,6 @@
   {
     "kind": "connector",
     "data": {
-      "id": "day-trade",
-      "name": "Day Trade",
-      "description": "Day Trade API connector",
-      "icon": "fa-usd",
-      "configuredProperties": {},
-      "properties": {
-        "host": {
-          "kind": "property",
-          "displayName": "Host",
-          "group": "producer",
-          "label": "producer",
-          "required": true,
-          "type": "string",
-          "javaType": "java.lang.String",
-          "tags":[],
-          "deprecated": false,
-          "secret": false,
-          "componentProperty": false,
-          "description": "Host and port of HTTP service to use (override host in swagger schema)"
-        },
-        "api_key": {
-          "kind": "property",
-          "displayName": "API Key",
-          "group": "producer",
-          "label": "producer",
-          "required": true,
-          "type": "string",
-          "javaType": "java.lang.String",
-          "tags":[],
-          "deprecated": false,
-          "secret": true,
-          "componentProperty": false,
-          "description": "The API Key used to access the service"
-        }
-      },
-      "actions": [
-        {
-          "name": "Place Trade",
-          "description": "Place trade on Day Trade API server",
-          "id": "io.syndesis:day-trade-place-connector:latest",
-          "camelConnectorGAV": "io.syndesis:day-trade-place-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "day-trade-place",
-          "definition": {
-            "inputDataShape": {
-              "kind": "java",
-              "type": "io.syndesis.connector.daytrade.Trade"
-            },
-            "outputDataShape": {
-              "kind": "none"
-            },
-            "propertyDefinitionSteps": []
-          }
-        },
-        {
-          "name": "Retrieve Trade",
-          "description": "Retrieve a trade on Day Trade API server",
-          "id": "io.syndesis:day-trade-place-connector:latest",
-          "camelConnectorGAV": "io.syndesis:day-trade-place-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "day-trade-place",
-          "definition": {
-            "inputDataShape": {
-              "kind": "java",
-              "type": "io.syndesis.connector.daytrade.Trade"
-            },
-            "outputDataShape": {
-              "kind": "java",
-              "type": "io.syndesis.connector.daytrade.Trade"
-            },
-            "propertyDefinitionSteps": []
-          }
-        },
-        {
-          "name": "Get Latest Trade",
-          "description": "Get the latest trade on Day Trade API server",
-          "id": "io.syndesis:day-trade-place-connector:latest",
-          "camelConnectorGAV": "io.syndesis:day-trade-place-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "day-trade-place",
-          "definition": {
-            "inputDataShape": {
-              "kind": "none"
-            },
-            "outputDataShape": {
-              "kind": "java",
-              "type": "io.syndesis.connector.daytrade.Trade"
-            },
-            "propertyDefinitionSteps": []
-          }
-        }
-      ]
-    }
-  },
-  {
-    "kind": "connector",
-    "data": {
-      "id": "linkedin",
-      "name": "LinkedIn",
-      "description": "Connect and interact with your professional social network",
-      "icon": "fa-puzzle-piece",
-      "configuredProperties": {},
-      "properties": {},
-      "actions": [
-        {
-          "id": "io.syndesis:linkedin-get-connections-connector:latest",
-          "name": "Get Connections",
-          "description": "Get all LinkedIn connections",
-          "camelConnectorGAV": "io.syndesis:linkedin-connections-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "linkedin-connections",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "none"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        },
-        {
-          "id": "io.syndesis:linkedin-add-invite-connector:latest",
-          "name": "Send Invite",
-          "description": "Send out a LinkedIn Invite",
-          "camelConnectorGAV": "io.syndesis:linkedin-invite-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "linkedin-invite",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "none"
-            },
-            "propertyDefinitionSteps": []
-          }
-        }
-      ]
-    }
-  },
-  {
-    "kind": "connector",
-    "data": {
-      "id": "servicenow",
-      "name": "ServiceNow",
-      "description": "Cloud-based IT Service Management",
-      "icon": "fa-puzzle-piece",
-      "configuredProperties": {},
-      "properties": {},
-      "actions": [
-        {
-          "id": "io.syndesis:servicenow-connector:latest",
-          "name": "service-now",
-          "description": "Provides access to all of ServiceNow REST API",
-          "camelConnectorGAV": "io.syndesis:servicenow-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "servicenow",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        }
-      ]
-    }
-  },
-  {
-    "kind": "connector",
-    "data": {
-      "id": "github",
-      "name": "GitHub",
-      "description": "Manage code on GitHub through commits, pull requests, tags, and more",
-      "icon": "fa-puzzle-piece",
-      "configuredProperties": {},
-      "properties": {},
-      "actions": [
-        {
-          "id": "io.syndesis:github-pullrequest-connector:latest",
-          "name": "github-pullrequest",
-          "description": "Create a GitHub PullRequest",
-          "camelConnectorGAV": "io.syndesis:github-pullrequest-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "github-pullrequest",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            }
-          }
-        },
-        {
-          "id": "io.syndesis:github-tag-connector:latest",
-          "name": "github-tag",
-          "description": "Create a GitHub Tag",
-          "camelConnectorGAV": "io.syndesis:github-tag-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "github-tag",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            }
-          }
-        },
-        {
-          "id": "io.syndesis:github-commit-connector:latest",
-          "name": "github-commit",
-          "description": "Performs a GitHub Commit",
-          "camelConnectorGAV": "io.syndesis:github-commit-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "github-commit",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        }
-      ]
-    }
-  },
-  {
-    "kind": "connector",
-    "data": {
-      "id": "gmail",
-      "name": "GMail",
-      "description": "Send and receive email using Google's Gmail service",
-      "icon": "fa-puzzle-piece",
-      "configuredProperties": {},
-      "properties": {},
-      "actions": [
-        {
-          "id": "io.syndesis:gmail-send:latest",
-          "name": "GMail Send",
-          "description": "Send an email",
-          "camelConnectorGAV": "io.syndesis:gmail-send-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "gmail-send",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        },
-        {
-          "id": "io.syndesis:gmail-list:latest",
-          "name": "GMail List",
-          "description": "List incoming messages",
-          "camelConnectorGAV": "io.syndesis:gmail-list-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "gmail-list",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        },
-        {
-          "id": "io.syndesis:gmail-get:latest",
-          "name": "GMail Get",
-          "description": "Get email message",
-          "camelConnectorGAV": "io.syndesis:gmail-get-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "gmail-get",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        },
-        {
-          "id": "io.syndesis:gmail-delete:latest",
-          "name": "GMail Delete",
-          "description": "Delete email message",
-          "camelConnectorGAV": "io.syndesis:gmail-delete-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "gmail-delete",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        }
-      ]
-    }
-  },
-  {
-    "kind": "connector",
-    "data": {
-      "id": "facebook",
-      "name": "Facebook",
-      "description": "Access Facebook social network features such as posts, users, checkins, etc",
-      "icon": "fa-puzzle-piece",
-      "configuredProperties": {},
-      "properties": {},
-      "actions": [
-        {
-          "id": "io.syndesis:facebook-post-connector:latest",
-          "name": "Post",
-          "description": "Creates a post to Facebook",
-          "camelConnectorGAV": "io.syndesis:facebook-post-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "facebook-post",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        },
-        {
-          "id": "io.syndesis:facebook-like-connector:latest",
-          "name": "Like",
-          "description": "Like something on Facebook",
-          "camelConnectorGAV": "io.syndesis:facebook-like-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "facebook-like",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        }
-      ]
-    }
-  },
-  {
-    "kind": "connector",
-    "data": {
-      "id": "jms",
-      "name": "Messaging",
-      "description": "Produce and consume messages for event-driven interaction",
-      "icon": "fa-puzzle-piece",
-      "configuredProperties": {},
-      "properties": {},
-      "actions": [
-        {
-          "id": "io.syndesis:jms-producer-connector:latest",
-          "name": "Message Producer",
-          "description": "Drop a message on a Queue",
-          "camelConnectorGAV": "io.syndesis:jms-producer-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "jms-producer",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            }
-          }
-        },
-        {
-          "id": "io.syndesis:jms-consumer-connector:latest",
-          "name": "Message Consumer",
-          "description": "Takes a message off a Queue",
-          "camelConnectorGAV": "io.syndesis:jms-consumer-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "jms-consumer",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        }
-      ]
-    }
-  },
-  {
-    "kind": "connector",
-    "data": {
-      "id": "ftp",
-      "name": "File Transfer",
-      "description": "Remote, secure file transfer",
-      "icon": "fa-puzzle-piece",
-      "configuredProperties": {},
-      "properties": {},
-      "actions": [
-        {
-          "id": "io.syndesis:ftp-connector:latest",
-          "name": "File Transport",
-          "description": "FTP/SFTP/FPTS file transfer",
-          "camelConnectorGAV": "io.syndesis:ftp-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "ftp",
-          "definition": {
-            "inputDataShape": {
-               "kind" : "any"
-            },
-            "outputDataShape": {
-               "kind" : "any"
-            },
-            "propertyDefinitionSteps": []
-          }
-        }
-      ]
-    }
-  },
-  {
-    "kind": "connector",
-    "data": {
       "id": "sql-stored",
       "name": "SQL Stored Procedure",
       "description": "Relational Database SQL Stored procedure invocation",
@@ -1265,8 +696,8 @@
         "url": {
           "kind": "property",
           "displayName": "Connection URL",
-          "group": "security",
-          "label": "common,security",
+          "group": "producer",
+          "label": "common",
           "required": true,
           "type": "string",
           "javaType": "java.lang.String",
@@ -1355,9 +786,9 @@
               "description": "Select the Stored Procedure",
               "properties": {
                 "procedureName": {
-                  "kind": "parameter",
+                  "kind": "path",
                   "displayName": "Procedure Name",
-                  "group": "common",
+                  "group": "producer",
                   "required": true,
                   "type": "string",
                   "javaType": "java.lang.String",
@@ -1373,7 +804,7 @@
               "description": "Specify SQL stored procedure parameters",
               "properties": {
                 "template": {
-                  "kind": "parameter",
+                  "kind": "path",
                   "displayName": "Template",
                   "group": "producer",
                   "required": false,

--- a/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
@@ -58,7 +58,7 @@ public class DataManagerTest {
         @SuppressWarnings("unchecked")
         ListResult<Connector> connectors = dataManager.fetchAll(Connector.class);
         assertThat(connectors.getItems().stream().map(Connector::getId).map(Optional::get))
-            .containsExactly("gmail", "github", "ftp", "facebook", "linkedin", "salesforce", "timer", "jms", "day-trade", "twitter", "servicenow", "http", "sql-stored", "trade-insight");
+            .containsExactly("gmail", "github", "ftp", "facebook", "linkedin", "salesforce", "timer", "jms", "twitter", "day-trade", "servicenow", "http", "sql-stored", "trade-insight");
         Assert.assertTrue(connectors.getTotalCount() > 1);
         Assert.assertTrue(connectors.getItems().size() > 1);
         Assert.assertEquals(connectors.getTotalCount(), connectors.getItems().size());
@@ -97,7 +97,7 @@ public class DataManagerTest {
     public void getSalesforceConnector() {
         Connector connector = dataManager.fetch(Connector.class, "salesforce");
         Assert.assertEquals("Second Connector in the deployment.json is Salesforce", "Salesforce", connector.getName());
-        Assert.assertEquals(8, connector.getActions().size());
+        Assert.assertEquals(7, connector.getActions().size());
     }
 
     @Test

--- a/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
@@ -97,7 +97,7 @@ public class DataManagerTest {
     public void getSalesforceConnector() {
         Connector connector = dataManager.fetch(Connector.class, "salesforce");
         Assert.assertEquals("Second Connector in the deployment.json is Salesforce", "Salesforce", connector.getName());
-        Assert.assertEquals(7, connector.getActions().size());
+        Assert.assertEquals(10, connector.getActions().size());
     }
 
     @Test

--- a/dao/src/test/java/io/syndesis/dao/DeploymentDescriptorTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DeploymentDescriptorTest.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.dao;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.apache.camel.catalog.connector.CamelConnectorCatalog;
+import org.apache.camel.catalog.connector.DefaultCamelConnectorCatalog;
+import org.apache.camel.catalog.maven.DefaultMavenArtifactProvider;
+import org.apache.camel.catalog.maven.MavenArtifactProvider;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Downloads all connectors defined in {@code deployment.json} and tries to
+ * resolve their endpoints using Camel catalog.
+ */
+public class DeploymentDescriptorTest {
+
+    private final CamelCatalog camelCatalog = new DefaultCamelCatalog(true);
+
+    private final CamelConnectorCatalog connectorCatalog = new DefaultCamelConnectorCatalog();
+
+    private final JsonNode deployment;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final MavenArtifactProvider mavenArtifactProvider = createArtifactProvider();
+
+    public DeploymentDescriptorTest() throws IOException {
+        deployment = mapper
+            .readTree(DeploymentDescriptorTest.class.getResourceAsStream("/io/syndesis/dao/deployment.json"));
+    }
+
+    @Test
+    @SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.JUnitTestContainsTooManyAsserts"})
+    public void deploymentDescriptorTakeCueFromConnectorDescriptor() {
+        for (final JsonNode entry : deployment) {
+            if ("connector".equals(entry.get("kind").asText())) {
+
+                final String connectorId = entry.get("data").get("id").asText();
+
+                final JsonNode connectorData = entry.get("data");
+                final JsonNode connectorPropertiesJson = connectorData.get("properties");
+
+                final JsonNode actions = connectorData.get("actions");
+                StreamSupport.stream(actions.spliterator(), true).forEach(action -> {
+                    final String actionName = action.get("name").asText();
+                    final String gav = action.get("camelConnectorGAV").asText();
+
+                    assertThat(gav).as("Action `%s` does not have `camelConnectorGAV` property", actionName)
+                        .isNotEmpty();
+
+                    final String[] coordinates = gav.split(":");
+
+                    mavenArtifactProvider.addArtifactToCatalog(camelCatalog, connectorCatalog, coordinates[0],
+                        coordinates[1], coordinates[2]);
+
+                    final String scheme = action.get("camelConnectorPrefix").asText();
+
+                    try {
+                        camelCatalog.asEndpointUri(scheme, new HashMap<>(), false);
+                    } catch (final URISyntaxException e) {
+                        fail("Action `%s` cannot be added to Camel context", actionName, e);
+                    }
+
+                    final String componentJsonSchemaFromCatalog = camelCatalog.componentJSonSchema(scheme);
+                    final JsonNode catalogedJsonSchema;
+                    try {
+                        catalogedJsonSchema = mapper.readTree(componentJsonSchemaFromCatalog);
+                    } catch (final IOException e) {
+                        fail("Unable to parse Camel component JSON schema", e);
+                        return;// never happens
+                    }
+
+                    final JsonNode componentPropertiesFromCatalog = catalogedJsonSchema.get("componentProperties");
+
+                    assertConnectorProperties(connectorId, connectorPropertiesJson, componentPropertiesFromCatalog);
+
+                    assertActionProperties(connectorId, action, actionName, catalogedJsonSchema);
+                });
+            }
+        }
+
+    }
+
+    @Test
+    public void thereShouldBeNoDuplicateMavenCoordinates() {
+        final Map<String, Long> coordinatesWithCount = StreamSupport.stream(deployment.spliterator(), true)
+            .filter(data -> "connector".equals(data.get("kind").asText()))
+            .flatMap(connector -> StreamSupport.stream(connector.get("data").get("actions").spliterator(), true))
+            .map(action -> action.get("camelConnectorGAV").asText())
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        final Map<String, Long> multipleCoordinates = coordinatesWithCount.entrySet().stream()
+            .filter(e -> e.getValue() > 1).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        assertThat(multipleCoordinates).as("Expected connector GAV coordinates to be unique").isEmpty();
+    }
+
+    @Test
+    public void thereShouldBeNoDuplicateNames() {
+        final Map<String, Long> namesWithCount = StreamSupport.stream(deployment.spliterator(), true)
+            .filter(data -> "connector".equals(data.get("kind").asText()))
+            .flatMap(connector -> StreamSupport.stream(connector.get("data").get("actions").spliterator(), true))
+            .map(action -> action.get("name").asText())
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        final Map<String, Long> multipleNames = namesWithCount.entrySet().stream().filter(e -> e.getValue() > 1)
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        assertThat(multipleNames).as("Expected unique action names").isEmpty();
+    }
+
+    private static void assertActionProperties(final String connectorId, final JsonNode action, final String actionName,
+        final JsonNode catalogedJsonSchema) {
+        final JsonNode actionDefinition = action.get("definition");
+
+        final JsonNode propertiesFromCatalog = catalogedJsonSchema.get("properties");
+
+        // make sure that all action properties are as defined in
+        // the connector
+        StreamSupport.stream(actionDefinition.get("propertyDefinitionSteps").spliterator(), true)
+            .flatMap(step -> StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(step.get("properties").fields(), Spliterator.CONCURRENT), true))
+            .forEach(property -> {
+                final String propertyName = property.getKey();
+                final JsonNode propertyDefinition = property.getValue();
+
+                final JsonNode catalogedPropertyDefinition = propertiesFromCatalog.get(propertyName);
+
+                assertThat(catalogedPropertyDefinition)
+                    .as("Definition of `%s` connector's action `%s` defines a property `%s` that is not defined in the Camel connector",
+                        connectorId, actionName, propertyName)
+                    .isNotNull();
+
+                assertThat(propertyDefinition.get("componentProperty"))
+                    .as("`componentProperty` field is missing for connector's %s %s action property %s", connectorId,
+                        actionName, propertyName)
+                    .isNotNull();
+                assertThat(propertyDefinition.get("componentProperty").asBoolean())
+                    .as("Definition of `%s` connector's action `%s` property `%s` should be marked as `componentProperty`",
+                        connectorId, actionName, propertyName)
+                    .isFalse();
+                // remove Syndesis specifics
+                final ObjectNode propertyDefinitionForComparisson = propertyNodeForComparisson(propertyDefinition);
+
+                // remove properties that we would like to customize
+                removeCustomizedProperties(propertyDefinitionForComparisson, catalogedPropertyDefinition);
+
+                assertThat(propertyDefinitionForComparisson)
+                    .as("Definition of `%s` connector's action's `%s` property `%s` differs from the one in Camel connector",
+                        connectorId, actionName, propertyName)
+                    .isEqualTo(catalogedPropertyDefinition);
+            });
+    }
+
+    private static void assertConnectorProperties(final String connectorId, final JsonNode connectorPropertiesJson,
+        final JsonNode componentPropertiesFromCatalog) {
+        // make sure that all connector properties are as defined in
+        // the connector
+        connectorPropertiesJson.fields().forEachRemaining(property -> {
+            final String propertyName = property.getKey();
+            final JsonNode propertyDefinition = property.getValue();
+
+            final JsonNode catalogedPropertyDefinition = componentPropertiesFromCatalog.get(propertyName);
+
+            assertThat(catalogedPropertyDefinition)
+                .as("Definition of `%s` connector has a property `%s` that is not defined in the Camel connector",
+                    connectorId, propertyName)
+                .isNotNull();
+
+            assertThat(propertyDefinition.get("componentProperty"))
+                .as("`componentProperty` field is missing for connector's %s property %s", connectorId, propertyName)
+                .isNotNull();
+            assertThat(propertyDefinition.get("componentProperty").asBoolean())
+                .as("Definition of `%s` connector's property `%s` should be marked as `componentProperty`", connectorId,
+                    propertyName)
+                .isTrue();
+            final ObjectNode propertyDefinitionForComparisson = propertyNodeForComparisson(propertyDefinition);
+
+            // remove properties that we would like to customize
+            removeCustomizedProperties(propertyDefinitionForComparisson, catalogedPropertyDefinition);
+
+            assertThat(propertyDefinitionForComparisson)
+                .as("Definition of `%s` connector's property `%s` differs from the one in Camel connector", connectorId,
+                    propertyName)
+                .isEqualTo(catalogedPropertyDefinition);
+        });
+    }
+
+    private static MavenArtifactProvider createArtifactProvider() {
+        final MavenArtifactProvider mavenArtifactProvider = new DefaultMavenArtifactProvider();
+
+        mavenArtifactProvider.addMavenRepository("maven.central", "https://repo1.maven.org/maven2");
+        mavenArtifactProvider.addMavenRepository("redhat.ga", "https://maven.repository.redhat.com/ga");
+        mavenArtifactProvider.addMavenRepository("jboss.ea", "https://repository.jboss.org/nexus/content/groups/ea");
+
+        return mavenArtifactProvider;
+    }
+
+    private static ObjectNode propertyNodeForComparisson(final JsonNode propertyDefinition) {
+        final ObjectNode propertyDefinitionForComparisson = propertyDefinition.deepCopy();
+        propertyDefinitionForComparisson.remove(Arrays.asList("tags", "componentProperty"));
+        return propertyDefinitionForComparisson;
+    }
+
+    private static void removeCustomizedProperties(final JsonNode... nodes) {
+        for (final JsonNode node : nodes) {
+            ((ObjectNode) node).remove(Arrays.asList("displayName", "description", "defaultValue", "optionalPrefix"));
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <basepom.test.timeout>150</basepom.test.timeout>
     <basepom.failsafe.timeout>150</basepom.failsafe.timeout>
 
-    <syndesis-connectors.version>0.5.0</syndesis-connectors.version>
+    <syndesis-connectors.version>0.5.2</syndesis-connectors.version>
     <syndesis-integration-runtime.version>0.1.6</syndesis-integration-runtime.version>
 
     <assertj-core.version>3.6.2</assertj-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,17 @@
         <scope>import</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-catalog-maven</artifactId>
+        <version>${camel.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
 
       <!-- Internal Dependencies -->
 

--- a/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
@@ -134,7 +134,7 @@ public class DefaultProjectGeneratorTest {
             .action(new Action.Builder()
                 .connectorId("timer")
                 .camelConnectorPrefix("periodic-timer-connector")
-                .camelConnectorGAV("io.syndesis:timer-connector:0.5.0")
+                .camelConnectorGAV("io.syndesis:timer-connector:0.5.2")
                 .build())
             .build();
 
@@ -147,7 +147,7 @@ public class DefaultProjectGeneratorTest {
             .action(new Action.Builder()
                 .connectorId("http")
                 .camelConnectorPrefix("http-get-connector")
-                .camelConnectorGAV("io.syndesis:http-get-connector:0.5.0")
+                .camelConnectorGAV("io.syndesis:http-get-connector:0.5.2")
                 .build())
             .build();
 
@@ -165,7 +165,7 @@ public class DefaultProjectGeneratorTest {
             .action(new Action.Builder()
                 .connectorId("http")
                 .camelConnectorPrefix("http-post-connector")
-                .camelConnectorGAV("io.syndesis:http-post-connector:0.5.0")
+                .camelConnectorGAV("io.syndesis:http-post-connector:0.5.2")
                 .build())
             .build();
 
@@ -211,7 +211,7 @@ public class DefaultProjectGeneratorTest {
                 .action(new Action.Builder()
                     .connectorId("timer")
                     .camelConnectorPrefix("periodic-timer-connector")
-                    .camelConnectorGAV("io.syndesis:timer-connector:0.5.0")
+                    .camelConnectorGAV("io.syndesis:timer-connector:0.5.2")
                     .build())
             .build();
 
@@ -225,7 +225,7 @@ public class DefaultProjectGeneratorTest {
             .action(new Action.Builder()
                 .connectorId("http")
                 .camelConnectorPrefix("http-get-connector")
-                .camelConnectorGAV("io.syndesis:http-get-connector:0.5.0")
+                .camelConnectorGAV("io.syndesis:http-get-connector:0.5.2")
                 .build())
             .build();
 
@@ -289,7 +289,7 @@ public class DefaultProjectGeneratorTest {
             .action(new Action.Builder()
                 .connectorId("timer")
                 .camelConnectorPrefix("periodic-timer-connector")
-                .camelConnectorGAV("io.syndesis:timer-connector:0.5.0")
+                .camelConnectorGAV("io.syndesis:timer-connector:0.5.2")
                 .build())
             .build();
 
@@ -307,7 +307,7 @@ public class DefaultProjectGeneratorTest {
             .action(new Action.Builder()
                 .connectorId("http")
                 .camelConnectorPrefix("http-post-connector")
-                .camelConnectorGAV("io.syndesis:http-post-connector:0.5.0")
+                .camelConnectorGAV("io.syndesis:http-post-connector:0.5.2")
                 .build())
             .build();
 
@@ -343,7 +343,7 @@ public class DefaultProjectGeneratorTest {
             .action(new Action.Builder()
                 .connectorId("timer")
                 .camelConnectorPrefix("periodic-timer-connector")
-                .camelConnectorGAV("io.syndesis:timer-connector:0.5.0")
+                .camelConnectorGAV("io.syndesis:timer-connector:0.5.2")
                 .build())
             .build();
 
@@ -363,7 +363,7 @@ public class DefaultProjectGeneratorTest {
             .action(new Action.Builder()
                 .connectorId("http")
                 .camelConnectorPrefix("http-post-connector")
-                .camelConnectorGAV("io.syndesis:http-post-connector:0.5.0")
+                .camelConnectorGAV("io.syndesis:http-post-connector:0.5.2")
                 .build())
             .build();
 

--- a/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
@@ -133,7 +133,7 @@ public class DefaultProjectGeneratorTest {
             .configuredProperties(map("period",5000))
             .action(new Action.Builder()
                 .connectorId("timer")
-                .camelConnectorPrefix("periodic-timer")
+                .camelConnectorPrefix("periodic-timer-connector")
                 .camelConnectorGAV("io.syndesis:timer-connector:0.5.0")
                 .build())
             .build();
@@ -210,7 +210,7 @@ public class DefaultProjectGeneratorTest {
             .configuredProperties(map("period",5000))
                 .action(new Action.Builder()
                     .connectorId("timer")
-                    .camelConnectorPrefix("periodic-timer")
+                    .camelConnectorPrefix("periodic-timer-connector")
                     .camelConnectorGAV("io.syndesis:timer-connector:0.5.0")
                     .build())
             .build();
@@ -288,7 +288,7 @@ public class DefaultProjectGeneratorTest {
             .configuredProperties(map("period", 5000))
             .action(new Action.Builder()
                 .connectorId("timer")
-                .camelConnectorPrefix("periodic-timer")
+                .camelConnectorPrefix("periodic-timer-connector")
                 .camelConnectorGAV("io.syndesis:timer-connector:0.5.0")
                 .build())
             .build();
@@ -342,7 +342,7 @@ public class DefaultProjectGeneratorTest {
             .configuredProperties(map("period", 5000))
             .action(new Action.Builder()
                 .connectorId("timer")
-                .camelConnectorPrefix("periodic-timer")
+                .camelConnectorPrefix("periodic-timer-connector")
                 .camelConnectorGAV("io.syndesis:timer-connector:0.5.0")
                 .build())
             .build();

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-filter-syndesis.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-filter-syndesis.yml
@@ -2,7 +2,7 @@
 flows:
 - steps:
   - kind: endpoint
-    uri: periodic-timer:every?period=5000
+    uri: periodic-timer-connector?period=5000
   - kind: filter
     expression: ${body.in.header.counter} > '10'
     steps:

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-integration.json
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-integration.json
@@ -23,7 +23,7 @@
           "name": "PeriodicTimer",
           "id": "io.syndesis_timer-connector_@syndesis-connectors.version@",
           "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "periodic-timer"
+          "camelConnectorPrefix": "periodic-timer-connector"
         },
         "configuredProperties": {
           "period": "5000"

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-mapper-syndesis.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-mapper-syndesis.yml
@@ -2,7 +2,7 @@
 flows:
 - steps:
   - kind: endpoint
-    uri: periodic-timer:every?period=5000
+    uri: periodic-timer-connector?period=5000
   - kind: endpoint
     uri: atlas:mapping-step-2.json
   - kind: endpoint

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-syndesis.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-syndesis.yml
@@ -2,7 +2,7 @@
 flows:
 - steps:
   - kind: endpoint
-    uri: periodic-timer:every?period=5000
+    uri: periodic-timer-connector?period=5000
   - kind: endpoint
     uri: http-get-connector?httpUri=http://localhost:8080/hello
   - kind: log

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-syndesis-with-secrets.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-syndesis-with-secrets.yml
@@ -2,6 +2,6 @@
 flows:
 - steps:
   - kind: endpoint
-    uri: periodic-timer:every?period=5000
+    uri: periodic-timer-connector?period=5000
   - kind: endpoint
     uri: http-get-connector-2?httpUri=http://localhost:8080/hello&password={{http-get-connector-2.password}}&username={{http-get-connector-2.username}}

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-syndesis.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-syndesis.yml
@@ -2,7 +2,7 @@
 flows:
 - steps:
   - kind: endpoint
-    uri: periodic-timer:every?period=5000
+    uri: periodic-timer-connector?period=5000
   - kind: endpoint
     uri: http-get-connector?httpUri=http://localhost:8080/hello
   - kind: log

--- a/runtime/src/main/resources/application.yml
+++ b/runtime/src/main/resources/application.yml
@@ -56,7 +56,7 @@ endpoints:
 dao:
   kind: jsondb
   schema:
-    version: 14 # changing this will reset all the DB data.
+    version: 15 # changing this will reset all the DB data.
 
 # OpenShift infra value
 openshift:


### PR DESCRIPTION
**Test will not pass until connectors are released**

This updates the `deployment.json` by removing the connectors that are
only for demo purposes (that is either do not work anymore or do not
have an implementation) and updating connector/action definitions to
match those in connectors.

Adds a test to make sure that the connectors defined in
`deployment.json` can be resolved and match in definition.