### PR TITLE
refactor: simplify integration status implementation and check

### DIFF
--- a/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -107,12 +107,10 @@ public interface Integration extends WithId<Integration>, WithTags, WithName, Se
     Optional<BigInteger> getTimesUsed();
 
     @JsonIgnore
-    default Optional<IntegrationStatus> getStatus() {
+    default IntegrationRevisionState getStatus() {
         Optional<IntegrationRevision> deployedRevision = getDeployedRevision();
 
-        return Optional.of(new IntegrationStatus.Builder()
-            .currentState(deployedRevision.map(r -> r.getCurrentState()).orElse(IntegrationRevisionState.Pending))
-            .build());
+        return deployedRevision.map(r -> r.getCurrentState()).orElse(IntegrationRevisionState.Pending);
     }
 
     @Override


### PR DESCRIPTION
`Integration::getStatus` returns a `Optional<IntegrationStatus>` that is
non empty in all cases with a single property (`currentState`)
populated. This simplifies that method to return just the
`IntegrationRevisionState`.
Also simplifies and makes more explicit the logic of counting active
integrations of a user.