### PR TITLE
Improving handling of Oauth exceptions

### DIFF
--- a/credential/src/test/java/io/syndesis/credential/CredentialsTest.java
+++ b/credential/src/test/java/io/syndesis/credential/CredentialsTest.java
@@ -15,10 +15,15 @@
  */
 package io.syndesis.credential;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.net.URI;
 import java.util.Optional;
-
-import io.syndesis.model.connection.Connection;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -39,12 +44,7 @@ import org.springframework.social.oauth2.OAuth2Operations;
 import org.springframework.social.oauth2.OAuth2Parameters;
 import org.springframework.util.MultiValueMap;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import io.syndesis.model.connection.Connection;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CredentialsTest {

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -155,6 +155,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.1-api</artifactId>
     </dependency>
@@ -220,6 +225,7 @@
           <ignoredUsedUndeclaredDependencies>
             <!-- if declared complains about being unused -->
             <ignoredUnusedDeclaredDependency>com.google.code.findbugs:findbugs-annotations</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework:spring-web</ignoredUnusedDeclaredDependency>
           </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/BaseExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/BaseExceptionMapper.java
@@ -43,7 +43,7 @@ abstract class BaseExceptionMapper<E extends Throwable> implements ExceptionMapp
 
         LOG.error(developerMessage, exception);
 
-        final RestError error = new RestError(developerMessage, userMessage, status.getStatusCode());
+        final RestError error = new RestError(developerMessage, userMessage, null, status.getStatusCode());
 
         return Response.status(error.errorCode).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
     }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ErrorMap.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ErrorMap.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.exception;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ErrorMap {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ErrorMap.class);
+
+    private ErrorMap() {
+        // utility class
+    }
+
+    /**
+     * Performs best effort to parse the rawMsg. If all parsers fail it returns the raw message.
+     *
+     * @param rawMsg
+     * @return the underlying error message.
+     */
+    public static String from(String rawMsg) {
+        if (rawMsg.matches("^\\s*\\<.*")) {
+            return parseWith(rawMsg, new XmlMapper());
+        }
+        if (rawMsg.matches("^\\s*\\{.*")) {
+            return parseWith(rawMsg, new ObjectMapper());
+        }
+        return rawMsg;
+    }
+
+    /**
+     * Tries to parse the rawMsg assuming it is JSON formatted.
+     * defaults to the rawMsg if parsing fails.
+     * @param rawMsg
+     * @return ErrorMap
+     */
+    /* default */ static String parseWith(String rawMsg, ObjectMapper mapper) {
+        try {
+            final JsonNode jsonNode = mapper.readTree(rawMsg);
+            final Optional<String> error = determineError(jsonNode);
+            return error.orElse(rawMsg);
+        } catch (IOException e) {
+            LOG.debug("Swallowing {}", e.getMessage(), e);
+        }
+        return rawMsg;
+    }
+
+    /* default */ static Optional<String> determineError(final JsonNode node) {
+        return Optional.of(tryLookingUp(node, "errors", "message")
+            .orElseGet(() -> tryLookingUp(node, "error", "message")
+                .orElseGet(() -> tryLookingUp(node, "error")
+                    .orElseGet(() -> tryLookingUp(node, "message")
+                        .orElse(null)))));
+    }
+
+    /* default */ static Optional<String> tryLookingUp(final JsonNode node, final String... pathElements) {
+        JsonNode current = node;
+        for (String pathElement : pathElements) {
+            current = current.get(pathElement);
+
+            if (current != null && current.isArray() && current.iterator().hasNext()) {
+                current = current.iterator().next();
+            }
+
+            if (current == null) {
+                return Optional.empty();
+            }
+        }
+
+        if (current.isObject()) {
+            return Optional.of(current.toString());
+        }
+
+        return Optional.of(current.asText());
+    }
+
+}

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/HttpClientErrorExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/HttpClientErrorExceptionMapper.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.exception;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Component
+@Provider
+public class HttpClientErrorExceptionMapper implements ExceptionMapper<HttpClientErrorException> {
+
+    @Override
+    public Response toResponse(HttpClientErrorException exception) {
+        RestError error = new RestError(
+                exception.getMessage(),
+                exception.getMessage(),
+                ErrorMap.from(new String(exception.getResponseBodyAsByteArray(), StandardCharsets.UTF_8)),
+                exception.getStatusCode().value());
+        return Response.status(exception.getStatusCode().value()).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
+    }
+}

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/HttpServerErrorExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/HttpServerErrorExceptionMapper.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.exception;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpServerErrorException;
+
+@Component
+@Provider
+public class HttpServerErrorExceptionMapper implements ExceptionMapper<HttpServerErrorException> {
+
+    @Override
+    public Response toResponse(HttpServerErrorException exception) {
+        RestError error = new RestError(
+                exception.getMessage(),
+                exception.getMessage(),
+                ErrorMap.from(new String(exception.getResponseBodyAsByteArray(), StandardCharsets.UTF_8)),
+                exception.getStatusCode().value());
+        return Response.status(exception.getStatusCode().value()).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
+    }
+}

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/InternalServerErrorExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/InternalServerErrorExceptionMapper.java
@@ -39,7 +39,7 @@ public class InternalServerErrorExceptionMapper implements ExceptionMapper<Inter
             final RestError error = new RestError(
                 "A remote call failed without a detailed error message, status message is: " + response.getStatus()
                     + " - " + response.getStatusInfo().getReasonPhrase(),
-                "Please contact the administrator and file a bug report", response.getStatus());
+                "Please contact the administrator and file a bug report", null, response.getStatus());
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).type(MediaType.APPLICATION_JSON_TYPE)
                 .entity(error).build();
         }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/RestError.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/RestError.java
