### PR TITLE
refactor: make DeploymentDescriptor integration test

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -167,6 +167,19 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
 
   </build>

--- a/dao/src/test/java/io/syndesis/dao/DeploymentDescriptorIT.java
+++ b/dao/src/test/java/io/syndesis/dao/DeploymentDescriptorIT.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.fail;
  * Downloads all connectors defined in {@code deployment.json} and tries to
  * resolve their endpoints using Camel catalog.
  */
-public class DeploymentDescriptorTest {
+public class DeploymentDescriptorIT {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -59,9 +59,9 @@ public class DeploymentDescriptorTest {
 
     private final MavenArtifactProvider mavenArtifactProvider = createArtifactProvider();
 
-    public DeploymentDescriptorTest() throws IOException {
+    public DeploymentDescriptorIT() throws IOException {
         deployment = MAPPER
-            .readTree(DeploymentDescriptorTest.class.getResourceAsStream("/io/syndesis/dao/deployment.json"));
+            .readTree(DeploymentDescriptorIT.class.getResourceAsStream("/io/syndesis/dao/deployment.json"));
     }
 
     @Test


### PR DESCRIPTION
Renames DeploymentDescriptor to DeploymentDescriptorIT and adds failsafe
plugin to POM to be executed.

Fixes #715