### PR TITLE
Adding support for setting tokens in the init data load

### DIFF
--- a/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -833,5 +833,22 @@
         }
       ]
     }
+  },
+  {
+    "kind": "connection",
+    "data": {
+      "id": "5",
+      "name": "PostgresDB",
+      "description": "Sample Database Connection for Stored Procedure Invocation",
+      "tags":["sampledb"],
+      "icon": "fa-globe",
+      "connectorId": "sql-stored",
+      "configuredProperties": {
+        "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+        "user": "sampledb",
+        "password": "@POSTGRESQL_SAMPLEDB_PASSWORD@",
+        "schema": "sampledb"
+      }
+    }
   }
 ]

--- a/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
@@ -68,9 +68,9 @@ public class DataManagerTest {
     public void getConnections() {
         @SuppressWarnings("unchecked")
         ListResult<Connection> connections = dataManager.fetchAll(Connection.class);
-        assertThat(connections.getItems().stream().map(Connection::getId).map(Optional::get)).containsExactly("1", "2", "3", "4");
-        Assert.assertEquals(4, connections.getTotalCount());
-        Assert.assertEquals(4, connections.getItems().size());
+        assertThat(connections.getItems().stream().map(Connection::getId).map(Optional::get)).containsExactly("1", "2", "3", "4", "5");
+        Assert.assertEquals(5, connections.getTotalCount());
+        Assert.assertEquals(5, connections.getItems().size());
         Assert.assertEquals(connections.getTotalCount(), connections.getItems().size());
     }
 

--- a/dao/src/test/resources/io/syndesis/dao/test-data.json
+++ b/dao/src/test/resources/io/syndesis/dao/test-data.json
@@ -1,0 +1,39 @@
+[
+  {
+    "kind": "connection",
+    "data": {
+      "id": "1",
+      "name": "Twitter Example",
+      "description": "Twitter Connection",
+      "createdDate": 1492095344060,
+      "lastUpdated": 1492095344060,
+      "icon": "fa-twitter",
+      "connectorId": "twitter",
+      "configuredProperties": {
+        "accessToken": "twitter-access-token",
+        "accessTokenSecret": "@SECRET_NOT_IN_ENV@",
+        "consumerKey": "twitter-consumer-key",
+        "consumerSecret": "twitter-consumer-secret"
+      }
+    }
+  },
+  {
+    "kind": "connection",
+    "data": {
+      "id": "2",
+      "name": "Database Example",
+      "description": "Sample Database Connection",
+      "createdDate": 1492095344060,
+      "lastUpdated": 1492095344060,
+      "tags":["example","test"],
+      "icon": "fa-globe",
+      "connectorId": "sql-stored",
+      "configuredProperties": {
+        "url": "jdbc:postgresql://syndesis-db:5432/sampledbm",
+        "user": "sampledb",
+        "password": "@POSTGRESQL_SAMPLEDB_PASSWORD@",
+        "schema": "sampledb"
+      }
+    }
+  }
+]

--- a/runtime/src/main/resources/application.yml
+++ b/runtime/src/main/resources/application.yml
@@ -56,7 +56,7 @@ endpoints:
 dao:
   kind: jsondb
   schema:
-    version: 16 # changing this will reset all the DB data.
+    version: 17 # changing this will reset all the DB data.
 
 # OpenShift infra value
 openshift:

--- a/runtime/src/test/java/io/syndesis/runtime/TagsITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/TagsITCase.java
@@ -30,8 +30,8 @@ public class TagsITCase extends BaseITCase {
         // Check the we can list the integrations.
         ResponseEntity<TagListResult> list = get("/api/v1/tags", TagListResult.class);
 
-        assertThat(list.getBody().getTotalCount()).as("total count").isEqualTo(2);
-        assertThat(list.getBody().getItems()).as("items").hasSize(2);
+        assertThat(list.getBody().getTotalCount()).as("total count").isEqualTo(3);
+        assertThat(list.getBody().getItems()).as("items").hasSize(3);
         assertThat(list.getBody().getItems().get(0).equals("example"));
 
     }


### PR DESCRIPTION
Adding sql-stored database connection which has password set from env
Requires https://github.com/syndesisio/syndesis-openshift-templates/pull/99 to be merged so the POSTGRESQL_SAMPLEDB_PASSWORD gets set in the synthesis-rest container's env.