### PR TITLE
Sanitize component aliaes #630 #660

### DIFF
--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/BaseHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/BaseHandler.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.controllers.integration.online;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.integration.model.steps.Endpoint;
+import io.syndesis.model.connection.Connector;
+import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.Step;
+import io.syndesis.openshift.OpenShiftService;
+
+public class BaseHandler {
+    private final OpenShiftService openShiftService;
+
+    protected BaseHandler(OpenShiftService openShiftService) {
+        this.openShiftService = openShiftService;
+    }
+
+    protected OpenShiftService openShiftService() {
+        return openShiftService;
+    }
+
+
+    /**
+     * Fetch the Connectors
+     */
+    protected static Map<String, Connector> fetchConnectorsMap(DataManager dataManager) {
+        return dataManager.fetchAll(Connector.class).getItems()
+            .stream()
+            .collect(Collectors.toMap(o -> o.getId().get(), Function.identity()));
+    }
+
+    /**
+     * Build Connector Suffix map.
+     */
+    protected static Map<Step, String> buildConnectorSuffixMap(Integration integration) {
+        final Map<Step, String> connectorIdMap = new HashMap<>();
+
+        integration.getSteps().ifPresent(steps -> {
+            steps.stream()
+                .filter(s -> s.getStepKind().equals(Endpoint.KIND))
+                .filter(s -> s.getAction().isPresent())
+                .filter(s -> s.getConnection().isPresent())
+                .collect(Collectors.groupingBy(s -> s.getAction().get().getCamelConnectorPrefix()))
+                .forEach(
+                    (prefix, stepList) -> {
+                        if (stepList.size() > 1) {
+                            for (int i = 0; i < stepList.size(); i++) {
+                                connectorIdMap.put(stepList.get(i), Integer.toString(i + 1));
+                            }
+                        }
+                    }
+                );
+            })
+        ;
+
+        return Collections.unmodifiableMap(connectorIdMap);
+    }
+}

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/DeactivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/DeactivateHandler.java
@@ -27,13 +27,9 @@ import io.syndesis.model.integration.Integration;
 import io.syndesis.openshift.OpenShiftDeployment;
 import io.syndesis.openshift.OpenShiftService;
 
