### PR TITLE
feat(setup): Add setup JAX-RS application for first time user setup

### DIFF
--- a/core/src/main/java/io/syndesis/core/immutable/ImmutablesStyle.java
+++ b/core/src/main/java/io/syndesis/core/immutable/ImmutablesStyle.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.model;
+package io.syndesis.core.immutable;
 
 import org.immutables.value.Value;
 

--- a/credential/src/main/java/io/syndesis/credential/package-info.java
+++ b/credential/src/main/java/io/syndesis/credential/package-info.java
@@ -13,5 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-@io.syndesis.model.ImmutablesStyle
+@ImmutablesStyle
 package io.syndesis.credential;
+
+import io.syndesis.core.immutable.ImmutablesStyle;

--- a/model/src/main/java/io/syndesis/model/connection/ActionDefinition.java
+++ b/model/src/main/java/io/syndesis/model/connection/ActionDefinition.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import io.syndesis.model.ImmutablesStyle;
+import io.syndesis.core.immutable.ImmutablesStyle;
 import io.syndesis.model.WithName;
 import io.syndesis.model.WithProperties;
 

--- a/model/src/main/java/io/syndesis/model/connection/package-info.java
+++ b/model/src/main/java/io/syndesis/model/connection/package-info.java
@@ -16,4 +16,4 @@
 @ImmutablesStyle
 package io.syndesis.model.connection;
 
-import io.syndesis.model.ImmutablesStyle;
+import io.syndesis.core.immutable.ImmutablesStyle;

--- a/model/src/main/java/io/syndesis/model/environment/package-info.java
+++ b/model/src/main/java/io/syndesis/model/environment/package-info.java
@@ -16,4 +16,4 @@
 @ImmutablesStyle
 package io.syndesis.model.environment;
 
-import io.syndesis.model.ImmutablesStyle;
+import io.syndesis.core.immutable.ImmutablesStyle;

--- a/model/src/main/java/io/syndesis/model/integration/package-info.java
+++ b/model/src/main/java/io/syndesis/model/integration/package-info.java
@@ -16,4 +16,4 @@
 @ImmutablesStyle
 package io.syndesis.model.integration;
 
-import io.syndesis.model.ImmutablesStyle;
+import io.syndesis.core.immutable.ImmutablesStyle;

--- a/model/src/main/java/io/syndesis/model/package-info.java
+++ b/model/src/main/java/io/syndesis/model/package-info.java
@@ -15,3 +15,5 @@
  */
 @ImmutablesStyle
 package io.syndesis.model;
+
+import io.syndesis.core.immutable.ImmutablesStyle;

--- a/model/src/main/java/io/syndesis/model/user/package-info.java
+++ b/model/src/main/java/io/syndesis/model/user/package-info.java
@@ -16,4 +16,4 @@
 @ImmutablesStyle
 package io.syndesis.model.user;
 
-import io.syndesis.model.ImmutablesStyle;
+import io.syndesis.core.immutable.ImmutablesStyle;

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
     <undertow.version>1.4.18.Final</undertow.version>
     <atlasmap.version>1.17.0</atlasmap.version>
     <camel-atlasmap.version>1.20.1</camel-atlasmap.version>
+    <apache-mime4j.version>0.6</apache-mime4j.version>
 
     <!-- maven plugin version -->
     <dep.plugin.dependency.version>3.0.1</dep.plugin.dependency.version>
@@ -196,6 +197,7 @@
     <module>runtime</module>
     <module>verifier</module>
     <module>inspector</module>
+    <module>setup</module>
   </modules>
 
   <dependencyManagement>
@@ -347,6 +349,12 @@
       <dependency>
         <groupId>io.syndesis</groupId>
         <artifactId>credential</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.syndesis</groupId>
+        <artifactId>setup</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -754,6 +762,32 @@
         <scope>test</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-admin-client</artifactId>
