### PR TITLE
refactor: provide default AuthenticationManager

### DIFF
--- a/runtime/src/main/java/io/syndesis/runtime/SecurityConfiguration.java
+++ b/runtime/src/main/java/io/syndesis/runtime/SecurityConfiguration.java
@@ -15,9 +15,13 @@
  */
 package io.syndesis.runtime;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -31,8 +35,6 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesUserDetailsService;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails;
 import org.springframework.security.web.authentication.preauth.RequestHeaderAuthenticationFilter;
-
-import javax.servlet.http.HttpServletRequest;
 
 @Configuration
 @EnableWebSecurity
@@ -86,4 +88,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         return authProvider;
     }
 
+    @Bean()
+    @Override
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
 }


### PR DESCRIPTION
By providing default AuthenticationManager bean to Spring application
context Spring Security auto configuration
(o.s.b.a.s.AuthenticationManagerConfiguration) is not triggered, and no
in-memory user details service will be created. This prevents the
message:

    Using default security password: ...

from being displayed at startup.