### PR TITLE
fix: Handle missing user info in OpenShift user object

### DIFF
--- a/rest/src/main/java/io/syndesis/rest/v1/handler/user/UserHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/user/UserHandler.java
@@ -31,6 +31,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.Optional;
 
 @Path("/users")
 @Api(value = "users")
@@ -56,6 +57,10 @@ public class UserHandler extends BaseHandler implements Lister<User>, Getter<Use
         String token = String.valueOf(SecurityContextHolder.getContext().getAuthentication().getCredentials());
         io.fabric8.openshift.api.model.User openShiftUser = this.openShiftService.whoAmI(token);
         Assert.notNull(openShiftUser, "A valid user is required");
-        return new User.Builder().username(openShiftUser.getMetadata().getName()).fullName(openShiftUser.getFullName()).build();
+        return new User.Builder()
+            .username(openShiftUser.getMetadata().getName())
+            .fullName(Optional.ofNullable(openShiftUser.getFullName()))
+            .name(Optional.ofNullable(openShiftUser.getFullName()))
+            .build();
     }
 }

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/user/UserHandlerTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/user/UserHandlerTest.java
@@ -55,5 +55,22 @@ public class UserHandlerTest {
         Assertions.assertThat(user.getUsername()).isEqualTo("testuser");
         Assertions.assertThat(user.getFullName()).isNotEmpty().hasValue("Test User");
     }
+    @Test
+    public void successfulWhoAmIWithoutFullName() {
+        openShiftServer.expect()
+            .get().withPath("/oapi/v1/users/~")
+            .andReturn(
+                200,
+                new UserBuilder().withNewMetadata().withName("testuser").and().build()
+            ).once();
+
+        SecurityContextHolder.getContext().setAuthentication(new PreAuthenticatedAuthenticationToken("testuser", "doesn'tmatter"));
+
+        UserHandler userHandler = new UserHandler(null, new OpenShiftServiceImpl(openShiftServer.getOpenshiftClient(), null));
+        User user = userHandler.whoAmI();
+        Assertions.assertThat(user).isNotNull();
+        Assertions.assertThat(user.getUsername()).isEqualTo("testuser");
+        Assertions.assertThat(user.getFullName()).isEmpty();
+    }
 
 }


### PR DESCRIPTION
Needed for TP2 if we want user info safely populated in UI.