@@ -34,6 +34,9 @@ public class RestError {
     @JsonProperty("userMsg")
     /* default */ String userMsg;
 
+    @JsonProperty("userMsgDetail")
+    /* default */ String userMsgDetail;
+
     @JsonProperty("errorCode")
     /* default */ Integer errorCode;
 
@@ -41,9 +44,10 @@ public class RestError {
         // makes it a Java bean
     }
 
-    public RestError(String developerMsg, String userMsg, Integer errorCode) {
+    public RestError(String developerMsg, String userMsg,  String userMsgDetail, Integer errorCode) {
         this.developerMsg = developerMsg;
         this.userMsg = userMsg;
+        this.userMsgDetail = userMsgDetail;
         this.errorCode = errorCode;
     }
     public String getDeveloperMsg() {
@@ -57,6 +61,12 @@ public class RestError {
     }
     public void setUserMsg(String userMsg) {
         this.userMsg = userMsg;
+    }
+    public String getUserMsgDetail() {
+        return userMsgDetail;
+    }
+    public void setUserMsgDetail(String userMsgDetail) {
+        this.userMsgDetail = userMsgDetail;
     }
     public Integer getErrorCode() {
         return errorCode;

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/exception/ErrorMapTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/exception/ErrorMapTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.exception;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ErrorMapTest {
+
+    @Test
+    public void testUnmarshalXML() {
+        String rawMsg = read("/HttpClientErrorException.xml");
+        assertThat(ErrorMap.from(rawMsg)).isEqualTo("Desktop applications only support the oauth_callback value 'oob'");
+    }
+
+    @Test
+    public void testUnmarshalJSON() {
+        String rawMsg = read("/HttpClientErrorException.json");
+        assertThat(ErrorMap.from(rawMsg)).isEqualTo("Could not authenticate you.");
+    }
+
+    @Test
+    public void testUnmarshalJSONVaryingFormats() {
+        assertThat(ErrorMap.from("{\"error\": \"some error\"}")).isEqualTo("some error");
+        assertThat(ErrorMap.from("{\"message\": \"some message\"}")).isEqualTo("some message");
+    }
+
+    @Test
+    public void testUnmarshalImpossible() {
+        String rawMsg = "This is just some other error format";
+        assertThat(ErrorMap.from(rawMsg)).isEqualTo(rawMsg);
+    }
+
+    @Test
+    public void shouldTryToLookupInJson() {
+        final JsonNodeFactory factory = JsonNodeFactory.instance;
+        final ObjectNode obj = factory.objectNode();
+        obj.set("a", factory.arrayNode().add("b").add("c"));
+        obj.set("x", factory.objectNode().set("y", factory.objectNode().put("z", "!")));
+
+        assertThat(ErrorMap.tryLookingUp(obj, "a")).contains("b");
+        assertThat(ErrorMap.tryLookingUp(obj, "a", "b")).isEmpty();
+        assertThat(ErrorMap.tryLookingUp(obj, "x", "y")).contains("{\"z\":\"!\"}");
+        assertThat(ErrorMap.tryLookingUp(obj, "x", "y", "z")).contains("!");
+    }
+
+    private static String read(final String path) {
+        try {
+            return String.join("", Files.readAllLines(Paths.get(ErrorMapTest.class.getResource(path).toURI())));
+        } catch (IOException | URISyntaxException e) {
+            throw new IllegalArgumentException("Unable to read from path: " + path, e);
+        }
+    }
+
+}

--- a/rest/src/test/resources/HttpClientErrorException.json
+++ b/rest/src/test/resources/HttpClientErrorException.json
@@ -1,0 +1,1 @@
+{"errors":[{"code":32,"message":"Could not authenticate you."}]}

--- a/rest/src/test/resources/HttpClientErrorException.xml
+++ b/rest/src/test/resources/HttpClientErrorException.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hash>
+  <error>Desktop applications only support the oauth_callback value 'oob'</error>
+  <request>/oauth/request_token</request>
+</hash>


### PR DESCRIPTION
Best effort parsing of the raw error message, with a fallback of sending the raw message. This message is set in the userMsgDetail.

https://github.com/syndesisio/syndesis-rest/issues/679
https://github.com/syndesisio/syndesis-rest/issues/652

Let's simply add more parsers as they different raw formats are found.