### PR TITLE
chore(setup): Add script to easily reset Keycloak github provider client ID and secret to enable rep

### DIFF
--- a/setup/reset-github-provider.sh
+++ b/setup/reset-github-provider.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+usage() {
+    echo "Usage: $(basename $0) <KEYCLOAK_URL>"
+    exit 1
+}
+
+KEYCLOAK_URL=${1}
+if [ -z "${KEYCLOAK_URL}" ]; then
+    usage
+fi
+
+if ! hash jq 2>/dev/null; then
+    echo "This script requires \`jq\` - please see https://stedolan.github.io/jq/download/
+or run \`brew install jq\` if you're on OS X"
+    exit 1
+fi
+
+KC_TOKEN=$(curl "${KEYCLOAK_URL}/auth/realms/master/protocol/openid-connect/token" \
+  -d "client_id=admin-cli" \
+  -d "username=$(oc get secrets -ojsonpath={.data.username} syndesis-keycloak-admin|base64 -d)" \
+  -d "password=$(oc get secrets -ojsonpath={.data.password} syndesis-keycloak-admin|base64 -d)" \
+  -d "grant_type=password" \
+  -fsSLk | \
+jq -r .access_token)
+
+KC_GITHUB_IDP=$(curl "${KEYCLOAK_URL}/auth/admin/realms/syndesis/identity-provider/instances/github" \
+  -fsSLk \
+  -k -vvv \
+  -H "Authorization: Bearer ${KC_TOKEN}" | \
+  sed -e 's/"clientId":"[a-zA-Z0-9]\+",/"clientId":"dummy",/' -e 's/"clientSecret":"\*\+",/"clientSecret":"dummy",/')
+
+curl "${KEYCLOAK_URL}/auth/admin/realms/syndesis/identity-provider/instances/github" \
+  -XPUT \
+  -fsSLk \
+  -k -vvv \
+  -H "Authorization: Bearer ${KC_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "${KC_GITHUB_IDP}"


### PR DESCRIPTION
@ryordan As discussed, this adds a simple script to reset the github provider crendentials in Keycloak
and hence re-enable the initial setup API handlers.