### PR TITLE
chore(connectors): Salesforce on-create|update data shapes set to `json-schema`

### DIFF
--- a/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -565,8 +565,7 @@
                "kind": "none"
             },
             "outputDataShape": {
-               "kind": "java",
-               "type": "io.syndesis.connector.salesforce.SalesforceIdentifier"
+               "kind": "json-schema"
             },
             "propertyDefinitionSteps": [{
               "name": "Name of the object",
@@ -601,8 +600,7 @@
                "kind": "none"
             },
             "outputDataShape": {
-               "kind": "java",
-               "type": "io.syndesis.connector.salesforce.SalesforceIdentifier"
+               "kind": "json-schema"
             },
             "propertyDefinitionSteps": [{
               "name": "Name of the object",


### PR DESCRIPTION
The output data shapes of Salesforce streaming connectors that react to create and update events have been changed to raw (JSON). This declares them as such.

This requires connectors project released with the change in https://github.com/syndesisio/connectors/pull/78