### PR TITLE
fix(deployment): proper Camel scheme for Twitter search connector

### DIFF
--- a/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -88,7 +88,7 @@
           "description": "Search tweets based one or more keywords",
           "id": "io.syndesis:twitter-search-connector:latest",
           "camelConnectorGAV": "io.syndesis:twitter-search-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "twitter-search",
+          "camelConnectorPrefix": "twitter-search-connector",
           "definition": {
             "inputDataShape": {
                "kind" : "none"
@@ -106,6 +106,7 @@
                   "displayName": "Ignore tweets previously found",
                   "group": "filter",
                   "label": "consumer,filter",
+                  "required": false,
                   "type": "boolean",
                   "javaType": "boolean",
                   "tags":[],
@@ -133,6 +134,7 @@
                   "displayName": "Delay",
                   "group": "scheduler",
                   "label": "consumer,scheduler",
+                  "required": false,
                   "type": "integer",
                   "javaType": "long",
                   "tags":[],

--- a/dao/src/test/java/io/syndesis/dao/DeploymentDescriptorTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DeploymentDescriptorTest.java
@@ -108,6 +108,14 @@ public class DeploymentDescriptorTest {
                         return;// never happens
                     }
 
+                    final JsonNode component = catalogedJsonSchema.get("component");
+                    final String groupId = component.get("groupId").asText();
+                    final String artifactId = component.get("artifactId").asText();
+                    final String version = component.get("version").asText();
+
+                    assertThat(new String[] {groupId, artifactId, version})
+                        .as("The scheme `%s` was resolved from a unexpected artifact", scheme).isEqualTo(coordinates);
+
                     final JsonNode componentPropertiesFromCatalog = catalogedJsonSchema.get("componentProperties");
 
                     assertConnectorProperties(connectorId, connectorPropertiesJson, componentPropertiesFromCatalog);
@@ -322,7 +330,8 @@ public class DeploymentDescriptorTest {
 
     private static void removeCustomizedProperties(final JsonNode... nodes) {
         for (final JsonNode node : nodes) {
-            ((ObjectNode) node).remove(Arrays.asList("displayName", "type", "description", "defaultValue", "optionalPrefix"));
+            ((ObjectNode) node)
+                .remove(Arrays.asList("displayName", "type", "description", "defaultValue", "optionalPrefix"));
         }
     }
 }


### PR DESCRIPTION
This changes the Twitter search connector from `twitter-search` that is
the scheme of a Camel component to `twitter-search-connector`. Also adds
additional assertion to the DeploymentDescriptorTest to catch such
mismatches.

Fixes #671