+        <version>${keycloak.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-multipart-provider</artifactId>
+        <version>${resteasy.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+
+      <!-- Only here to exclude commons-logging transitive dependency - not direct dependency-->
+      <dependency>
+        <groupId>org.apache.james</groupId>
+        <artifactId>apache-mime4j</artifactId>
+        <version>${apache-mime4j.version}</version>
+        <scope>runtime</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
@@ -912,6 +946,11 @@
                     <requireReleaseDeps>
                       <message>No Snapshots Allowed!</message>
                     </requireReleaseDeps>
+                    <bannedDependencies>
+                      <excludes>
+                        <exclude>commons-logging</exclude>
+                      </excludes>
+                    </bannedDependencies>
                   </rules>
                   <fail>false</fail>
                 </configuration>

--- a/project-generator/src/main/java/io/syndesis/project/converter/package-info.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/package-info.java
@@ -16,4 +16,4 @@
 @ImmutablesStyle
 package io.syndesis.project.converter;
 
-import io.syndesis.model.ImmutablesStyle;
+import io.syndesis.core.immutable.ImmutablesStyle;

--- a/rest/src/main/java/io/syndesis/rest/v1/operations/Violation.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/operations/Violation.java
@@ -22,7 +22,7 @@ import javax.validation.metadata.ConstraintDescriptor;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import io.syndesis.model.ImmutablesStyle;
+import io.syndesis.core.immutable.ImmutablesStyle;
 
 import org.immutables.value.Value;
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -492,6 +492,12 @@
       <artifactId>credential</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>setup</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- Credentials to support -->
     <dependency>
       <groupId>org.springframework.social</groupId>

--- a/runtime/src/main/java/io/syndesis/runtime/JacksonContextResolver.java
+++ b/runtime/src/main/java/io/syndesis/runtime/JacksonContextResolver.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.rest.v1;
+package io.syndesis.runtime;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;

--- a/runtime/src/main/java/io/syndesis/runtime/KeycloakConfiguration.java
+++ b/runtime/src/main/java/io/syndesis/runtime/KeycloakConfiguration.java
@@ -116,6 +116,7 @@ public class KeycloakConfiguration extends KeycloakWebSecurityConfigurerAdapter 
             .antMatchers("/api/v1/index.html").permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/credentials/callback").permitAll()
             .antMatchers("/api/v1/**").authenticated()
+            .antMatchers("/api/setup").authenticated()
             .anyRequest().permitAll();
 
         http.csrf().disable();

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Copyright (C) 2016 Red Hat, Inc.
+~
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~           http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>syndesis-rest-parent</artifactId>
+    <groupId>io.syndesis</groupId>
+    <version>0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>setup</artifactId>
+  <name>Syndesis REST :: Setup</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-admin-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/setup/src/main/java/io/syndesis/rest/setup/SetupApplication.java
+++ b/setup/src/main/java/io/syndesis/rest/setup/SetupApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.setup;
+
+import io.swagger.jaxrs.config.BeanConfig;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@Component
+@ApplicationPath("/api/setup")
+public class SetupApplication extends Application {
+
+    public SetupApplication() {
+        BeanConfig beanConfig = new BeanConfig();
+        beanConfig.setVersion("v1");
+        beanConfig.setSchemes(new String[]{"http", "https"});
+        beanConfig.setBasePath("/api/setup");
+        beanConfig.setResourcePackage(getClass().getPackage().getName());
+        beanConfig.setScan(true);
+    }
+
+}

--- a/setup/src/main/java/io/syndesis/rest/setup/SetupConfiguration.java
+++ b/setup/src/main/java/io/syndesis/rest/setup/SetupConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.setup;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configured in spring.factories so that this configuration is automatically picked
+ * up when included in the classpath.
+ */
+@Configuration
+@ComponentScan
+public class SetupConfiguration {
+
+}

--- a/setup/src/main/java/io/syndesis/rest/setup/SetupHandler.java
+++ b/setup/src/main/java/io/syndesis/rest/setup/SetupHandler.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.setup;
+
+import io.swagger.annotations.Api;
+import io.syndesis.rest.setup.keycloak.KeycloakProperties;
+import io.syndesis.rest.setup.model.SetupConfigurationRequest;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.IdentityProviderResource;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+@Api(value = "setup")
+@Component
+public class SetupHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SetupHandler.class);
+
+    private Keycloak keycloakAdminClient;
+    private KeycloakProperties keycloakProperties;
+
+    public SetupHandler(final Keycloak keycloakAdminClient, final KeycloakProperties keycloakProperties) {
+        this.keycloakAdminClient = keycloakAdminClient;
+        this.keycloakProperties = keycloakProperties;
+    }
+
+    @GET
+    public Response get() {
+        IdentityProviderRepresentation idp = getGitHubIdentityProvider();
+
+        if (idp == null) {
+            LOG.error("Missing GitHub identity provider");
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+
+        if (isClientIdUnset(idp)) {
+            return Response.status(Response.Status.GONE).build();
+        }
+
+        return Response.status(Response.Status.NO_CONTENT).build();
+    }
+
+    @PUT
+    @Consumes("application/json")
+    public Response update(@NotNull @Valid SetupConfigurationRequest setupConfiguration) {
+        IdentityProviderResource identityProviderResource = getGitHubIdentityProviderResource();
+
+        if (identityProviderResource == null) {
+            LOG.error("Missing GitHub identity provider");
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+
+        IdentityProviderRepresentation idp = identityProviderResource.toRepresentation();
+        if (isClientIdUnset(idp)) {
+            return Response.status(Response.Status.GONE).build();
+        }
+
+        idp.getConfig().put("clientId", setupConfiguration.getGitHubOAuthConfiguration().getClientId());
+        idp.getConfig().put("clientSecret", setupConfiguration.getGitHubOAuthConfiguration().getClientSecret());
+
+        identityProviderResource.update(idp);
+        return Response.status(Response.Status.NO_CONTENT).build();
+    }
+
+    private IdentityProviderResource getGitHubIdentityProviderResource() {
+        return keycloakAdminClient.realm(keycloakProperties.getSyndesisRealm()).identityProviders().get(keycloakProperties.getGitHubIdentityProviderId());
+    }
+
+    private RealmRepresentation getRealm() {
+        return keycloakAdminClient.realm(keycloakProperties.getSyndesisRealm()).toRepresentation();
+    }
+
+    private IdentityProviderRepresentation getGitHubIdentityProvider() {
+        RealmRepresentation realm = getRealm();
+        return getGitHubIdentityProviderFromRealm(realm);
+    }
+
+    private IdentityProviderRepresentation getGitHubIdentityProviderFromRealm(RealmRepresentation realm) {
+        for (IdentityProviderRepresentation idp : realm.getIdentityProviders()) {
+            if (keycloakProperties.getGitHubIdentityProviderId().equals(idp.getProviderId())) {
+                return idp;
+            }
+        }
+
+        return null;
+    }
+
+    private boolean isClientIdUnset(IdentityProviderRepresentation idp) {
+        return !keycloakProperties.getGithubIdentityProviderUnsetClientId().equals(idp.getConfig().get("clientId"));
+    }
+
+}

--- a/setup/src/main/java/io/syndesis/rest/setup/keycloak/KeycloakProperties.java
+++ b/setup/src/main/java/io/syndesis/rest/setup/keycloak/KeycloakProperties.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.setup.keycloak;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("keycloak")
+public class KeycloakProperties {
+
+    private boolean enabled = true;
+
+    private String keycloakUrl = "http://syndesis-keycloak:8080/auth";
+
+    private String adminUsername = "admin";
+
+    private String adminPassword;
+
+    private String adminRealm = "master";
+
+    private String adminClientId = "admin-cli";
+
+    private String syndesisRealm = "syndesis";
+
+    private String gitHubIdentityProviderId = "github";
+
+    private String githubIdentityProviderUnsetClientId = "dummy";
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getAdminUsername() {
+        return adminUsername;
+    }
+
+    public void setAdminUsername(String adminUsername) {
+        this.adminUsername = adminUsername;
+    }
+
+    public String getAdminPassword() {
+        return adminPassword;
+    }
+
+    public void setAdminPassword(String adminPassword) {
+        this.adminPassword = adminPassword;
+    }
+
+    public String getKeycloakUrl() {
+        return keycloakUrl;
+    }
+
+    public void setKeycloakUrl(String keycloakUrl) {
+        this.keycloakUrl = keycloakUrl;
+    }
+
+    public String getAdminRealm() {
+        return adminRealm;
+    }
+
+    public void setAdminRealm(String adminRealm) {
+        this.adminRealm = adminRealm;
+    }
+
+    public String getAdminClientId() {
+        return adminClientId;
+    }
+
+    public void setAdminClientId(String adminClientId) {
+        this.adminClientId = adminClientId;
+    }
+
+    public String getSyndesisRealm() {
+        return syndesisRealm;
+    }
+
+    public void setSyndesisRealm(String syndesisRealm) {
+        this.syndesisRealm = syndesisRealm;
+    }
+
+    public String getGitHubIdentityProviderId() {
+        return gitHubIdentityProviderId;
+    }
+
+    public void setGitHubIdentityProviderId(String gitHubIdentityProviderId) {
+        this.gitHubIdentityProviderId = gitHubIdentityProviderId;
+    }
+
+    public String getGithubIdentityProviderUnsetClientId() {
+        return githubIdentityProviderUnsetClientId;
+    }
+
+    public void setGithubIdentityProviderUnsetClientId(String githubIdentityProviderUnsetClientId) {
+        this.githubIdentityProviderUnsetClientId = githubIdentityProviderUnsetClientId;
+    }
+}

--- a/setup/src/main/java/io/syndesis/rest/setup/keycloak/KeycloakSetupConfiguration.java
+++ b/setup/src/main/java/io/syndesis/rest/setup/keycloak/KeycloakSetupConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.setup.keycloak;
+
+import org.keycloak.admin.client.Keycloak;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configured in spring.factories so that this configuration is automatically picked
+ * up when included in the classpath.
+ */
+@Configuration
+@ComponentScan
+@ConditionalOnProperty(value = "keycloak.enabled", matchIfMissing = true, havingValue = "true")
+@EnableConfigurationProperties(KeycloakProperties.class)
+public class KeycloakSetupConfiguration {
+
+    @Bean
+    Keycloak keycloakAdminClient(KeycloakProperties props) {
+
+        return Keycloak.getInstance(
+            props.getKeycloakUrl(),
+            props.getAdminRealm(),
+            props.getAdminUsername(),
+            props.getAdminPassword(),
+            props.getAdminClientId()
+        );
+    }
+}

--- a/setup/src/main/java/io/syndesis/rest/setup/model/GitHubOAuthConfiguration.java
+++ b/setup/src/main/java/io/syndesis/rest/setup/model/GitHubOAuthConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.setup.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableGitHubOAuthConfiguration.Builder.class)
+public interface GitHubOAuthConfiguration {
+
+    String getClientId();
+
+    String getClientSecret();
+
+}

--- a/setup/src/main/java/io/syndesis/rest/setup/model/SetupConfigurationRequest.java
+++ b/setup/src/main/java/io/syndesis/rest/setup/model/SetupConfigurationRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.setup.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableSetupConfigurationRequest.Builder.class)
+public interface SetupConfigurationRequest {
+
+    GitHubOAuthConfiguration getGitHubOAuthConfiguration();
+
+}

