### PR TITLE
refactor: use same Maven repositories thought

### DIFF
--- a/connector-catalog/pom.xml
+++ b/connector-catalog/pom.xml
@@ -30,6 +30,12 @@
   <name>Syndesis REST :: Connector Catalog</name>
 
   <dependencies>
+
+    <dependency>
+       <groupId>io.syndesis</groupId>
+       <artifactId>core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-catalog</artifactId>

--- a/connector-catalog/src/main/java/io/syndesis/connector/catalog/ConnectorCatalogProperties.java
+++ b/connector-catalog/src/main/java/io/syndesis/connector/catalog/ConnectorCatalogProperties.java
@@ -18,34 +18,31 @@ package io.syndesis.connector.catalog;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+
+import io.syndesis.core.MavenProperties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("camel.connector.catalog")
 public class ConnectorCatalogProperties {
 
-    private Map<String, String> mavenRepos = new ConcurrentHashMap<>(1);
-
     private List<String> connectorGAVs = new ArrayList<>(5);
 
-    public ConnectorCatalogProperties() {
-        this.mavenRepos.put("maven.central", "https://repo.maven.apache.org/maven2/");
-    }
+    private final MavenProperties mavenProperties;
 
-    public Map<String, String> getMavenRepos() {
-        return mavenRepos;
-    }
-
-    public void setMavenRepos(Map<String, String> mavenRepos) {
-        this.mavenRepos = mavenRepos;
+    public ConnectorCatalogProperties(final MavenProperties mavenProperties) {
+        this.mavenProperties = mavenProperties;
     }
 
     public List<String> getConnectorGAVs() {
         return connectorGAVs;
     }
 
-    public void setConnectorGAVs(List<String> connectorGAVs) {
+    public Map<String, String> getMavenRepos() {
+        return mavenProperties.getRepositories();
+    }
+
+    public void setConnectorGAVs(final List<String> connectorGAVs) {
         this.connectorGAVs = connectorGAVs;
     }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,12 @@
     <!-- === Internal dependencies (don't touch without discussion) ========================== -->
     <!-- (none) -->
     <!-- ===================================================================================== -->
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>

--- a/core/src/main/java/io/syndesis/core/MavenProperties.java
+++ b/core/src/main/java/io/syndesis/core/MavenProperties.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.core;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("maven")
+public class MavenProperties {
+
+    private final Map<String, String> repositories = new ConcurrentHashMap<>(3);
+
+    public MavenProperties() {
+    }
+
+    public MavenProperties(final Map<String, String> repositories) {
+        this.repositories.putAll(repositories);
+    }
+
+    public Map<String, String> getRepositories() {
+        return repositories;
+    }
+
+    public void setRepositories(final Map<String, String> repositories) {
+        this.repositories.clear();
+        this.repositories.putAll(repositories);
+    }
+
+}

--- a/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -48,6 +49,7 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import io.syndesis.connector.catalog.ConnectorCatalog;
+import io.syndesis.core.MavenProperties;
 import io.syndesis.core.Names;
 import io.syndesis.integration.model.Flow;
 import io.syndesis.integration.model.SyndesisHelpers;
@@ -225,7 +227,12 @@ public class DefaultProjectGenerator implements ProjectGenerator {
                 gavsSeen.add(gav);
             });
         }
-        return generateFromPomContext(new PomContext(integration.getId().orElse(""), integration.getName(), integration.getDescription().orElse(null), connectors), pomMustache);
+        return generateFromPomContext(new PomContext(integration.getId().orElse(""),
+                                                    integration.getName(),
+                                                    integration.getDescription().orElse(null),
+                                                    connectors,
+                                                    generatorProperties.getMavenProperties()),
+                                        pomMustache);
     }
 
     @SuppressWarnings("PMD.UnusedPrivateMethod") // PMD false positive
@@ -342,11 +349,14 @@ public class DefaultProjectGenerator implements ProjectGenerator {
 
         private final Set<MavenGav> connectors;
 
-        /* default */ PomContext(String id, String name, String description, Set<MavenGav> connectors) {
+        private final MavenProperties mavenProperties;
+
+        /* default */ PomContext(String id, String name, String description, Set<MavenGav> connectors, MavenProperties mavenProperties) {
             this.id = id;
             this.name = name;
             this.description = description;
             this.connectors = connectors;
+            this.mavenProperties = mavenProperties;
         }
 
         public String getId() {
@@ -363,6 +373,10 @@ public class DefaultProjectGenerator implements ProjectGenerator {
 
         public Set<MavenGav> getConnectors() {
             return connectors;
+        }
+
+        public Set<Entry<String, String>> getMavenRepositories() {
+            return mavenProperties.getRepositories().entrySet();
         }
     }
 }

--- a/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorProperties.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorProperties.java
@@ -18,6 +18,8 @@ package io.syndesis.project.converter;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.syndesis.core.MavenProperties;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("generator")
@@ -30,6 +32,12 @@ public class ProjectGeneratorProperties {
      */
     private final Templates templates = new Templates();
 
+    private final MavenProperties mavenProperties;
+
+    public ProjectGeneratorProperties(final MavenProperties mavenProperties) {
+        this.mavenProperties = mavenProperties;
+    }
+
     public Boolean isSecretMaskingEnabled() {
         return secretMaskingEnabled;
     }
@@ -40,6 +48,10 @@ public class ProjectGeneratorProperties {
 
     public Templates getTemplates() {
         return templates;
+    }
+
+    public MavenProperties getMavenProperties() {
+        return mavenProperties;
     }
 
     public static class Templates {

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/pom.xml.mustache
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/pom.xml.mustache
@@ -17,6 +17,17 @@
     <syndesis-integration-runtime.version>@syndesis-integration-runtime.version@</syndesis-integration-runtime.version>
     <camel-atlasmap.version>@camel-atlasmap.version@</camel-atlasmap.version>
   </properties>
+  {{^mavenRepositories.empty}}
+
+  <repositories>
+    {{#mavenRepositories}}
+    <repository>
+      <id>{{key}}</id>
+      <url>{{value}}</url>
+    </repository>
+    {{/mavenRepositories}}
+  </repositories>
+  {{/mavenRepositories.empty}}
 
   <dependencyManagement>
     <dependencies>

--- a/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.syndesis.connector.catalog.ConnectorCatalog;
 import io.syndesis.connector.catalog.ConnectorCatalogProperties;
+import io.syndesis.core.MavenProperties;
 import io.syndesis.integration.support.Strings;
 import io.syndesis.model.connection.Action;
 import io.syndesis.model.connection.Connection;
@@ -73,7 +74,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Parameterized.class)
 public class DefaultProjectGeneratorTest {
     private static final String CONNECTORS_VERSION = ResourceBundle.getBundle("test").getString("connectors.version");
-    private static final ConnectorCatalogProperties CATALOG_PROPERTIES = new ConnectorCatalogProperties();
+    private static MavenProperties mavenProperties = new MavenProperties(map("maven.central", "https://repo1.maven.org/maven2",
+        "redhat.ga", "https://maven.repository.redhat.com/ga",
+        "jboss.ea", "https://repository.jboss.org/nexus/content/groups/ea"));
+    private static final ConnectorCatalogProperties CATALOG_PROPERTIES = new ConnectorCatalogProperties(mavenProperties);
     private static Properties properties = new Properties();
     private static final ObjectMapper OBJECT_MAPPER;
     private static final TypeReference<HashMap<String, Connector>> CONNECTOR_MAP_TYPE_REF;
@@ -96,11 +100,6 @@ public class DefaultProjectGeneratorTest {
             OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
             CONNECTOR_MAP_TYPE_REF = new TypeReference<HashMap<String, Connector>>() {
             };
-            final Map<String, String> repositories = new HashMap<>();
-            repositories.put("maven.central", "https://repo1.maven.org/maven2");
-            repositories.put("redhat.ga", "https://maven.repository.redhat.com/ga");
-            repositories.put("jboss.ea", "https://repository.jboss.org/nexus/content/groups/ea");
-            CATALOG_PROPERTIES.setMavenRepos(repositories);
     }
 
     private Path runtimeDir;
@@ -213,7 +212,7 @@ public class DefaultProjectGeneratorTest {
             .connectors(connectors)
             .build();
 
-        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties();
+        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties(new MavenProperties());
         generatorProperties.getTemplates().setOverridePath(this.basePath);
         generatorProperties.getTemplates().getAdditionalResources().addAll(this.additionalResources);
 
@@ -269,7 +268,7 @@ public class DefaultProjectGeneratorTest {
             .connectors(connectors)
             .build();
 
-        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties();
+        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties(mavenProperties);
         generatorProperties.getTemplates().setOverridePath(this.basePath);
         generatorProperties.getTemplates().getAdditionalResources().addAll(this.additionalResources);
         generatorProperties.setSecretMaskingEnabled(true);
@@ -334,7 +333,7 @@ public class DefaultProjectGeneratorTest {
             .connectors(connectors)
             .build();
 
-        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties();
+        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties(mavenProperties);
         generatorProperties.getTemplates().setOverridePath(this.basePath);
         generatorProperties.getTemplates().getAdditionalResources().addAll(this.additionalResources);
         generatorProperties.setSecretMaskingEnabled(true);
@@ -355,7 +354,7 @@ public class DefaultProjectGeneratorTest {
             .build();
 
 
-        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties();
+        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties(mavenProperties);
         generatorProperties.getTemplates().setOverridePath(this.basePath);
         generatorProperties.getTemplates().getAdditionalResources().addAll(this.additionalResources);
 
@@ -409,7 +408,7 @@ public class DefaultProjectGeneratorTest {
             .connectors(connectors)
             .build();
 
-        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties();
+        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties(mavenProperties);
         generatorProperties.getTemplates().setOverridePath(this.basePath);
         generatorProperties.getTemplates().getAdditionalResources().addAll(this.additionalResources);
 
@@ -498,7 +497,7 @@ public class DefaultProjectGeneratorTest {
             .connectors(connectors)
             .build();
 
-        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties();
+        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties(mavenProperties);
         generatorProperties.getTemplates().setOverridePath(this.basePath);
         generatorProperties.getTemplates().getAdditionalResources().addAll(this.additionalResources);
 
@@ -527,7 +526,7 @@ public class DefaultProjectGeneratorTest {
     }
 
     // Helper method to help constuct maps with concise syntax
-    private Map<String, String> map(Object... values) {
+    private static Map<String, String> map(Object... values) {
         HashMap<String, String> rc = new HashMap<>();
         for (int i = 0; i + 1 < values.length; i += 2) {
             rc.put(values[i].toString(), values[i + 1].toString());

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-pom.xml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-pom.xml
@@ -18,6 +18,21 @@
     <camel-atlasmap.version>@camel-atlasmap.version@</camel-atlasmap.version>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>maven.central</id>
+      <url>https://repo1.maven.org/maven2</url>
+    </repository>
+    <repository>
+      <id>jboss.ea</id>
+      <url>https://repository.jboss.org/nexus/content/groups/ea</url>
+    </repository>
+    <repository>
+      <id>redhat.ga</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/runtime/src/main/java/io/syndesis/runtime/Application.java
+++ b/runtime/src/main/java/io/syndesis/runtime/Application.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import javax.validation.Validator;
 
+import io.syndesis.core.MavenProperties;
 import io.syndesis.rest.v1.state.ClientSideState;
 import io.syndesis.rest.v1.state.ClientSideStateProperties;
 import io.syndesis.rest.v1.state.StaticEdition;
@@ -47,7 +48,7 @@ import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication(exclude = {TwitterAutoConfiguration.class, FacebookAutoConfiguration.class,
     LinkedInAutoConfiguration.class, SocialWebAutoConfiguration.class})
-@EnableConfigurationProperties(ClientSideStateProperties.class)
+@EnableConfigurationProperties({ClientSideStateProperties.class, MavenProperties.class})
 public class Application extends SpringBootServletInitializer {
 
     private static final Logger LOG = LoggerFactory.getLogger(Application.class);

--- a/runtime/src/main/resources/application.yml
+++ b/runtime/src/main/resources/application.yml
@@ -82,10 +82,6 @@ controllers:
   integration:
     enabled: true
 
-camel:
-  connector:
-    catalog:
-      mavenRepos:
-        maven.central: https://repo1.maven.org/maven2
-        redhat.ga: https://maven.repository.redhat.com/ga
-        jboss.ea: https://repository.jboss.org/nexus/content/groups/ea
+maven:
+  repositories:
+    maven.central: https://repo1.maven.org/maven2

--- a/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
+++ b/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
@@ -17,6 +17,7 @@ package io.syndesis.image;
 
 import io.syndesis.connector.catalog.ConnectorCatalog;
 import io.syndesis.connector.catalog.ConnectorCatalogProperties;
+import io.syndesis.core.MavenProperties;
 import io.syndesis.core.SuppressFBWarnings;
 import io.syndesis.dao.init.ModelData;
 import io.syndesis.dao.init.ReadApiClientData;
@@ -120,9 +121,9 @@ public class Application implements ApplicationRunner {
     @SuppressWarnings("PMD.UseProperClassLoader")
     private static void generate(GenerateProjectRequest request, File targetDir) throws IOException {
 
-        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties();
-        ConnectorCatalogProperties catalogProperties = new ConnectorCatalogProperties();
-        catalogProperties.setMavenRepos(new HashMap<>());
+        MavenProperties mavenProperties = new MavenProperties();
+        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties(mavenProperties);
+        ConnectorCatalogProperties catalogProperties = new ConnectorCatalogProperties(mavenProperties);
         StepVisitorFactoryRegistry registry = new StepVisitorFactoryRegistry(Arrays.asList());
         DefaultProjectGenerator generator = new DefaultProjectGenerator(new ConnectorCatalog(catalogProperties), generatorProperties, registry);
 


### PR DESCRIPTION
Adds MavenProperties that currently holds only Maven repositories that
the connector catalog, project generator and builder image generator
use.

Defines by default to use only Maven central.

Fixes #664