### PR TITLE
Adding filestore with DB backend

### DIFF
--- a/filestore/pom.xml
+++ b/filestore/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>syndesis-rest-parent</artifactId>
+    <groupId>io.syndesis</groupId>
+    <version>1.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>filestore</artifactId>
+  <name>Syndesis REST :: FileStore</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.jdbi</groupId>
+      <artifactId>jdbi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- == Test ==========================================================================  -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/filestore/src/main/java/io/syndesis/filestore/FileStore.java
+++ b/filestore/src/main/java/io/syndesis/filestore/FileStore.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.filestore;
+
+import java.io.InputStream;
+
+public interface FileStore {
+
+    /**
+     * Initialize the file store.
+     */
+    void init();
+
+    /**
+     * Write a file on a path.
+     *
+     * The path must be absolute (e.g. "/path/to/file.zip").
+     *
+     * If a file already exists it is overwritten.
+     * Parent directories are created automatically.
+     *
+     * @param path the destination path
+     * @param file the content of the file
+     */
+    void write(String path, InputStream file);
+
+    /**
+     * Write a file on a temporary path.
+     *
+     * The path wil be decided by the file store and returned to the client.
+     *
+     * @param file the content of the file
+     * @return the path created for the file
+     */
+    String writeTemporaryFile(InputStream file);
+
+    /**
+     * Read a file from a path.
+     *
+     * The path must be absolute (e.g. "/path/to/file.zip").
+     *
+     * @param path the path to read
+     * @return the file content or null if the file is not present
+     */
+    InputStream read(String path);
+
+    /**
+     * Delete a file corresponding to a path.
+     *
+     * The path must be absolute (e.g. "/path/to/file.zip").
+     *
+     * @param path the path to the file to delete
+     * @return true if the file existed before deleting
+     */
+    boolean delete(String path);
+
+    /**
+     * Moves a file from a source path to a destination path.
+     *
+     * Both paths must be absolute (e.g. "/path/to/file.zip").
+     *
+     * If a file already exists in the destination path, it is overwritten.
+     * If the source file does not exist, the operation is cancelled and the
+     * destination file (if present) is left unchanged.
+     *
+     * @param fromPath the source path
+     * @param toPath the destination path
+     * @return true if the source file existed before moving it
+     */
+    boolean move(String fromPath, String toPath);
+
+}

--- a/filestore/src/main/java/io/syndesis/filestore/FileStoreException.java
+++ b/filestore/src/main/java/io/syndesis/filestore/FileStoreException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.filestore;
+
+/**
+ * These runtime exceptions are thrown by the methods of the FileStore
+ */
+public class FileStoreException extends RuntimeException {
+
+    public FileStoreException(String message) {
+        super(message);
+    }
+
+    public FileStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public static RuntimeException launderThrowable(Throwable cause) {
+        return launderThrowable("An error has occurred.", cause);
+    }
+
+    public static RuntimeException launderThrowable(String message, Throwable cause) {
+        if (cause instanceof RuntimeException) {
+            return ((RuntimeException) cause);
+        } else if (cause instanceof Error) {
+            throw ((Error) cause);
+        } else {
+            throw new FileStoreException(message, cause);
+        }
+    }
+}

--- a/filestore/src/main/java/io/syndesis/filestore/impl/FileStoreSupport.java
+++ b/filestore/src/main/java/io/syndesis/filestore/impl/FileStoreSupport.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.filestore.impl;
+
+import io.syndesis.filestore.FileStoreException;
+
+import java.util.regex.Pattern;
+
+/**
+ * Utility methods for any FileStore
+ */
+public final class FileStoreSupport {
+
+    /**
+     * Characters commonly accepted in file names (any position)
+     */
+    private static final String COM_CHAR = "\\w-()\\[\\],";
+
+    /**
+     * Pattern for a file name or a directory name
+     */
+    private static final String FDIR_PATTERN = "[.]?([" + COM_CHAR + "][" + COM_CHAR + ".]*|[" + COM_CHAR + "][" + COM_CHAR + ". ]*[" + COM_CHAR + ".])";
+
+    /**
+     * Complete pattern of a path
+     */
+    private static final Pattern VALID_PATH_PATTERN = Pattern.compile("^/(" + FDIR_PATTERN + "/)*" + FDIR_PATTERN + "$");
+
+    private FileStoreSupport() {
+    }
+
+    /**
+     * Checks if the path is valid and throws an exception if it's not.
+     * @param path the path to check
+     * @throws FileStoreException if the path is not valid
+     */
+    public static void checkValidPath(String path) throws FileStoreException {
+        if (!isValidPath(path)) {
+            throw new FileStoreException("Invalid path: " + path);
+        }
+    }
+
+    /**
+     * Checks if the path is valid
+     * @param path the path to check
+     * @return true if the path is valid
+     */
+    public static boolean isValidPath(String path) {
+        return VALID_PATH_PATTERN.matcher(path).matches();
+    }
+
+}

