### PR TITLE
Fix ignoredUnusedDeclaredDependency issue in syndesis-rest/model.

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -113,7 +113,9 @@
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <ignoredUnusedDeclaredDependencies>io.syndesis.integration-runtime:model</ignoredUnusedDeclaredDependencies>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>io.syndesis.integration-runtime:model</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Getting an error building syndesis-rest because it appears like the `<ignoredUnusedDeclaredDependencies/>` needs a `<ignoredUnusedDeclaredDependency/>` tag.