### PR TITLE
refactor(project-generator): remove camel-test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <basepom.test.timeout>300</basepom.test.timeout>
     <basepom.check.skip-all>true</basepom.check.skip-all>
     <basepom.test.timeout>150</basepom.test.timeout>
-    <basepom.failsafe.timeout>150</basepom.failsafe.timeout>
+    <basepom.failsafe.timeout>0</basepom.failsafe.timeout>
 
     <syndesis-connectors.version>0.5.6</syndesis-connectors.version>
     <syndesis-integration-runtime.version>0.1.6</syndesis-integration-runtime.version>

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/pom.xml.mustache
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/pom.xml.mustache
@@ -98,14 +98,6 @@
       <version>\${syndesis-integration-runtime.version}</version>
     </dependency>
 
-    <!-- testing -->
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-test</artifactId>
-      <version>\${camel.version}</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-pom.xml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-pom.xml
@@ -106,14 +106,6 @@
       <version>\${syndesis-integration-runtime.version}</version>
     </dependency>
 
-    <!-- testing -->
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-test</artifactId>
-      <version>\${camel.version}</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-pom.xml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-pom.xml
@@ -106,14 +106,6 @@
       <version>\${syndesis-integration-runtime.version}</version>
     </dependency>
 
-    <!-- testing -->
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-test</artifactId>
-      <version>\${camel.version}</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
This removes `camel-test` dependacy from the generated integration POM.
Should be few bytes less to transfer in the build.