--- a/filestore/src/main/java/io/syndesis/filestore/impl/SqlFileStore.java
+++ b/filestore/src/main/java/io/syndesis/filestore/impl/SqlFileStore.java
@@ -1,0 +1,341 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.filestore.impl;
+
+import io.syndesis.filestore.FileStore;
+import io.syndesis.filestore.FileStoreException;
+import org.apache.commons.io.IOUtils;
+import org.postgresql.largeobject.LargeObject;
+import org.postgresql.largeobject.LargeObjectManager;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.exceptions.CallbackFailedException;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.sql.Blob;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementation of a {@code FileStore} backed by a SQL database.
+ */
+public class SqlFileStore implements FileStore {
+
+    enum DatabaseKind {
+        PostgreSQL, H2, DERBY
+    }
+
+    private final DBI dbi;
+
+    private DatabaseKind databaseKind;
+
+    public SqlFileStore(DBI dbi) {
+        this(dbi, DatabaseKind.PostgreSQL);
+    }
+
+    public SqlFileStore(DBI dbi, DatabaseKind databaseKind) {
+        this.dbi = dbi;
+        this.databaseKind = databaseKind;
+    }
+
+    @Override
+    public void init() {
+        try {
+            dbi.useHandle(h -> {
+                if (databaseKind == DatabaseKind.PostgreSQL) {
+                    h.execute("CREATE TABLE filestore (path VARCHAR COLLATE \"C\" PRIMARY KEY, data OID)");
+                } else if (databaseKind == DatabaseKind.H2) {
+                    h.execute("CREATE TABLE filestore (path VARCHAR PRIMARY KEY, data BLOB)");
+                } else if (databaseKind == DatabaseKind.DERBY) {
+                    h.execute("CREATE TABLE filestore (path VARCHAR(1000), data BLOB, PRIMARY KEY (path))");
+                } else {
+                    throw new FileStoreException("Unsupported database kind: " + databaseKind);
+                }
+            });
+        } catch (CallbackFailedException ex) {
+            throw new FileStoreException("Unable to initialize the filestore", ex);
+        }
+    }
+
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    public void destroy() {
+        try {
+            dbi.useHandle(h -> h.execute("DROP TABLE filestore"));
+        } catch (CallbackFailedException ex) {
+            // simply ignore
+        }
+    }
+
+    @Override
+    public void write(String path, InputStream file) {
+        FileStoreSupport.checkValidPath(path);
+        Objects.requireNonNull(file, "file cannot be null");
+
+        try {
+            dbi.inTransaction((h, status) -> {
+                doWrite(h, path, file);
+                return true;
+            });
+        } catch (CallbackFailedException ex) {
+            throw new FileStoreException("Unable to write on path " + path, ex);
+        }
+    }
+
+    @Override
+    public String writeTemporaryFile(InputStream file) {
+        Objects.requireNonNull(file, "file cannot be null");
+
+        try {
+            return dbi.inTransaction((h, status) -> {
+                String path = newRandomTempFilePath();
+                doWrite(h, path, file);
+                return path;
+            });
+        } catch (CallbackFailedException ex) {
+            throw new FileStoreException("Unable to write on temporary path", ex);
+        }
+    }
+
+    @Override
+    public InputStream read(String path) {
+        FileStoreSupport.checkValidPath(path);
+
+        try {
+            if (databaseKind == DatabaseKind.PostgreSQL) {
+                return doReadPostgres(path);
+            } else if (databaseKind == DatabaseKind.DERBY) {
+                return doReadDerby(path);
+            } else {
+                return dbi.inTransaction((h, status) -> doReadStandard(h, path));
+            }
+        } catch (CallbackFailedException ex) {
+            throw new FileStoreException("Unable to read data from path " + path, ex);
+        }
+    }
+
+    @Override
+    public boolean delete(String path) {
+        FileStoreSupport.checkValidPath(path);
+
+        try {
+            return dbi.inTransaction((h, status) -> doDelete(h, path));
+        } catch (CallbackFailedException ex) {
+            throw new FileStoreException("Unable to delete path " + path, ex);
+        }
+    }
+
+    @Override
+    public boolean move(String fromPath, String toPath) {
+        FileStoreSupport.checkValidPath(fromPath);
+        FileStoreSupport.checkValidPath(toPath);
+
+        try {
+            return dbi.inTransaction((h, status) -> {
+                boolean existed = h.select("SELECT 1 from filestore WHERE path=?", fromPath).size() > 0;
+                if (existed) {
+                    doDelete(h, toPath);
+                    h.update("UPDATE filestore SET path=? WHERE path=?", toPath, fromPath);
+                }
+
+                return existed;
+            });
+        } catch (CallbackFailedException ex) {
+            throw new FileStoreException("Unable to move file from path " + fromPath + " to path " + toPath, ex);
+        }
+    }
+
+    // ============================================================
+
+    private void doWrite(Handle h, String path, InputStream file) {
+        if (databaseKind == DatabaseKind.PostgreSQL) {
+            doWritePostgres(h, path, file);
+        } else if (databaseKind == DatabaseKind.DERBY) {
+            doWriteDerby(h, path, file);
+        } else {
+            doWriteStandard(h, path, file);
+        }
+    }
+
+    private void doWriteStandard(Handle h, String path, InputStream file) {
+        doDelete(h, path);
+        h.insert("INSERT INTO filestore(path, data) values (?,?)", path, file);
+    }
+
+    private void doWritePostgres(Handle h, String path, InputStream file) {
+        doDelete(h, path);
+        try {
+            LargeObjectManager lobj = ((org.postgresql.PGConnection) h.getConnection()).getLargeObjectAPI();
+            long oid = lobj.createLO();
+            LargeObject obj = lobj.open(oid, LargeObjectManager.WRITE);
+            try (OutputStream lob = obj.getOutputStream()) {
+                IOUtils.copy(file, lob);
+            }
+
+            h.insert("INSERT INTO filestore(path, data) values (?,?)", path, oid);
+        } catch (IOException | SQLException ex) {
+            throw FileStoreException.launderThrowable(ex);
+        }
+    }
+
+    private void doWriteDerby(Handle h, String path, InputStream file) {
+        doDelete(h, path);
+        try {
+            Blob blob = h.getConnection().createBlob();
+            try (OutputStream out = blob.setBinaryStream(1)) {
+                IOUtils.copy(file, out);
+            }
+
+            h.insert("INSERT INTO filestore(path, data) values (?,?)", path, blob);
+        } catch (IOException | SQLException ex) {
+            throw FileStoreException.launderThrowable(ex);
+        }
+    }
+
+    private InputStream doReadStandard(Handle h, String path) {
+        List<Map<String, Object>> res = h.select("SELECT data FROM filestore WHERE path=?", path);
+
+        Optional<Blob> blob = res.stream()
+            .map(row -> row.get("data"))
+            .map(Blob.class::cast)
+            .findFirst();
+
+        if (blob.isPresent()) {
+            try {
+                return blob.get().getBinaryStream();
+            } catch (SQLException ex) {
+                throw new FileStoreException("Unable to read from BLOB", ex);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Derby does not allow to read from the blob after the connection has been closed.
+     * It also requires an outcome of commit/rollback.
+     */
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    private InputStream doReadDerby(String path) {
+        Handle h = dbi.open();
+        try {
+            h.getConnection().setAutoCommit(false);
+
+            List<Map<String, Object>> res = h.select("SELECT data FROM filestore WHERE path=?", path);
+
+            Optional<Blob> blob = res.stream()
+                .map(row -> row.get("data"))
+                .map(Blob.class::cast)
+                .findFirst();
+
+            if (blob.isPresent()) {
+                return new HandleCloserInputStream(h, blob.get().getBinaryStream());
+            } else {
+                h.commit();
+                h.close();
+                return null;
+            }
+
+        } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") Exception e) {
+            // Do cleanup
+            try {
+                h.rollback();
+            } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") Exception ex) {
+                // ignore
+            }
+            IOUtils.closeQuietly(h);
+
+            throw FileStoreException.launderThrowable(e);
+        }
+    }
+
+    /**
+     * Postgres does not allow to read from the large object after the connection has been closed.
+     */
+    private InputStream doReadPostgres(String path) {
+        Handle h = dbi.open();
+        try {
+            h.getConnection().setAutoCommit(false);
+
+            List<Map<String, Object>> res = h.select("SELECT data FROM filestore WHERE path=?", path);
+
+            Optional<Long> oid = res.stream()
+                .map(row -> row.get("data"))
+                .map(Long.class::cast)
+                .findFirst();
+
+            if (oid.isPresent()) {
+                LargeObjectManager lobj = ((org.postgresql.PGConnection) h.getConnection()).getLargeObjectAPI();
+                LargeObject obj = lobj.open(oid.get(), LargeObjectManager.READ);
+                return new HandleCloserInputStream(h, obj.getInputStream());
+            } else {
+                h.close();
+                return null;
+            }
+
+        } catch (SQLException e) {
+            IOUtils.closeQuietly(h);
+            throw FileStoreException.launderThrowable(e);
+        }
+    }
+
+    private boolean doDelete(Handle h, String path) {
+        return h.update("DELETE FROM filestore WHERE path=?", path) > 0;
+    }
+
+    private String newRandomTempFilePath() {
+        SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd-HH-mm", Locale.ROOT);
+        return "/tmp/" + fmt.format(new Date()) + "_" + UUID.randomUUID();
+    }
+
+    /**
+     * Allows closing a handle after the given {@link InputStream} has been fully read and closed.
+     */
+    static class HandleCloserInputStream extends FilterInputStream {
+
+        private Handle handle;
+
+        public HandleCloserInputStream(Handle handle, InputStream in) {
+            super(in);
+            this.handle = handle;
+        }
+
+        @Override
+        @SuppressWarnings("PMD.EmptyCatchBlock")
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                try {
+                    handle.commit();
+                } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") Exception ex) {
+                    // ignore
+                }
+                handle.close();
+            }
+        }
+    }
+
+}

