### PR TITLE
specific cache key based on poms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - restore_cache:
           key: syndesis-rest-m2-{{ checksum "pom.xml" }}-{{ checksum "connector-catalog/pom.xml" }}-{{ checksum "controllers/pom.xml" }}-{{ checksum "core/pom.xml" }}-{{ checksum "credential/pom.xml" }}-{{ checksum "dao/pom.xml" }}-{{ checksum "github/pom.xml" }}-{{ checksum "jsondb/pom.xml" }}-{{ checksum "model/pom.xml" }}-{{ checksum "model2/pom.xml" }}-{{ checksum "openshift/pom.xml" }}-{{ checksum "project-generator/pom.xml" }}-{{ checksum "rest/pom.xml" }}-{{ checksum "syndesis-maven-plugin/pom.xml" }}-{{ checksum "runtime/pom.xml" }}-{{ checksum "verifier/pom.xml" }}-{{ checksum "inspector/pom.xml" }}-{{ checksum "setup/pom.xml" }}
           key: syndesis-rest-m2-{{ checksum "pom.xml" }}
+          key: syndesis-rest-m2
 
       - run:
           name: Maven

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,14 +30,16 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: syndesis-rest-m2
+          key: syndesis-rest-m2-{{ checksum "pom.xml" }}-{{ checksum "connector-catalog/pom.xml" }}-{{ checksum "controllers/pom.xml" }}-{{ checksum "core/pom.xml" }}-{{ checksum "credential/pom.xml" }}-{{ checksum "dao/pom.xml" }}-{{ checksum "github/pom.xml" }}-{{ checksum "jsondb/pom.xml" }}-{{ checksum "model/pom.xml" }}-{{ checksum "model2/pom.xml" }}-{{ checksum "openshift/pom.xml" }}-{{ checksum "project-generator/pom.xml" }}-{{ checksum "rest/pom.xml" }}-{{ checksum "syndesis-maven-plugin/pom.xml" }}-{{ checksum "runtime/pom.xml" }}-{{ checksum "verifier/pom.xml" }}-{{ checksum "inspector/pom.xml" }}-{{ checksum "setup/pom.xml" }}
+          key: syndesis-rest-m2-{{ checksum "pom.xml" }}
 
       - run:
           name: Maven
           command: ./mvnw --batch-mode -U -Pfabric8 install
 
       - save_cache:
-          key: syndesis-rest-m2
+          key: syndesis-rest-m2-{{ checksum "pom.xml" }}-{{ checksum "connector-catalog/pom.xml" }}-{{ checksum "controllers/pom.xml" }}-{{ checksum "core/pom.xml" }}-{{ checksum "credential/pom.xml" }}-{{ checksum "dao/pom.xml" }}-{{ checksum "github/pom.xml" }}-{{ checksum "jsondb/pom.xml" }}-{{ checksum "model/pom.xml" }}-{{ checksum "model2/pom.xml" }}-{{ checksum "openshift/pom.xml" }}-{{ checksum "project-generator/pom.xml" }}-{{ checksum "rest/pom.xml" }}-{{ checksum "syndesis-maven-plugin/pom.xml" }}-{{ checksum "runtime/pom.xml" }}-{{ checksum "verifier/pom.xml" }}-{{ checksum "inspector/pom.xml" }}-{{ checksum "setup/pom.xml" }}
+
           paths:
           - ~/.m2
 


### PR DESCRIPTION
You can only write to the cache once, so the key needs to update if dependencies change, or else you keep missing the and re downloading the those new dependencies. Taking a hash of all poms in the project seems like a pretty good key. 