### PR TITLE
Fixing invalid swagger link issues #382

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [Authentication](#authentication)
 
 ### Swagger
-[![Swagger](http://dgrechka.net/swagger_validator_content_type_proxy.php?url=https://circleci.com/api/v1/project/syndesisio/syndesis-rest/latest/artifacts/0/$CIRCLE_ARTIFACTS/swagger.json)](https://online.swagger.io/validator/debug?url=https://circleci.com/api/v1/project/syndesisio/syndesis-rest/latest/artifacts/0/$CIRCLE_ARTIFACTS/swagger.json)
+[![Swagger](http://dgrechka.net/swagger_validator_content_type_proxy.php?url=https://syndesis-staging.b6ff.rh-idev.openshiftapps.com/api/v1/swagger.json)](https://online.swagger.io/validator/debug?url=https://syndesis-staging.b6ff.rh-idev.openshiftapps.com/api/v1/swagger.json)
 
 # Building
 

--- a/rest/src/main/java/io/syndesis/rest/v1/V1Application.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/V1Application.java
@@ -28,6 +28,7 @@ public class V1Application extends Application {
     public V1Application() {
         BeanConfig beanConfig = new BeanConfig();
         beanConfig.setVersion("v1");
+        beanConfig.setTitle("Syndesis Rest API");
         beanConfig.setSchemes(new String[]{"http", "https"});
         beanConfig.setBasePath("/api/v1");
         beanConfig.setResourcePackage(getClass().getPackage().getName());


### PR DESCRIPTION
#382 red icon on README.md and https://github.com/syndesisio/syndesis-rest/issues/646

Issue 1 is that circle-ci changed the api to their build artifacts: https://circleci.com/docs/2.0/artifacts/#downloading-all-artifacts-for-a-build-on-circleci
So we can no longer have a direct link to the swagger.json on circle-ci. Only a link to a document with links: https://circleci.com/api/v1.1/project/github/syndesisio/syndesis-rest/latest/artifacts. Next best thing seems to use the link to staging.

Issue 2 our swagger.json is not valid as it is missing a title attribute, causing the red error icon.

> {"messages":["attribute info.title is missing"],"schemaValidationMessages":[{"level":"error","domain":"validation","keyword":"required","message":"object has missing required properties ([\"title\"])","schema":{"loadingURI":"http://swagger.io/v2/schema.json#","pointer":"/definitions/info"},"instance":{"pointer":"/info"}}]}

so I added a title attribute.
