### PR TITLE
refactor: upgrade to Camel 2.20.0, few Maven bits

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dmaven.artifact.threads=8

--- a/credential/pom.xml
+++ b/credential/pom.xml
@@ -28,6 +28,14 @@
   <artifactId>credential</artifactId>
   <name>Syndesis REST :: Credential</name>
 
+  <repositories>
+    <!-- needed for Spring Social Salesforce fork from mikegirard/spring-social-salesforce -->
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+
   <dependencies>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,61 +76,6 @@
     </repository>
   </distributionManagement>
 
-  <repositories>
-
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter-releases</id>
-      <name>jcenter</name>
-      <url>https://jcenter.bintray.com</url>
-    </repository>
-
-    <!-- needed for Spring Social Salesforce fork from mikegirard/spring-social-salesforce -->
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-
-    <!-- required for camel -->
-    <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter-releases</id>
-      <name>jcenter</name>
-      <url>https://jcenter.bintray.com</url>
-    </pluginRepository>
-
-    <!-- required for camel -->
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -144,12 +89,12 @@
 
     <assertj-core.version>3.6.2</assertj-core.version>
     <caffeine.version>2.4.0</caffeine.version>
-    <camel.version>2.20.0.fuse-000106</camel.version>
+    <camel.version>2.20.0</camel.version>
     <jdbi.version>2.78</jdbi.version>
     <hibernate.validator.version>5.3.5.Final</hibernate.validator.version>
     <immutables.version>2.5.1</immutables.version>
     <infinispan.version>9.0.0.Final</infinispan.version>
-    <jackson.version>2.8.9</jackson.version>
+    <jackson.version>2.8.10</jackson.version>
     <junit.version>4.12</junit.version>
     <keycloak.version>2.5.4.Final</keycloak.version>
     <kubernetes.client.version>2.2.13</kubernetes.client.version>

--- a/project-generator/pom.xml
+++ b/project-generator/pom.xml
@@ -29,28 +29,6 @@
   <artifactId>project-generator</artifactId>
   <name>Syndesis REST :: Project Generator</name>
 
-  <repositories>
-    <repository>
-      <id>apache.snapshots</id>
-      <name>Apache Development Snapshot Repository</name>
-      <url>https://repository.apache.org/content/repositories/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter-releases</id>
-      <name>jcenter</name>
-      <url>https://jcenter.bintray.com</url>
-    </repository>
-  </repositories>
-
   <dependencies>
 
     <dependency>

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/pom.xml.mustache
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/pom.xml.mustache
@@ -18,31 +18,6 @@
     <camel-atlasmap.version>@camel-atlasmap.version@</camel-atlasmap.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>maven-central</id>
-      <name>Maven Central</name>
-      <url>https://repo.maven.apache.org/maven2/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-pom.xml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-pom.xml
@@ -18,31 +18,6 @@
     <camel-atlasmap.version>@camel-atlasmap.version@</camel-atlasmap.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>maven-central</id>
-      <name>Maven Central</name>
-      <url>https://repo.maven.apache.org/maven2/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-pom.xml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-pom.xml
@@ -18,31 +18,6 @@
     <camel-atlasmap.version>@camel-atlasmap.version@</camel-atlasmap.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>maven-central</id>
-      <name>Maven Central</name>
-      <url>https://repo.maven.apache.org/maven2/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -41,6 +41,30 @@
     <keycloak.cli.script>./jboss-cli.sh</keycloak.cli.script>
   </properties>
 
+  <repositories>
+
+    <!-- needed for Spring Social Salesforce fork from mikegirard/spring-social-salesforce -->
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+
+  </repositories>
+
+  <pluginRepositories>
+
+    <!-- needed for swagger2markup-maven-plugin -->
+    <pluginRepository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>jcenter-releases</id>
+      <name>jcenter</name>
+      <url>https://jcenter.bintray.com</url>
+    </pluginRepository>
+
+  </pluginRepositories>
+
   <build>
     <finalName>runtime</finalName>
 


### PR DESCRIPTION
Upgrades Camel to 2.20.0 (from Fuse EA) and removes the Fuse EA
repository. Also adds Maven configuration intended to speed up the
build (GC configuration, 8 parallel threads for downloads).

We still need jitpack and bintray repositories, I've added them to the
POMs where those dependencies are needed to prevent Maven contacting
them for other dependencies.

Fixes #701