--- a/filestore/src/test/java/io/syndesis/filestore/impl/SqlFileStoreTest.java
+++ b/filestore/src/test/java/io/syndesis/filestore/impl/SqlFileStoreTest.java
@@ -1,0 +1,282 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.filestore.impl;
+
+import io.syndesis.filestore.FileStoreException;
+import org.apache.commons.io.IOUtils;
+import org.apache.derby.jdbc.EmbeddedDataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.skife.jdbi.v2.DBI;
+
+import javax.sql.DataSource;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class SqlFileStoreTest {
+
+    private SqlFileStore fileStore;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> configs() {
+        EmbeddedDataSource derbyDs = new EmbeddedDataSource();
+        derbyDs.setDatabaseName("test");
+        derbyDs.setCreateDatabase("create");
+
+        JdbcDataSource h2Ds = new JdbcDataSource();
+        h2Ds.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
+
+        // Tests on postgres disabled
+
+//        PGPoolingDataSource postgresDs = new PGPoolingDataSource();
+//        postgresDs.setServerName("localhost");
+//        postgresDs.setDatabaseName("syndesis");
+//        postgresDs.setUser("postgres");
+//        postgresDs.setPassword("password");
+
+        return Arrays.asList(new Object[][]{
+            {derbyDs, SqlFileStore.DatabaseKind.DERBY},
+//            {postgresDs, SqlFileStore.DatabaseKind.PostgreSQL},
+            {h2Ds, SqlFileStore.DatabaseKind.H2},
+        });
+    }
+
+    public SqlFileStoreTest(DataSource ds, SqlFileStore.DatabaseKind kind) throws Exception {
+        DBI dbi = new DBI(ds);
+        this.fileStore = new SqlFileStore(dbi, kind);
+        this.fileStore.destroy();
+        this.fileStore.init();
+    }
+
+    @Test
+    public void testSmallFile() throws IOException {
+        String path = "/file";
+        String content = "Hello Wòrld!";
+
+        write(path, content.getBytes(StandardCharsets.UTF_8));
+        String retrieved = read(path, StandardCharsets.UTF_8);
+
+        assertEquals(content, retrieved);
+
+        fileStore.delete(path);
+        assertNull(read(path));
+    }
+
+    @Test
+    public void testBiggerFile() throws IOException {
+        String path = "/bigfile";
+        byte[] data = new byte[4_000_000];
+        data[2017] = 42;
+
+        write(path, data);
+        byte[] retrieved = read(path);
+        assertArrayEquals(data, retrieved);
+
+        fileStore.delete(path);
+        assertNull(read(path));
+    }
+
+    @Test
+    public void testOverwrite() throws IOException {
+        String path = "/file";
+        String anotherPath = "/dir/file";
+        String content1 = "Hello Wòrld!";
+        String content2 = "Hello Wòrld2!";
+
+        write(anotherPath, content1.getBytes(StandardCharsets.UTF_8));
+        assertEquals(content1, read(anotherPath, StandardCharsets.UTF_8));
+
+        write(path, content1.getBytes(StandardCharsets.UTF_8));
+        assertEquals(content1, read(path, StandardCharsets.UTF_8));
+
+        write(path, content2.getBytes(StandardCharsets.UTF_8));
+        assertEquals(content2, read(path, StandardCharsets.UTF_8));
+
+        assertEquals(content1, read(anotherPath, StandardCharsets.UTF_8));
+
+        fileStore.delete(path);
+        assertNull(read(path));
+
+        assertEquals(content1, read(anotherPath, StandardCharsets.UTF_8));
+        fileStore.delete(anotherPath);
+        assertNull(read(anotherPath));
+    }
+
+    @Test
+    public void testMove() throws IOException {
+        String content = "Hello Wòrld!";
+
+        write("/file1", content.getBytes(StandardCharsets.UTF_8));
+        assertTrue(fileStore.move("/file1", "/file2"));
+        assertEquals(content, read("/file2", StandardCharsets.UTF_8));
+        assertNull(read("/file1"));
+    }
+
+    @Test
+    public void testMoveOverwrite() throws IOException {
+        String content1 = "Hello Wòrld!";
+        String content2 = "Hello Wòrld2!";
+
+        write("/file1", content1.getBytes(StandardCharsets.UTF_8));
+        write("/file2", content2.getBytes(StandardCharsets.UTF_8));
+        assertTrue(fileStore.move("/file1", "/file2"));
+        assertEquals(content1, read("/file2", StandardCharsets.UTF_8));
+        assertNull(read("/file1"));
+    }
+
+    @Test
+    public void testWrongMove() throws IOException {
+        String content = "Hello Wòrld!";
+
+        write("/file", content.getBytes(StandardCharsets.UTF_8));
+        assertFalse(fileStore.move("/this-path-does-not-exist", "/file"));
+        assertEquals(content, read("/file", StandardCharsets.UTF_8));
+        assertNull(read("/this-path-does-not-exist"));
+    }
+
+    @Test
+    public void testMoveTempFile() throws IOException {
+        String content = "Hello Wòrld!";
+        String temp = writeTemp(content.getBytes(StandardCharsets.UTF_8));
+        FileStoreSupport.checkValidPath(temp);
+        fileStore.move(temp, "/home/file");
+        assertEquals(content, read("/home/file", StandardCharsets.UTF_8));
+        assertNull(read(temp));
+    }
+
+    @Test
+    public void testAllMethodsRefuseInvalidTokensInPath() throws IOException {
+        byte[] dummyContent = "Hello".getBytes(StandardCharsets.UTF_8);
+        String[] invalidTokens = {"/", "\\", "%", "$", "#", "\n", "\r", "\"", "'", "!"};
+        for (String token : invalidTokens) {
+            expectInvalidPath(() -> {
+                write("/dir" + token, dummyContent);
+                Assert.fail("Should throw exception");
+                return true;
+            });
+
+            expectInvalidPath(() -> read("/dir" + token));
+            expectInvalidPath(() -> fileStore.delete("/dir" + token));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    public void testAllowedPaths() throws IOException {
+        // Allowed
+        read("/connector_2.11-2.15-SNAPSHOT.jar");
+        read("/path/to/connector_2.11-2.15-SNAPSHOT.jar");
+        read("/path/to/file.");
+        read("/a/b/cccccc---------");
+        read("/.hidden/path/to/connector_2.11-2.15-SNAPSHOT.jar");
+        read("/.hidden/path/.to/connector_2.11-2.15-SNAPSHOT.jar");
+        read("/.hidden/path/.to/.connector_2.11-2.15-SNAPSHOT.jar");
+        read("/hello world/to/File (1).zip");
+
+        // Not allowed
+        expectInvalidPath(() -> fileStore.read("/"));
+        expectInvalidPath(() -> fileStore.read("//a"));
+        expectInvalidPath(() -> fileStore.read("/a/a/"));
+        expectInvalidPath(() -> fileStore.read("a"));
+        expectInvalidPath(() -> fileStore.read("/b/c/d--/"));
+        expectInvalidPath(() -> fileStore.read("\\a"));
+        expectInvalidPath(() -> fileStore.read("/è"));
+        expectInvalidPath(() -> fileStore.read("/#"));
+        expectInvalidPath(() -> fileStore.read("/a/b/c//aa.jar"));
+        expectInvalidPath(() -> fileStore.read("/."));
+        expectInvalidPath(() -> fileStore.read("/a/."));
+        expectInvalidPath(() -> fileStore.read("/a/b/."));
+        expectInvalidPath(() -> fileStore.read("/a/b/./c"));
+        expectInvalidPath(() -> fileStore.read("/ a"));
+        expectInvalidPath(() -> fileStore.read("/ a/b"));
+        expectInvalidPath(() -> fileStore.read("/a/ b"));
+        expectInvalidPath(() -> fileStore.read("/ /b"));
+        expectInvalidPath(() -> fileStore.read("/a/b "));
+        expectInvalidPath(() -> fileStore.read("/a /b "));
+    }
+
+    @Test
+    public void testNoLeak() throws IOException {
+        byte[] dummyContent = "Hello".getBytes(StandardCharsets.UTF_8);
+        for (int i=0; i<100; i++) {
+            write("/file" + i, dummyContent);
+            assertArrayEquals(dummyContent, read("/file" + i));
+            fileStore.delete("/file" + i);
+        }
+    }
+
+    private <T> void expectInvalidPath(Callable<T> callable) {
+        assertNotNull(callable);
+        try {
+            callable.call();
+            Assert.fail("Expected exception");
+        } catch (FileStoreException ex) {
+            assertTrue(ex.getMessage().startsWith("Invalid path"));
+        } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") Exception ex) {
+            Assert.fail("Got generic exception");
+        }
+    }
+
+    private String writeTemp(byte[] data) throws IOException {
+        try (ByteArrayInputStream stream = new ByteArrayInputStream(data)) {
+            return fileStore.writeTemporaryFile(stream);
+        }
+    }
+
+    private void write(String path, byte[] data) throws IOException {
+        try (ByteArrayInputStream stream = new ByteArrayInputStream(data)) {
+            fileStore.write(path, stream);
+        }
+    }
+
+    @SuppressWarnings("PMD.ReturnEmptyArrayRatherThanNull")
+    private byte[] read(String path) throws IOException {
+        try (InputStream in = fileStore.read(path)) {
+            if (in != null) {
+                return IOUtils.toByteArray(in);
+            }
+        }
+        return null;
+    }
+
+    private String read(String path, Charset charset) throws IOException {
+        try (InputStream in = fileStore.read(path)) {
+            if (in != null) {
+                return IOUtils.toString(in, charset);
+            }
+        }
+        return null;
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <assertj-core.version>3.6.2</assertj-core.version>
     <caffeine.version>2.4.0</caffeine.version>
     <camel.version>2.20.0</camel.version>
+    <derby.version>10.14.1.0</derby.version>
     <jdbi.version>2.78</jdbi.version>
     <hibernate.validator.version>5.3.5.Final</hibernate.validator.version>
     <immutables.version>2.5.1</immutables.version>
@@ -134,6 +135,7 @@
     <module>core</module>
     <module>credential</module>
     <module>dao</module>
+    <module>filestore</module>
     <module>jsondb</module>
     <module>model</module>
     <module>model2</module>
@@ -232,6 +234,12 @@
       <dependency>
         <groupId>io.syndesis</groupId>
         <artifactId>dao</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.syndesis</groupId>
+        <artifactId>filestore</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -648,6 +656,13 @@
         <version>${postgresql.version}</version>
         <scope>runtime</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derby</artifactId>
+        <version>${derby.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -523,6 +523,12 @@
       <artifactId>jsondb</artifactId>
     </dependency>
 
+    <!-- FileStore implementation -->
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>filestore</artifactId>
+    </dependency>
+
     <!-- ===================================================================================== -->
 
     <dependency>

--- a/runtime/src/main/java/io/syndesis/runtime/DataSourceConfiguration.java
+++ b/runtime/src/main/java/io/syndesis/runtime/DataSourceConfiguration.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.runtime;
+
+import org.skife.jdbi.v2.DBI;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+/**
+ * Creates and configures a DBI object
+ */
+@Configuration
+public class DataSourceConfiguration {
+
+    @Bean
+    public DBI dbiBean(@Autowired DataSource dataSource) {
+        return new DBI(dataSource);
+    }
+
+}

--- a/runtime/src/main/java/io/syndesis/runtime/DataStoreConfiguration.java
+++ b/runtime/src/main/java/io/syndesis/runtime/DataStoreConfiguration.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.runtime;
+
+import io.syndesis.jsondb.impl.SqlJsonDB;
+import org.skife.jdbi.v2.DBI;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Creates and configures the main datastore
+ */
+@Configuration
+public class DataStoreConfiguration {
+
+    @Bean
+    @Autowired
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    public SqlJsonDB realTimeDB(DBI dbi) {
+        SqlJsonDB jsondb = new SqlJsonDB(dbi, null);
+        try {
+            jsondb.createTables();
+        } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") Exception ignore) {
+        }
+        return jsondb;
+    }
+
+}

--- a/runtime/src/main/java/io/syndesis/runtime/FileStoreConfiguration.java
+++ b/runtime/src/main/java/io/syndesis/runtime/FileStoreConfiguration.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Red Hat, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,35 +15,27 @@
  */
 package io.syndesis.runtime;
 
-import io.syndesis.jsondb.impl.SqlJsonDB;
+import io.syndesis.filestore.FileStore;
+import io.syndesis.filestore.impl.SqlFileStore;
 import org.skife.jdbi.v2.DBI;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.sql.DataSource;
-
 /**
- * Creates and configures a DBI object
+ * Creates and configures the file store
  */
 @Configuration
-public class StoreConfiguration {
-
-    @Bean
-    public DBI dbiBean(@Autowired DataSource dataSource) {
-        return new DBI(dataSource);
-    }
+@ConditionalOnProperty(value = "filestore.enabled")
+public class FileStoreConfiguration {
 
     @Bean
     @Autowired
-    @SuppressWarnings("PMD.EmptyCatchBlock")
-    public SqlJsonDB realTimeDB(DBI dbi) {
-        SqlJsonDB jsondb = new SqlJsonDB(dbi, null);
-        try {
-            jsondb.createTables();
-        } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") Exception ignore) {
-        }
-        return jsondb;
+    public FileStore fileStore(DBI dbi) {
+        SqlFileStore fileStore = new SqlFileStore(dbi);
+        fileStore.init();
+        return fileStore;
     }
 
 }

--- a/runtime/src/main/resources/application.yml
+++ b/runtime/src/main/resources/application.yml
@@ -58,6 +58,9 @@ dao:
   schema:
     version: 20 # changing this will reset all the DB data.
 
+filestore:
+  enabled: false
+
 # OpenShift infra value
 openshift:
   # Base API Url up to the api version number (i.e. ending in sth like "oapi1/v1"

--- a/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
@@ -59,7 +59,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ContextConfiguration(classes = {
 		Application.class,
         InfinispanCacheConfiguration.class,
-        StoreConfiguration.class,
+        DataStoreConfiguration.class,
         SyndesisCorsConfiguration.class
 })
 public abstract class BaseITCase {


### PR DESCRIPTION
First PR on syndesis :smile: 
This fixes #735.

It adds a Filestore that can be used to store binary artifacts such as JARs.
The interface allows to do operation on filesystem-like paths and can be adapted to store artifacts in whatever storage we want in the future.

Current implementation uses a DB table called `filestore` inside the postgres database with 2 columns (`path` and `data`).

All the required file operation should be already implemented (write, load, move, delete and temp file support). Others can be added as needed.

