### PR TITLE
feat(runtime): Prefetch connector catalog

### DIFF
--- a/connector-catalog/pom.xml
+++ b/connector-catalog/pom.xml
@@ -54,6 +54,14 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/connector-catalog/src/main/java/io/syndesis/connector/catalog/ConnectorCatalog.java
+++ b/connector-catalog/src/main/java/io/syndesis/connector/catalog/ConnectorCatalog.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Red Hat, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,7 +15,21 @@
  */
 package io.syndesis.connector.catalog;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.CollectionStringBuffer;
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.catalog.connector.CamelConnectorCatalog;
 import org.apache.camel.catalog.connector.DefaultCamelConnectorCatalog;
@@ -24,21 +38,23 @@ import org.apache.camel.catalog.maven.MavenArtifactProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URISyntaxException;
-import java.util.Map;
-
 public class ConnectorCatalog {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConnectorCatalog.class);
+    private static final String CONNECTOR_SCHEMAS = "/META-INF/camel/camel-meta.json";
 
     private final CamelConnectorCatalog connectorCatalog;
     private final CamelCatalog camelCatalog;
     private final MavenArtifactProvider maven;
 
+    private final Set<String> prefetchedConnectors = new HashSet<>();
+
     public ConnectorCatalog(ConnectorCatalogProperties props) {
 
         connectorCatalog = new DefaultCamelConnectorCatalog();
         camelCatalog = new DefaultCamelCatalog(true);
+
+        prefetchConnectors();
 
         maven = new DefaultMavenArtifactProvider();
 
@@ -51,7 +67,124 @@ public class ConnectorCatalog {
         }
     }
 