--- a/setup/src/main/java/io/syndesis/rest/setup/model/package-info.java
+++ b/setup/src/main/java/io/syndesis/rest/setup/model/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ImmutablesStyle
+package io.syndesis.rest.setup.model;
+
+import io.syndesis.core.immutable.ImmutablesStyle;

--- a/setup/src/main/resources/META-INF/spring.factories
+++ b/setup/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+    io.syndesis.rest.setup.SetupConfiguration,\
+    io.syndesis.rest.setup.keycloak.KeycloakSetupConfiguration


### PR DESCRIPTION
The setup application provides a single endpoint, at `/api/setup`. This is
a one time only handler: once it is updated, it is unusable. The endpoint
accepts the following methods:

`GET`: This checks if setup is required. It returns `204` (`No Content`) if
the setup handler is still enabled, and `410` (`Gone`) if it is already
configured and hence can't be called again.

`PUT`: This attempts to update the configuration as requested. This handler
will return `410` (`Gone`) if configuration is no longer required. If the
endpoint is still enabled, then the handler accepts a JSON body with the
following format:

```json
{
  "gitHubOAuthConfiguration": {
    "clientId": "yourclientid",
    "clientSecret": "topsecret"
  }
}
```

The format of this is extensible for any future first time user setup
steps.

/cc @kahboom @gashcrumb