### PR TITLE
fix: if the status of the integration revision ...

### DIFF
--- a/controllers/pom.xml
+++ b/controllers/pom.xml
@@ -126,6 +126,25 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
@@ -197,7 +197,7 @@ public class IntegrationController {
                         .withCurrentState(IntegrationRevisionState.from(update.getStatus()));
 
                     //replace revision
-                    integration.getDeployedRevision().map(revisions::remove);
+                    revisions.remove(revision);
 
                     final IntegrationRevision last = integration.lastRevision();
                     if (IntegrationRevisionState.from(update.getStatus()).equals(last.getCurrentState())) {

--- a/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
@@ -55,8 +55,8 @@ public class IntegrationController {
     private final EventBus eventBus;
     private final ConcurrentHashMap<Integration.Status, StatusChangeHandlerProvider.StatusChangeHandler> handlers = new ConcurrentHashMap<>();
     private final Set<String> scheduledChecks = new HashSet<>();
-    private ExecutorService executor;
-    private ScheduledExecutorService scheduler;
+    /* default */ ExecutorService executor;
+    /* default */ ScheduledExecutorService scheduler;
 
     private static final long SCHEDULE_INTERVAL_IN_SECONDS = 60;
 
@@ -159,7 +159,7 @@ public class IntegrationController {
         return "Integration " + integration.getId().orElse("[none]");
     }
 
-    private void callStatusChangeHandler(StatusChangeHandlerProvider.StatusChangeHandler handler, String integrationId) {
+    /* default */ void callStatusChangeHandler(StatusChangeHandlerProvider.StatusChangeHandler handler, String integrationId) {
         executor.submit(() -> {
             Integration integration = dataManager.fetch(Integration.class, integrationId);
             String checkKey = getIntegrationMarkerKey(integration);
@@ -197,9 +197,16 @@ public class IntegrationController {
                         .withCurrentState(IntegrationRevisionState.from(update.getStatus()));
 
                     //replace revision
-                    revisions.remove(revision);
-                    revisions.add(revision);
+                    integration.getDeployedRevision().map(revisions::remove);
 
+                    final IntegrationRevision last = integration.lastRevision();
+                    if (IntegrationRevisionState.from(update.getStatus()).equals(last.getCurrentState())) {
+                        revision = new IntegrationRevision.Builder().createFrom(revision)
+                            .version(last.getVersion())
+                            .parentVersion(last.getParentVersion())
+                            .build();
+                    }
+                    revisions.add(revision);
 
                     dataManager.update(new Integration.Builder()
                         .createFrom(updated)

--- a/controllers/src/test/java/io/syndesis/controllers/integration/IntegrationControllerTest.java
+++ b/controllers/src/test/java/io/syndesis/controllers/integration/IntegrationControllerTest.java
@@ -43,6 +43,7 @@ public class IntegrationControllerTest {
     private static final String INTEGRATION_ID = "test-integration";
 
     @Test
+    @SuppressWarnings("PMD.DoNotUseThreads")
     public void shouldReplaceIntegrationRevisions() {
         final DataManager dataManager = mock(DataManager.class);
         final EventBus eventBus = mock(EventBus.class);

--- a/controllers/src/test/java/io/syndesis/controllers/integration/IntegrationControllerTest.java
+++ b/controllers/src/test/java/io/syndesis/controllers/integration/IntegrationControllerTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.controllers.integration;
+
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.syndesis.controllers.integration.StatusChangeHandlerProvider.StatusChangeHandler;
+import io.syndesis.controllers.integration.StatusChangeHandlerProvider.StatusChangeHandler.StatusUpdate;
+import io.syndesis.core.EventBus;
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.Integration.Status;
+import io.syndesis.model.integration.IntegrationRevision;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IntegrationControllerTest {
+
+    private static final String INTEGRATION_ID = "test-integration";
+
+    @Test
+    public void shouldReplaceIntegrationRevisions() {
+        final DataManager dataManager = mock(DataManager.class);
+        final EventBus eventBus = mock(EventBus.class);
+        final StatusChangeHandlerProvider handlerFactory = mock(StatusChangeHandlerProvider.class);
+
+        final IntegrationController integrationController = new IntegrationController(dataManager, eventBus,
+            handlerFactory);
+
+        integrationController.executor = mock(ExecutorService.class);
+        integrationController.scheduler = mock(ScheduledExecutorService.class);
+
+        final StatusChangeHandler handler = mock(StatusChangeHandler.class);
+        when(handler.getTriggerStatuses()).thenReturn(EnumSet.allOf(Integration.Status.class));
+        when(handler.execute(any(Integration.class))).thenReturn(new StatusUpdate(Status.Pending),
+            new StatusUpdate(Status.Pending), new StatusUpdate(Status.Activated));
+
+        final Integration integration = new Integration.Builder().id(INTEGRATION_ID)
+            .desiredStatus(Integration.Status.Activated).createdDate(new Date())
+            .addRevision(new IntegrationRevision.Builder().version(1).build())
+            .addRevision(new IntegrationRevision.Builder().version(2).build()).build();
+
+        final AtomicReference<Integration> currentIntegration = new AtomicReference<>(integration);
+        when(dataManager.fetch(Integration.class, INTEGRATION_ID)).thenAnswer(invocation -> currentIntegration.get());
+
+        when(integrationController.executor.submit(any(Runnable.class))).then(invocation -> {
+            invocation.getArgumentAt(0, Runnable.class).run();
+            return null;
+        });
+
+        final ArgumentCaptor<Integration> updatedIntegrations = ArgumentCaptor.forClass(Integration.class);
+        doNothing().when(dataManager).update(updatedIntegrations.capture());
+
+        integrationController.callStatusChangeHandler(handler, INTEGRATION_ID);
+        Integration newIntegration = updatedIntegrations.getValue();
+        assertThat(newIntegration.getRevisions()).hasSize(3);
+        currentIntegration.set(newIntegration);
+
+        integrationController.callStatusChangeHandler(handler, INTEGRATION_ID);
+        assertThat(updatedIntegrations.getAllValues().get(1).getRevisions()).hasSize(3);
+
+        // status update is now Activated
+        integrationController.callStatusChangeHandler(handler, INTEGRATION_ID);
+        assertThat(updatedIntegrations.getAllValues().get(2).getRevisions()).hasSize(4);
+    }
+}

--- a/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -30,6 +30,7 @@ import org.immutables.value.Value;
 
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -112,6 +113,10 @@ public interface Integration extends WithId<Integration>, WithTags, WithName, Se
     @Override
     default Integration withId(String id) {
         return new Builder().createFrom(this).id(id).build();
+    }
+
+    default IntegrationRevision lastRevision() {
+        return getRevisions().stream().max(Comparator.comparingInt(r -> r.getVersion().orElse(0))).get();
     }
 
     class Builder extends ImmutableIntegration.Builder {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -351,7 +351,7 @@
     <priority>4</priority>
   </rule>
   <rule ref="rulesets/java/j2ee.xml/DoNotUseThreads">
-    <priority>3</priority>
+    <priority>5</priority>
   </rule>
   <rule ref="rulesets/java/clone.xml/CloneMethodMustImplementCloneable">
     <priority>3</priority>


### PR DESCRIPTION
...does not change update the last revision

Currently we add a new integration revision for every status check,
about one every minute, this leads to a huge number of rows being added
to the database.

This change updates the last integration revision if the status of the
last revision does not change with the update. This way we have the
number of revisions tied to the number of state changes.

Fixes #638