### PR TITLE
fix: sql stored connector id

### DIFF
--- a/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -668,7 +668,7 @@
   {
     "kind": "connector",
     "data": {
-      "id": "sql-stored",
+      "id": "sql-stored-connector",
       "name": "SQL Stored Procedure",
       "description": "Relational Database SQL Stored procedure invocation",
       "icon": "fa-database",

--- a/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
@@ -58,7 +58,7 @@ public class DataManagerTest {
         @SuppressWarnings("unchecked")
         ListResult<Connector> connectors = dataManager.fetchAll(Connector.class);
         assertThat(connectors.getItems().stream().map(Connector::getId).map(Optional::get))
-            .containsExactly("gmail", "github", "ftp", "facebook", "linkedin", "salesforce", "jms", "timer", "twitter", "day-trade", "servicenow", "http", "sql-stored", "trade-insight");
+            .containsExactly("gmail", "github", "ftp", "facebook", "linkedin", "salesforce", "jms", "timer", "twitter", "day-trade", "servicenow", "sql-stored-connector", "http", "trade-insight");
         Assert.assertTrue(connectors.getTotalCount() > 1);
         Assert.assertTrue(connectors.getItems().size() > 1);
         Assert.assertEquals(connectors.getTotalCount(), connectors.getItems().size());

--- a/runtime/src/main/resources/application.yml
+++ b/runtime/src/main/resources/application.yml
@@ -56,7 +56,7 @@ endpoints:
 dao:
   kind: jsondb
   schema:
-    version: 15 # changing this will reset all the DB data.
+    version: 16 # changing this will reset all the DB data.
 
 # OpenShift infra value
 openshift:

--- a/runtime/src/test/java/io/syndesis/runtime/action/DynamicActionSqlStoredITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/action/DynamicActionSqlStoredITCase.java
@@ -77,7 +77,7 @@ public class DynamicActionSqlStoredITCase extends BaseITCase {
 
     @Before
     public void setupConnection() {
-        dataManager.create(new Connection.Builder().id(connectionId).connectorId("sql-stored")
+        dataManager.create(new Connection.Builder().id(connectionId).connectorId("sql-stored-connector")
             .putConfiguredProperty("user", "sa").build());
     }
 
@@ -85,7 +85,7 @@ public class DynamicActionSqlStoredITCase extends BaseITCase {
     public void setupMocks() {
         stubFor(WireMock
             .post(urlEqualTo(
-                "/api/v1/connectors/sql-stored/actions/io.syndesis:sql-stored-connector:latest"))//
+                "/api/v1/connectors/sql-stored-connector/actions/io.syndesis:sql-stored-connector:latest"))//
             .withHeader("Accept", containing("application/json"))//
             .withRequestBody(
                     equalToJson("{\"template\":null,\"noop\":null,\"procedureName\":null,\"batch\":null,\"user\":\"sa\"}"))
@@ -96,7 +96,7 @@ public class DynamicActionSqlStoredITCase extends BaseITCase {
 
         stubFor(WireMock
             .post(urlEqualTo(
-                "/api/v1/connectors/sql-stored/actions/io.syndesis:sql-stored-connector:latest"))//
+                "/api/v1/connectors/sql-stored-connector/actions/io.syndesis:sql-stored-connector:latest"))//
             .withHeader("Accept", equalTo("application/json"))//
             .withRequestBody(
                     equalToJson("{\"template\":null,\"batch\":null,\"noop\":null,\"user\":\"sa\",\"procedureName\":\"DEMO_ADD\"}"))
@@ -121,12 +121,12 @@ public class DynamicActionSqlStoredITCase extends BaseITCase {
         ConfigurationProperty procedureNames = firstResponse.getBody().getPropertyDefinitionSteps().iterator().next().getProperties().get("procedureName");
         assertThat(procedureNames.getEnum().size() == 2);
         assertThat(procedureNames.getEnum().iterator().next().getLabel().startsWith("DEMO_ADD"));
-        
+
         final ResponseEntity<ActionDefinition> secondResponse = http(HttpMethod.POST,
-                "/api/v1/connections/" + connectionId + "/actions/io.syndesis:sql-stored-connector:latest", 
+                "/api/v1/connections/" + connectionId + "/actions/io.syndesis:sql-stored-connector:latest",
                 Collections.singletonMap("procedureName", "DEMO_ADD"),
                 ActionDefinition.class, tokenRule.validToken(), headers, HttpStatus.OK);
-        
+
         //System.out.println("secondResponse:" + mapper.writerWithDefaultPrettyPrinter().writeValueAsString(secondResponse));
         //System.out.println("inputSchema: " + mapper.writerWithDefaultPrettyPrinter().writeValueAsString(secondResponse.getBody().getInputDataShape().get()));
         boolean isValid = false;


### PR DESCRIPTION
SQL Stored connector id needs to be `sql-stored-connector` otherwise
when that ID is sent to verifier it will lookup the builtin `sql-stored`
Camel component.