### PR TITLE
fix: Proper build and deployment handling

### DIFF
--- a/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
@@ -188,6 +188,7 @@ public class IntegrationController {
                         .createFrom(current)
                         .currentStatus(update.getStatus()) // Status must not be null
                         .statusMessage(Optional.ofNullable(update.getStatusMessage()))
+                        .stepsDone(Optional.ofNullable(update.getStepsPerformed()))
                         .createdDate(Integration.Status.Activated.equals(update.getStatus()) ? now : integration.getCreatedDate().get())
                         .lastUpdated(new Date())
                         .build();

--- a/controllers/src/main/java/io/syndesis/controllers/integration/StatusChangeHandlerProvider.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/StatusChangeHandlerProvider.java
@@ -32,7 +32,7 @@ public interface StatusChangeHandlerProvider {
         StatusUpdate execute(Integration model);
 
         class StatusUpdate {
-            private Integration.Status status ;
+            final private Integration.Status status;
             private String statusMessage;
             private List<String> stepsPerformed;
 

--- a/controllers/src/main/java/io/syndesis/controllers/integration/StatusChangeHandlerProvider.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/StatusChangeHandlerProvider.java
@@ -32,7 +32,7 @@ public interface StatusChangeHandlerProvider {
         StatusUpdate execute(Integration model);
 
         class StatusUpdate {
-            final private Integration.Status status;
+            private final Integration.Status status;
             private String statusMessage;
             private List<String> stepsPerformed;
 

--- a/controllers/src/main/java/io/syndesis/controllers/integration/StatusChangeHandlerProvider.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/StatusChangeHandlerProvider.java
@@ -32,8 +32,14 @@ public interface StatusChangeHandlerProvider {
         StatusUpdate execute(Integration model);
 
         class StatusUpdate {
-            private Integration.Status status;
+            private Integration.Status status ;
             private String statusMessage;
+            private List<String> stepsPerformed;
+
+            public StatusUpdate(Integration.Status status, List<String> stepsPerformed) {
+                this.status = status;
+                this.stepsPerformed = stepsPerformed;
+            }
 
             public StatusUpdate(Integration.Status status, String statusMessage) {
                 this.status = status;
@@ -41,7 +47,7 @@ public interface StatusChangeHandlerProvider {
             }
 
             public StatusUpdate(Integration.Status status) {
-                this(status, null);
+                this.status = status;
             }
 
             public Integration.Status getStatus() {
@@ -50,6 +56,10 @@ public interface StatusChangeHandlerProvider {
 
             public String getStatusMessage() {
                 return statusMessage;
+            }
+
+             public List<String> getStepsPerformed() {
+                return stepsPerformed;
             }
         }
     }

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
@@ -360,11 +360,12 @@ public class ActivateHandler extends BaseHandler implements StatusChangeHandlerP
 
     private class BuildStepPerformer {
         private final List<String> stepsPerformed;
-        private Integration integration;
+        private final Integration integration;
 
         BuildStepPerformer(Integration integration) {
             this.integration = integration;
-            this.stepsPerformed = integration.getStepsDone().orElseGet(ArrayList::new);
+            this.stepsPerformed = integration.getStepsDone().isPresent() ?
+                new ArrayList<>(integration.getStepsDone().get()) : new ArrayList<>();
         }
 
         /* default */ void perform(String step, IoCheckedFunction<Integration> callable) throws IOException {

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
@@ -367,7 +367,7 @@ public class ActivateHandler extends BaseHandler implements StatusChangeHandlerP
             this.stepsPerformed = integration.getStepsDone().orElseGet(ArrayList::new);
         }
 
-        void perform(String step, IoCheckedFunction<Integration> callable) throws IOException {
+        /* default */ void perform(String step, IoCheckedFunction<Integration> callable) throws IOException {
             if (!stepsPerformed.contains(step)) {
                 callable.apply(integration);
                 stepsPerformed.add(step);
@@ -376,7 +376,7 @@ public class ActivateHandler extends BaseHandler implements StatusChangeHandlerP
             }
         }
 
-        public List<String> getStepsPerformed() {
+        /* default */ List<String> getStepsPerformed() {
             return stepsPerformed;
         }
     }

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/BaseHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/BaseHandler.java
@@ -27,9 +27,14 @@ import io.syndesis.model.connection.Connector;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.model.integration.Step;
 import io.syndesis.openshift.OpenShiftService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BaseHandler {
     private final OpenShiftService openShiftService;
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseHandler.class);
+
 
     protected BaseHandler(OpenShiftService openShiftService) {
         this.openShiftService = openShiftService;
@@ -39,6 +44,21 @@ public class BaseHandler {
         return openShiftService;
     }
 
+    protected void logInfo(Integration integration, String format, Object ... args) {
+        if (LOG.isInfoEnabled()) {
+            LOG.info(getLabel(integration) + ": " + format, args);
+        }
+    }
+
+    protected void logError(Integration integration, String format, Object ... args) {
+        if (LOG.isErrorEnabled()) {
+            LOG.error(getLabel(integration) + ": " + format, args);
+        }
+    }
+
+    private String getLabel(Integration integration) {
+        return "Integration " + integration.getId().orElse("[none]");
+    }
 
     /**
      * Fetch the Connectors

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/BaseHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/BaseHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import io.syndesis.core.Names;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.integration.model.steps.Endpoint;
 import io.syndesis.model.connection.Connector;
@@ -57,7 +58,7 @@ public class BaseHandler {
     }
 
     private String getLabel(Integration integration) {
-        return "Integration " + integration.getId().orElse("[none]");
+        return String.format("Integration [%s]",Names.sanitize(integration.getName()));
     }
 
     /**

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/DeactivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/DeactivateHandler.java
@@ -40,6 +40,7 @@ public class DeactivateHandler extends BaseHandler implements StatusChangeHandle
     public StatusUpdate execute(Integration integration) {
         try {
             openShiftService().scale(integration.getName(), 0);
+            logInfo(integration,"Deactivated");
         } catch (KubernetesClientException e) {
             // Ignore 404 errors, means the deployment does not exist for us
             // to scale down

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/DeleteHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/DeleteHandler.java
@@ -38,6 +38,7 @@ public class DeleteHandler extends BaseHandler implements StatusChangeHandlerPro
             || openShiftService().delete(integration.getName())
             ? Integration.Status.Deleted
             : Integration.Status.Pending;
+        logInfo(integration,"Deleted");
 
         return new StatusUpdate(currentStatus);
     }

--- a/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -40,7 +40,7 @@ import org.immutables.value.Value;
 @UniqueProperty(value = "name", groups = UniquenessRequired.class)
 public interface Integration extends WithId<Integration>, WithTags, WithName, Serializable {
 
-    enum Status { Draft, Pending, Activated, Deactivated, Deleted}
+    enum Status { Draft, Pending, Activated, Deactivated, Deleted }
 
     @Override
     default Kind getKind() {
@@ -85,6 +85,8 @@ public interface Integration extends WithId<Integration>, WithTags, WithName, Se
     Optional<Status> getDesiredStatus();
 
     Optional<Status> getCurrentStatus();
+
+    Optional<List<String>> getStepsDone();
 
     Optional<String> getStatusMessage();
 

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftConfigurationProperties.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftConfigurationProperties.java
@@ -24,8 +24,6 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class OpenShiftConfigurationProperties {
 
-    private static final String DEFAULT_INTEGRATION_SA = "syndesis-integration";
-
     public static final String SERVICE_CA_CERT_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt";
 
     private boolean enabled;
@@ -39,8 +37,6 @@ public class OpenShiftConfigurationProperties {
     private String apiBaseUrl;
 
     private String namespace;
-
-    private String integrationServiceAccount = DEFAULT_INTEGRATION_SA;
 
     public boolean isEnabled() {
         return enabled;
@@ -86,11 +82,4 @@ public class OpenShiftConfigurationProperties {
         this.namespace = namespace;
     }
 
-    public String getIntegrationServiceAccount() {
-        return integrationServiceAccount;
-    }
-
-    public void setIntegrationServiceAccount(String integrationServiceAccount) {
-        this.integrationServiceAccount = integrationServiceAccount;
-    }
 }

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
@@ -35,7 +35,7 @@ public interface OpenShiftService {
      * @param name name of the build
      * @param data the deployment data to use
      */
-    void ensureSetup(String name, DeploymentData data);
+    void setup(String name, DeploymentData data);
 
     /**
      * Start a previously created build with the data from the given directory
@@ -44,6 +44,16 @@ public interface OpenShiftService {
      * @param tarInputStream input stream representing a tar file containing the project files
      */
     void build(String name, InputStream tarInputStream) throws IOException;
+
+    /**
+     * Perform a deployment
+     *
+     * @param name name of the deployment to trigger
+     *
+     */
+    void deploy(String name);
+
+    boolean isReady(String name);
 
     /**
      * Deletes the deployment (Deployment and Build configurations, Image Streams etc)
@@ -80,4 +90,5 @@ public interface OpenShiftService {
      */
     List<DeploymentConfig> getDeploymentsByLabel(Map<String, String> labels);
 
+    boolean isBuildStarted(String buildName);
 }

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
@@ -200,6 +200,8 @@ public class OpenShiftServiceImpl implements OpenShiftService {
               .withNewSourceStrategy()
                 .withNewFrom().withKind("ImageStreamTag").withName(builderStreamTag).endFrom()
                 .withIncremental(true)
+                // TODO: This environment setup needs to be externalized into application.properties
+                // https://github.com/syndesisio/syndesis-rest/issues/682
                 .withEnv(new EnvVar("MAVEN_OPTS","-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx300m", null))
               .endSourceStrategy()
             .endStrategy()

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
@@ -37,10 +37,10 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     }
 
     @Override
-    public void ensureSetup(String name, DeploymentData deploymentData) {
+    public void setup(String name, DeploymentData deploymentData) {
         String sName = Names.sanitize(name);
         ensureImageStreams(sName);
-        ensureDeploymentConfig(sName, deploymentData, this.config.getIntegrationServiceAccount());
+        ensureDeploymentConfig(sName, deploymentData);
         ensureSecret(sName, deploymentData);
         ensureBuildConfig(sName, deploymentData, this.config.getBuilderImageStreamTag());
     }
@@ -51,6 +51,18 @@ public class OpenShiftServiceImpl implements OpenShiftService {
         openShiftClient.buildConfigs().withName(sName)
                        .instantiateBinary()
                        .fromInputStream(tarInputStream);
+    }
+
+    @Override
+    public void deploy(String name) {
+        String sName = Names.sanitize(name);
+        openShiftClient.deploymentConfigs().withName(sName).deployLatest();
+    }
+
+    @Override
+    public boolean isReady(String name) {
+        String sName = Names.sanitize(name);
+        return openShiftClient.deploymentConfigs().withName(sName).isReady();
     }
 
     @Override
@@ -96,6 +108,16 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     }
 
     @Override
+    public boolean isBuildStarted(String name) {
+        String sName = Names.sanitize(name);
+        return !openShiftClient.builds()
+                               .withLabel("openshift.io/build-config.name", sName)
+                               .withField("status", "Running")
+                               .list().getItems().isEmpty();
+    }
+
+
+    @Override
     public List<DeploymentConfig> getDeploymentsByLabel(Map<String, String> labels) {
         return openShiftClient.deploymentConfigs().withLabels(labels).list().getItems();
     };
@@ -115,7 +137,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
         return openShiftClient.imageStreams().withName(name).delete();
     }
 
-    private void ensureDeploymentConfig(String name, DeploymentData deploymentData, String serviceAccount) {
+    private void ensureDeploymentConfig(String name, DeploymentData deploymentData) {
         openShiftClient.deploymentConfigs().withName(name).createOrReplaceWithNew()
             .withNewMetadata()
             .withName(name)
@@ -128,8 +150,6 @@ public class OpenShiftServiceImpl implements OpenShiftService {
             .withNewTemplate()
             .withNewMetadata().addToLabels("integration", name).endMetadata()
             .withNewSpec()
-            .withServiceAccount(serviceAccount)
-            .withServiceAccountName(serviceAccount)
             .addNewContainer()
             .withImage(" ").withImagePullPolicy("Always").withName(name)
             .addNewPort().withName("jolokia").withContainerPort(8778).endPort()
@@ -150,6 +170,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
             .addNewTrigger().withType("ConfigChange").endTrigger()
             .addNewTrigger().withType("ImageChange")
             .withNewImageChangeParams()
+            // set automatic to 'true' when not performing the deployments on our own
             .withAutomatic(true).addToContainerNames(name)
             .withNewFrom().withKind("ImageStreamTag").withName(name + ":latest").endFrom()
             .endImageChangeParams()
@@ -157,6 +178,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
             .endSpec()
             .done();
     }
+
 
 
     private boolean removeDeploymentConfig(String projectName) {
@@ -178,7 +200,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
               .withNewSourceStrategy()
                 .withNewFrom().withKind("ImageStreamTag").withName(builderStreamTag).endFrom()
                 .withIncremental(true)
-                .withEnv(new EnvVar("MAVEN_OPTS","-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx500m", null))
+                .withEnv(new EnvVar("MAVEN_OPTS","-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx300m", null))
               .endSourceStrategy()
             .endStrategy()
             .withNewOutput().withNewTo().withKind("ImageStreamTag").withName(name + ":latest").endTo().endOutput()

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceNoOp.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceNoOp.java
@@ -25,13 +25,23 @@ import io.fabric8.openshift.api.model.DeploymentConfig;
 public class OpenShiftServiceNoOp implements OpenShiftService {
 
     @Override
-    public void ensureSetup(String name, DeploymentData d) {
+    public void setup(String name, DeploymentData d) {
         // Empty no-op just for testing
     }
 
     @Override
     public void build(String name, InputStream tarInputStream) {
         // Empty no-op just for testing
+    }
+
+    @Override
+    public void deploy(String name) {
+        // Empty no-op just for testing
+    }
+
+    @Override
+    public boolean isReady(String name) {
+        return true;
     }
 
     @Override
@@ -57,5 +67,10 @@ public class OpenShiftServiceNoOp implements OpenShiftService {
     @Override
     public List<DeploymentConfig> getDeploymentsByLabel(Map<String, String> labels) {
         return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isBuildStarted(String buildName) {
+        return false;
     }
 }

--- a/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
@@ -44,6 +44,7 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import io.syndesis.connector.catalog.ConnectorCatalog;
+import io.syndesis.core.Names;
 import io.syndesis.integration.model.Flow;
 import io.syndesis.integration.model.SyndesisHelpers;
 import io.syndesis.integration.model.SyndesisModel;
@@ -124,8 +125,8 @@ public class DefaultProjectGenerator implements ProjectGenerator {
         Integration integration = request.getIntegration();
         integration.getSteps().ifPresent(steps -> {
             for (Step step : steps) {
-                LOG.debug("Integration {} : Adding step {} ",
-                         integration.getId().orElse("[none]"),
+                LOG.debug("Integration [{}]: Adding step {} ",
+                          Names.sanitize(integration.getName()),
                          step.getId().orElse(""));
                 step.getAction().ifPresent(action -> connectorCatalog.addConnector(action.getCamelConnectorGAV()));
             }
@@ -185,7 +186,7 @@ public class DefaultProjectGenerator implements ProjectGenerator {
 
 
                 addAdditionalResources(tos);
-                LOG.info("Integration {} : Project files written to output stream",request.getIntegration().getName());
+                LOG.info("Integration [{}]: Project files written to output stream",Names.sanitize(request.getIntegration().getName()));
             } catch (IOException e) {
                 if (LOG.isErrorEnabled()) {
                     LOG.error(String.format("Exception while creating runtime build tar for integration %s : %s",

--- a/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
@@ -124,7 +124,7 @@ public class DefaultProjectGenerator implements ProjectGenerator {
         Integration integration = request.getIntegration();
         integration.getSteps().ifPresent(steps -> {
             for (Step step : steps) {
-                LOG.info("Integration {} : Adding step {} ",
+                LOG.debug("Integration {} : Adding step {} ",
                          integration.getId().orElse("[none]"),
                          step.getId().orElse(""));
                 step.getAction().ifPresent(action -> connectorCatalog.addConnector(action.getCamelConnectorGAV()));

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
@@ -91,7 +91,7 @@ public class IntegrationHandler extends BaseHandler
             //Not sure if we need to do that for both current and desired status,
             //but If we don't do include the desired state, IntegrationITCase is not going to pass anytime soon. Why?
             //Cause that test, is using NoopHandlerProvider, so that means no controllers.
-            throw new EntityNotFoundException();
+            throw new EntityNotFoundException(String.format("Integration %s has been deleted", integration.getId()));
         }
 
         //fudging the timesUsed for now


### PR DESCRIPTION
For now we are triggering a deployment explicitly, to circumvent
issue on our target platform which has problems with deployment triggers.

However I was not able to disable image triggers on the deployment, otherwise
imagestream could not be used. This cause a double deployment on
platforms with working triggers
This is not nice but should not harm to much.