-public class DeactivateHandler implements StatusChangeHandlerProvider.StatusChangeHandler {
-
-
-    private final OpenShiftService openShiftService;
-
+public class DeactivateHandler extends BaseHandler implements StatusChangeHandlerProvider.StatusChangeHandler {
     DeactivateHandler(OpenShiftService openShiftService) {
-        this.openShiftService = openShiftService;
+        super(openShiftService);
     }
 
     @Override
@@ -59,7 +55,7 @@ public class DeactivateHandler implements StatusChangeHandlerProvider.StatusChan
             .build();
 
         try {
-            openShiftService.scale(deployment);
+            openShiftService().scale(deployment);
         } catch (KubernetesClientException e) {
             // Ignore 404 errors, means the deployment does not exist for us
             // to scale down
@@ -68,7 +64,7 @@ public class DeactivateHandler implements StatusChangeHandlerProvider.StatusChan
             }
         }
 
-        Integration.Status currentStatus = openShiftService.isScaled(deployment)
+        Integration.Status currentStatus = openShiftService().isScaled(deployment)
             ? Integration.Status.Deactivated
                 : Integration.Status.Pending;
 

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/DeleteHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/DeleteHandler.java
@@ -24,12 +24,9 @@ import io.syndesis.model.integration.Integration;
 import io.syndesis.openshift.OpenShiftDeployment;
 import io.syndesis.openshift.OpenShiftService;
 
-public class DeleteHandler implements StatusChangeHandlerProvider.StatusChangeHandler {
-
-    private final OpenShiftService openShiftService;
-
+public class DeleteHandler extends BaseHandler implements StatusChangeHandlerProvider.StatusChangeHandler {
     DeleteHandler(OpenShiftService openShiftService) {
-        this.openShiftService = openShiftService;
+        super(openShiftService);
     }
 
     @Override
@@ -52,8 +49,8 @@ public class DeleteHandler implements StatusChangeHandlerProvider.StatusChangeHa
             .token(token)
             .build();
 
-        Integration.Status currentStatus = !openShiftService.exists(deployment)
-            || openShiftService.delete(deployment)
+        Integration.Status currentStatus = !openShiftService().exists(deployment)
+            || openShiftService().delete(deployment)
             ? Integration.Status.Deleted
             : Integration.Status.Pending;
 

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/OnlineHandlerProvider.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/OnlineHandlerProvider.java
@@ -29,18 +29,18 @@ import org.springframework.stereotype.Component;
 
 @Component
 @ConditionalOnProperty(value = "controllers.integration.enabled", havingValue = "true", matchIfMissing = true)
-public class OnlineHandlerProvider implements StatusChangeHandlerProvider {
+public class OnlineHandlerProvider extends BaseHandler implements StatusChangeHandlerProvider {
 
     private final DataManager dataManager;
-    private final OpenShiftService openShiftService;
     private final GitHubService gitHubService;
     private final ProjectGenerator projectConverter;
     private final ControllersConfigurationProperties properties;
 
     public OnlineHandlerProvider(DataManager dataManager, OpenShiftService openShiftService,
                                  GitHubService gitHubService, ProjectGenerator projectConverter, ControllersConfigurationProperties properties) {
+        super(openShiftService);
+
         this.dataManager = dataManager;
-        this.openShiftService = openShiftService;
         this.gitHubService = gitHubService;
         this.projectConverter = projectConverter;
         this.properties = properties;
@@ -49,8 +49,9 @@ public class OnlineHandlerProvider implements StatusChangeHandlerProvider {
     @Override
     public List<StatusChangeHandler> getStatusChangeHandlers() {
         return Arrays.asList(
-            new ActivateHandler(dataManager, openShiftService, gitHubService, projectConverter, properties),
-            new DeactivateHandler(openShiftService),
-            new DeleteHandler(openShiftService));
+            new ActivateHandler(dataManager, openShiftService(), gitHubService, projectConverter, properties),
+            new DeactivateHandler(openShiftService()),
+            new DeleteHandler(openShiftService())
+        );
     }
 }

--- a/project-generator/src/main/java/io/syndesis/project/converter/visitor/StepVisitorContext.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/visitor/StepVisitorContext.java
@@ -16,13 +16,14 @@
 
 package io.syndesis.project.converter.visitor;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.function.Function;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.model.integration.Step;
 import org.immutables.value.Value;
-
-import java.util.Iterator;
-import java.util.Queue;
 
 @Value.Immutable
 @JsonDeserialize(builder = StepVisitorContext.Builder.class)
@@ -34,16 +35,20 @@ public interface StepVisitorContext extends Iterator<StepVisitorContext> {
 
     Queue<Step> getRemaining();
 
+    Function<Step, Optional<String>> getConnectorIdSupplier();
+
     default boolean hasNext() {
         return !getRemaining().isEmpty();
     }
 
     default StepVisitorContext next() {
-        Queue<Step> remaining = getRemaining();
-        Step next = remaining.remove();
+        final int index = getIndex();
+        final Queue<Step> remaining = getRemaining();
+        final Step next = remaining.remove();
 
         return new StepVisitorContext.Builder()
-            .index(getIndex()+1)
+            .createFrom(this)
+            .index(index + 1)
             .step(next)
             .remaining(remaining)
             .build();

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-syndesis-with-secrets-and-multiple-connector-of-same-type.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-syndesis-with-secrets-and-multiple-connector-of-same-type.yml
@@ -1,0 +1,9 @@
+---
+flows:
+- steps:
+  - kind: endpoint
+    uri: periodic-timer-connector?period=5000
+  - kind: endpoint
+    uri: http-get-connector-1?httpUri=http://localhost:8080/hello&password={{http-get-connector-1.password}}&username={{http-get-connector-1.username}}
+  - kind: endpoint
+    uri: http-get-connector-2?httpUri=http://localhost:8080/bye&password={{http-get-connector-2.password}}&username={{http-get-connector-2.username}}

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-syndesis-with-secrets.yml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-syndesis-with-secrets.yml
@@ -4,4 +4,4 @@ flows:
   - kind: endpoint
     uri: periodic-timer-connector?period=5000
   - kind: endpoint
-    uri: http-get-connector-2?httpUri=http://localhost:8080/hello&password={{http-get-connector-2.password}}&username={{http-get-connector-2.username}}
+    uri: http-get-connector?httpUri=http://localhost:8080/hello&password={{http-get-connector.password}}&username={{http-get-connector.username}}


### PR DESCRIPTION
The project generator now writes the syndesis.yaml like:

```yaml
---
flows:
- steps:
  - kind: endpoint
    uri: twitter-mention-connector:MENTIONS
  - kind: endpoint
    uri: http-get-connector?httpUri=www.google.com/2
  - kind: endpoint
    uri: twitter-search-1:cameltest?delay=1000&filterOld=true
  - kind: endpoint
    uri: twitter-search-2:camelprod?delay=1234&filterOld=true
  - kind: endpoint
    uri: http-get-connector?httpUri=www.google.com/1
```
So:
- if a connector is repeated but it does not have any component options, its scheme is preserved (see http-get-connector) 
- if a connector does have component options but it is not repeated, its scheme is preserved
- if a connector is both repeated and has component options, its scheme is suffixed with ``-${sequence}`` were the sequence is computed from the number of occurrencies of the connector

The generated secret follow a similar behavior:

```properties
# this is not repeated so no need to create aliases
twitter-mention-connector.accessToken=...
twitter-mention-connector.accessTokenSecret=...
twitter-mention-connector.consumerKey=...
twitter-mention-connector.consumerSecret=...

twitter-search.configurations.twitter-search-1.accessToken=...
twitter-search.configurations.twitter-search-1.accessTokenSecret=...
twitter-search.configurations.twitter-search-1.consumerKey=...
twitter-search.configurations.twitter-search-1.consumerSecret=...

twitter-search.configurations.twitter-search-2.accessToken=...
twitter-search.configurations.twitter-search-2.accessTokenSecret=...
twitter-search.configurations.twitter-search-2.consumerKey=...
twitter-search.configurations.twitter-search-2.consumerSecret=...
```