### PR TITLE
ci(circleci): Add -U to mvn invocation to ensure updates are pulled for missing dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
       - run:
           name: Maven
-          command: ./mvnw --batch-mode -Pfabric8 install
+          command: ./mvnw --batch-mode -U -Pfabric8 install
 
       - save_cache:
           key: syndesis-rest-m2


### PR DESCRIPTION
With the ongoing problems of JBoss EA repository, this ensures that cached dependency failures are
ignored on subsequent builds.