+    private void prefetchConnectors() {
+        try (InputStream is = getClass().getResourceAsStream(CONNECTOR_SCHEMAS)) {
+            if (is != null) {
+                ArrayNode descriptors = (ArrayNode) new ObjectMapper().readTree(is);
+                for (JsonNode descriptor : descriptors) {
+                    JsonNode gav = descriptor.get("gav");
+                    if (gav == null) {
+                        continue;
+                    }
+                    String gavCoords[] = gav.textValue().split(":");
+                    if (gavCoords.length < 3) {
+                        continue;
+                    }
+                    LOG.info("Prefetched meta for {}:{}:{}", gavCoords[0], gavCoords[1], gavCoords[2]);
+                    prefetchedConnectors.add(gav.textValue());
+
+                    JsonNode connector = descriptor.get("connector");
+                    ObjectNode component = (ObjectNode) descriptor.get("component");
+                    if (connector != null) {
+                        addConnector(gavCoords, connector, component);
+                    }
+                    if (component != null) {
+                        addComponent(component);
+                    }
+                }
+            }
+        } catch (IOException exp) {
+            LOG.error("Cannot initialize connectors from {} : {}", CONNECTOR_SCHEMAS, exp.getMessage(), exp);
+        }
+    }
+
+    private void addComponent(ObjectNode component) {
+        ObjectNode meta = (ObjectNode) component.get("meta");
+        Iterator<Map.Entry<String, JsonNode>> it = meta.fields();
+        while (it.hasNext()) {
+            Map.Entry<String, JsonNode> entry = it.next();
+            String json = entry.getValue().asText();
+            String javaType = extractJavaType(json);
+            if (javaType != null) {
+                camelCatalog.addComponent(entry.getKey(), javaType, json);
+            }
+        }
+    }
+
+    private void addConnector(String[] gavCoords, JsonNode connector, ObjectNode component) {
+        JsonNode meta = connector.get("meta");
+        connectorCatalog.addConnector(
+            gavCoords[0], gavCoords[1], gavCoords[2],
+            meta.get("name").textValue(),
+            meta.get("scheme").textValue(),
+            meta.get("javaType").textValue(),
+            meta.get("description").textValue(),
+            extractLabels(meta),
+            extractJson(connector, "meta"),
+            extractJsonTextString(connector, "schema"),
+            extractJsonTextString(component, "schema"));
+    }
+
+    private String extractJavaType(String json) {
+        try {
+            ObjectNode node = (ObjectNode) new ObjectMapper().readTree(json);
+            JsonNode c = node.get("component");
+            if (c != null) {
+                JsonNode ret = c.get("javaType");
+                if (ret != null) {
+                    return ret.asText();
+                }
+            }
+            return null;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private String extractJsonTextString(JsonNode descriptor, String key) {
+        if (descriptor != null && descriptor.hasNonNull(key)) {
+            // TODO: If this is a real JSON object, print it as JSON
+            // I.e. when JsonSchemaHelper is 'fixed', and
+            // ExtractConnectorDescriptorsMojo updated to store real json objects for
+            // JSONNodes and not only text
+            return descriptor.get(key).asText();
+        } else {
+            return null;
+        }
+    }
+
+    private String extractJson(JsonNode descriptor, String key) {
+        if (descriptor != null && descriptor.hasNonNull(key)) {
+            return getJsonAsString(descriptor.get(key));
+        } else {
+            return null;
+        }
+    }
+
+    private String getJsonAsString(JsonNode jsonNode) {
+        try {
+            return new ObjectMapper().writeValueAsString(jsonNode);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    private String extractLabels(JsonNode tree) {
+        Iterator<JsonNode> it = tree.withArray("labels").iterator();
+
+        CollectionStringBuffer csb = new CollectionStringBuffer(",");
+        while (it.hasNext()) {
+            String text = it.next().textValue();
+            csb.append(text);
+        }
+        return csb.toString();
+    }
+
     public final void addConnector(String gav) {
+        if (prefetchedConnectors.contains(gav)) {
+            return;
+        }
+
         String[] splitGAV = gav.split(":");
         if (splitGAV.length == 3) {
             String groupId = splitGAV[0];
@@ -67,11 +200,11 @@ public class ConnectorCatalog {
     public String buildEndpointUri(String scheme, Map<String, String> options) throws URISyntaxException {
         String result = camelCatalog.asEndpointUri(scheme, options, false);
         // we need to strip off the colon bit.
-        if( result.equals(scheme+":")) {
+        if (result.equals(scheme + ":")) {
             result = scheme;
         }
-        if( result.startsWith(scheme+":?")) {
-            result = scheme+result.substring(scheme.length()+1);
+        if (result.startsWith(scheme + ":?")) {
+            result = scheme + result.substring(scheme.length() + 1);
         }
         return result;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -897,6 +897,7 @@
             <ignoredResourcePattern>features.xml</ignoredResourcePattern>
             <ignoredResourcePattern>org/infinispan/.*</ignoredResourcePattern>
             <ignoredResourcePattern>ValidationMessages.properties</ignoredResourcePattern>
+            <ignoredResourcePattern>about.html</ignoredResourcePattern>
           </ignoredResourcePatterns>
         </configuration>
       </plugin>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -62,9 +62,80 @@
             <id>generate-mapper-inspections</id>
             <goals>
               <goal>generate-mapper-inspections</goal>
+              <goal>extract-connector-descriptors</goal>
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <!-- ==== Twitter ==== -->
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>twitter-mention-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>twitter-search-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <!-- ==== Salesforce ==== -->
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-on-create-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-on-update-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-on-delete-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-update-sobject-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-upsert-sobject-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-create-sobject-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-get-sobject-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-get-sobject-with-id-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-delete-sobject-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>salesforce-delete-sobject-with-id-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+          <!-- ==== SQL ==== -->
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>sql-stored-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>

--- a/syndesis-maven-plugin/pom.xml
+++ b/syndesis-maven-plugin/pom.xml
@@ -38,11 +38,75 @@
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>model</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-web</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.security</groupId>
+          <artifactId>spring-security-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.keycloak</groupId>
+          <artifactId>keycloak-spring-security-adapter</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.keycloak</groupId>
+          <artifactId>keycloak-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.keycloak</groupId>
+          <artifactId>keycloak-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.keycloak</groupId>
+          <artifactId>keycloak-adapter-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>javax.ws.rs-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>dao</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-beans</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.infinispan</groupId>
+          <artifactId>infinispan-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.infinispan</groupId>
+          <artifactId>infinispan-commons</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hibernate.javax.persistence</groupId>
+          <artifactId>hibernate-jpa-2.1-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -103,6 +167,35 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-artifact-transfer</artifactId>
+      <version>0.9.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>3.5</version>
@@ -120,6 +213,100 @@
       <groupId>io.syndesis</groupId>
       <artifactId>rest</artifactId>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-web</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.security</groupId>
+          <artifactId>spring-security-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.keycloak</groupId>
+          <artifactId>keycloak-spring-security-adapter</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.keycloak</groupId>
+          <artifactId>keycloak-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-beans</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-autoconfigure</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-test</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.social</groupId>
+          <artifactId>spring-social-twitter</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.social</groupId>
+          <artifactId>spring-social-config</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.social</groupId>
+          <artifactId>spring-social-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-test</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.security</groupId>
+          <artifactId>spring-security-crypto</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.github.mikegirard</groupId>
+          <artifactId>spring-social-salesforce</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.infinispan</groupId>
+          <artifactId>infinispan-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hibernate.javax.persistence</groupId>
+          <artifactId>hibernate-jpa-2.1-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.fabric8</groupId>
+          <artifactId>kubernetes-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.fabric8</groupId>
+          <artifactId>kubernetes-model</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.keycloak</groupId>
+          <artifactId>keycloak-adapter-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.swagger</groupId>
+          <artifactId>swagger-jaxrs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -158,16 +345,21 @@
       </plugin>
 
       <plugin>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <configuration>
+          <ignoredClassPatterns>
+            <ignoredClassPattern>org.eclipse.aether.util.artifact.*</ignoredClassPattern>
+            <ignoredClassPattern>org.eclipse.aether.util.filter.*</ignoredClassPattern>
+          </ignoredClassPatterns>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>com.ning.maven.plugins</groupId>
         <artifactId>maven-dependency-versions-check-plugin</artifactId>
         <configuration>
           <exceptions>
-            <exception>
-              <groupId>com.fasterxml.jackson.core</groupId>
-              <artifactId>jackson-annotations</artifactId>
-              <resolvedVersion>2.8.8</resolvedVersion>
-              <expectedVersion>2.8.4</expectedVersion>
-            </exception>
             <exception>
               <groupId>com.google.guava</groupId>
               <artifactId>guava</artifactId>
@@ -191,22 +383,12 @@
       </plugin>
 
       <plugin>
-        <groupId>org.basepom.maven</groupId>
-        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <groupId>com.hubspot.maven.plugins</groupId>
+        <artifactId>dependency-management-maven-plugin</artifactId>
         <configuration>
-          <ignoredClassPatterns>
-            <ignoredClassPattern>org.aopalliance.*</ignoredClassPattern>
-            <ignoredClassPattern>javax.annotation.*</ignoredClassPattern>
-            <ignoredClassPattern>io.fabric8.kubernetes.client.*</ignoredClassPattern>
-            <ignoredClassPattern>org.infinispan.*</ignoredClassPattern>
-            <ignoredClassPattern>org.springframework.security.crypto.*</ignoredClassPattern>
-            <ignoredClassPattern>org.objectweb.asm.*</ignoredClassPattern>
-            <ignoredClassPattern>javax.ws.*</ignoredClassPattern>
-          </ignoredClassPatterns>
-          <ignoredResourcePatterns>
-            <ignoredResourcePattern>about.html</ignoredResourcePattern>
-            <ignoredResourcePattern>features.xml</ignoredResourcePattern>
-          </ignoredResourcePatterns>
+          <requireManagement>
+            <allowExclusions>true</allowExclusions>
+          </requireManagement>
         </configuration>
       </plugin>
 

--- a/syndesis-maven-plugin/src/main/java/io/syndesis/maven/ExtractConnectorDescriptorsMojo.java
+++ b/syndesis-maven-plugin/src/main/java/io/syndesis/maven/ExtractConnectorDescriptorsMojo.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.Charset;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.Properties;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.artifact.resolve.ArtifactResolver;
+import org.apache.maven.shared.artifact.resolve.ArtifactResolverException;
+import org.apache.maven.shared.artifact.resolve.ArtifactResult;
+
+/**
+ * Simple maven plugin for creating a JSON file holding all connectors descriptors which are supported.
+ *
+ * @author roland
+ * @since 23.09.17
+ */
+@Mojo(name = "extract-connector-descriptors", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
+
+    @Component
+    private ArtifactResolver artifactResolver;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
+
+    @Parameter(defaultValue = "${project.remoteArtifactRepositories}", readonly = true, required = true)
+    private List<ArtifactRepository> remoteRepositories;
+
+    @Parameter(defaultValue = "${project.build.outputDirectory}/META-INF/camel/camel-meta.json")
+    private String target;
+
+    @Override
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        ArrayNode root = new ArrayNode(JsonNodeFactory.instance);
+
+        URLClassLoader classLoader = null;
+        try {
+            PluginDescriptor desc = (PluginDescriptor) getPluginContext().get("pluginDescriptor");
+            List<Artifact> artifacts = desc.getArtifacts();
+            ProjectBuildingRequest buildingRequest =
+                new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+            buildingRequest.setRemoteRepositories(remoteRepositories);
+            for (Artifact artifact : artifacts) {
+                ArtifactResult result = artifactResolver.resolveArtifact(buildingRequest, artifact);
+                File jar = result.getArtifact().getFile();
+                classLoader = createClassLoader(jar);
+                if (classLoader == null) {
+                    throw new IOException("Can not create classloader for " + jar);
+                }
+                ObjectNode entry = new ObjectNode(JsonNodeFactory.instance);
+                addConnectorMeta(entry, classLoader);
+                    addComponentMeta(entry, classLoader);
+                if (entry.size() > 0) {
+                    addGav(entry, artifact);
+                    root.add(entry);
+                }
+            }
+            if (root.size() > 0) {
+                saveCamelMetaData(root);
+            }
+        } catch (ArtifactResolverException | IOException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        } finally {
+            if (classLoader != null) {
+                try {
+                    classLoader.close();
+                } catch (IOException ignored) {
+
+                }
+            }
+        }
+    }
+
+    private URLClassLoader createClassLoader(File jar) throws MalformedURLException {
+        return AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
+            public URLClassLoader run() {
+                try {
+                    return new URLClassLoader(new URL[]{jar.toURI().toURL()});
+                } catch (MalformedURLException e) {
+                    return null;
+                }
+            }
+        });
+    }
+
+    private void addConnectorMeta(ObjectNode root, ClassLoader classLoader) {
+        ObjectNode node = new ObjectNode(JsonNodeFactory.instance);
+        addOptionalNode(classLoader, node, "meta", "camel-connector.json");
+        addOptionalSchemaAsString(classLoader, node, "schema", "camel-connector-schema.json");
+        if (node.size() > 0) {
+            root.set("connector", node);
+        }
+    }
+
+
+    private void addComponentMeta(ObjectNode root, ClassLoader classLoader) {
+        // is there any custom Camel components in this library?
+        ObjectNode component = new ObjectNode(JsonNodeFactory.instance);
+
+        ObjectNode componentMeta = getComponentMeta(classLoader);
+        if (componentMeta != null) {
+            component.set("meta", componentMeta);
+        }
+        addOptionalSchemaAsString(classLoader, component, "schema", "camel-component-schema.json");
+
+        if (component.size() > 0) {
+            root.set("component", component);
+        }
+    }
+
+    private ObjectNode getComponentMeta(ClassLoader classLoader) {
+        Properties properties = loadComponentProperties(classLoader);
+        if (properties == null) {
+            return null;
+        }
+        String components = (String) properties.get("components");
+        if (components == null) {
+            return null;
+        }
+        String[] part = components.split("\\s");
+        ObjectNode componentMeta = new ObjectNode(JsonNodeFactory.instance);
+        for (String scheme : part) {
+            // find the class name
+            String javaType = extractComponentJavaType(classLoader, scheme);
+            if (javaType == null) {
+                continue;
+            }
+            String schemeMeta = loadComponentJSonSchema(classLoader, scheme, javaType);
+            if (schemeMeta == null) {
+                continue;
+            }
+            componentMeta.set(scheme, new TextNode(schemeMeta));
+        }
+        return componentMeta.size() > 0 ? componentMeta : null;
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private Properties loadComponentProperties(ClassLoader classLoader) {
+        try {
+            // load the component files using the recommended way by a component.properties file
+            InputStream is = classLoader.getResourceAsStream("META-INF/services/org/apache/camel/component.properties");
+            if (is != null) {
+                Properties ret = new Properties();
+                ret.load(is);
+                return ret;
+            }
+        } catch (Exception e) {
+            getLog().warn("WARN: Error loading META-INF/services/org/apache/camel/component.properties file due " + e.getMessage());
+        }
+        return null;
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private String extractComponentJavaType(ClassLoader classLoader, String scheme) {
+        try {
+            InputStream is = classLoader.getResourceAsStream("META-INF/services/org/apache/camel/component/" + scheme);
+            if (is != null) {
+                Properties props = new Properties();
+                props.load(is);
+                return (String) props.get("class");
+            }
+        } catch (Exception e) {
+            getLog().warn("WARN: Error loading META-INF/services/org/apache/camel/component/" + scheme + " file due " + e.getMessage());
+        }
+        return null;
+    }
+
+    // TODO: Should return an ObjectNode, but because of
+    // Camels' JSonSchemaHelper being very picky on the format, we use it as plain string directly
+    private String loadComponentJSonSchema(ClassLoader classLoader, String scheme, String javaType) {
+        int pos = javaType.lastIndexOf('.');
+        String path = javaType.substring(0, pos);
+        path = path.replace('.', '/');
+        path = new StringBuilder(path).append("/").append(scheme).append(".json").toString();
+        return getOpaqueJsonString(classLoader, path);
+    }
+
+
+    private void saveCamelMetaData(ArrayNode root) throws MojoExecutionException, IOException {
+        File targetFile = new File(target);
+        if (!targetFile.getParentFile().exists() &&
+            !targetFile.getParentFile().mkdirs()) {
+            throw new MojoExecutionException("Cannot create directory " + targetFile.getParentFile());
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writerWithDefaultPrettyPrinter().writeValue(new File(target), root);
+    }
+
+    private void addOptionalSchemaAsString(ClassLoader cl, ObjectNode node, String key, String path) {
+        // We can't use real JSON here as
+        // https://github.com/apache/camel/blob/master/camel-core/src/main/java/org/apache/camel/runtimecatalog/JSonSchemaHelper.java#L44-L123
+        // can parse proper JSON. We need to do it as an opaque sting
+        String result = getOpaqueJsonString(cl, path);
+        if (result != null) {
+            node.set(key, new TextNode(result));
+        }
+    }
+
+    private void addOptionalNode(ClassLoader cl, ObjectNode node, String key, String path) {
+        JsonNode result = getJson(cl, path);
+        if (result != null) {
+            node.set(key, result);
+        }
+    }
+
+    private void addGav(ObjectNode node, Artifact artifact) {
+        TextNode gavNode = new TextNode(
+            String.format("%s:%s:%s",
+                          artifact.getGroupId(),
+                          artifact.getArtifactId(),
+                          artifact.getVersion()));
+        node.set("gav", gavNode);
+    }
+
+    private JsonNode getJson(ClassLoader classLoader, String path) {
+        try {
+            InputStream is = classLoader.getResourceAsStream(path);
+            if (is == null) {
+                return null;
+            }
+            return new ObjectMapper().readTree(is);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private String getOpaqueJsonString(ClassLoader classLoader, String path) {
+        try {
+            InputStream is = classLoader.getResourceAsStream(path);
+            if (is == null) {
+                return null;
+            }
+            return IOUtils.toString(is, Charset.defaultCharset());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
When creating project files, a `CamelCatalog` and `CamelConnectorCatalog`
is required to calculate the proper endpoint URL

Up to now, this is only done via Grape which does a live
introspection and download of connector jars.

A new plugin goal `syndesis:extract-connector-descriptor` has been
introduced to fetch this information offline.
By adding this to `META-INF/camel/camel-meta.json`, the runtime
can query this file and build up a CamelCatalog from this information only.
This avoids to reach out to the internet, which can have unexpected
side effects related to the performance.

-------

This is still work in progress. Actually the generation works nicely and has been introduced to the runtime pom.xml
During startup of the `ConnectorCatalog` this `/META-INF/camel/camel-meta.json` is parsed and the `CamelCatalog` as well as the `CamelConnectorCatalog` is build up.

It was tried to mimic the way how the `MavenArtifactProvider` resolves the required data, however it still fails.

When using the catalog on a prefetched connector, the following error happens:

```
2017-09-23 18:17:50.608 ERROR [-,,,] 1 --- [pool-5-thread-1] i.s.c.i.online.ActivateHandler           : Integration -KujxQDBjnvVpgWd0MgV : Failure

java.lang.IllegalArgumentException: Endpoint with scheme twitter-mention-connector has no syntax defined in the json schema
	at org.apache.camel.catalog.AbstractCamelCatalog.doAsEndpointUri(AbstractCamelCatalog.java:892) ~[camel-catalog-2.20.0.fuse-000101.jar!/:2.20.0.fuse-000101]
	at org.apache.camel.catalog.AbstractCamelCatalog.asEndpointUri(AbstractCamelCatalog.java:869) ~[camel-catalog-2.20.0.fuse-000101.jar!/:2.20.0.fuse-000101]
	at io.syndesis.connector.catalog.ConnectorCatalog.buildEndpointUri(ConnectorCatalog.java:164) ~[connector-catalog-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at io.syndesis.project.converter.visitor.EndpointStepVisitor.createEndpoint(EndpointStepVisitor.java:129) ~[project-generator-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at io.syndesis.project.converter.visitor.EndpointStepVisitor.createEndpoint(EndpointStepVisitor.java:125) ~[project-generator-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at io.syndesis.project.converter.visitor.EndpointStepVisitor.visit(EndpointStepVisitor.java:64) ~[project-generator-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at io.syndesis.project.converter.DefaultProjectGenerator.visitStep(DefaultProjectGenerator.java:219) ~[project-generator-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at io.syndesis.project.converter.DefaultProjectGenerator.lambda$generateFlowYaml$4(DefaultProjectGenerator.java:207) ~[project-generator-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at java.util.Optional.ifPresent(Optional.java:159) ~[na:1.8.0_131]
	at io.syndesis.project.converter.DefaultProjectGenerator.generateFlowYaml(DefaultProjectGenerator.java:184) ~[project-generator-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at io.syndesis.project.converter.DefaultProjectGenerator.generate(DefaultProjectGenerator.java:157) ~[project-generator-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at io.syndesis.controllers.integration.online.ActivateHandler.createProjectFiles(ActivateHandler.java:251) ~[controllers-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at io.syndesis.controllers.integration.online.ActivateHandler.execute(ActivateHandler.java:123) ~[controllers-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at io.syndesis.controllers.integration.IntegrationController.lambda$callStatusChangeHandler$10(IntegrationController.java:175) [controllers-0.1-SNAPSHOT.jar!/:0.1-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[na:1.8.0_131]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_131]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_131]
```

The following connectors have been preloaded from the plugin's dependencies:

```
2017-09-23 18:15:32.127  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for org.apache.camel:camel-salesforce:2.20.0.fuse-000101
2017-09-23 18:15:32.128  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:salesforce-on-update-connector:0.5.5
2017-09-23 18:15:32.130  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:salesforce-on-delete-connector:0.5.5
2017-09-23 18:15:32.135  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:salesforce-update-sobject-connector:0.5.5
2017-09-23 18:15:32.143  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:salesforce-upsert-sobject-connector:0.5.5
2017-09-23 18:15:32.156  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:salesforce-create-sobject-connector:0.5.5
2017-09-23 18:15:32.160  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:salesforce-get-sobject-connector:0.5.5
2017-09-23 18:15:32.163  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:salesforce-get-sobject-with-id-connector:0.5.5
2017-09-23 18:15:32.166  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:salesforce-delete-sobject-connector:0.5.5
2017-09-23 18:15:32.167  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:salesforce-delete-sobject-with-id-connector:0.5.5
2017-09-23 18:15:32.170  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for io.syndesis:sql-stored-connector:0.5.5
2017-09-23 18:15:32.172  INFO [-,,,] 1 --- [           main] i.s.connector.catalog.ConnectorCatalog   : Prefetched meta for org.apache.camel:camel-sql:2.20.0.fuse-000101
```

Don't think its a major issue, but happy for any hint to fix this as I'm on the road tomorrow and this is still 
considered to be a blocker for TP1. 'will continue tomorrow, but who will fix this before me, will get (a) one pint of franconian beer and (b) a mini-jar of fresh Jolokia pepper powder from 2017 ;-)

@lburgazzoli @jimmidyson @zregvart @davsclaus is this good enough of an offer ;-) ?