### PR TITLE
fix: Explicitly set the deployment history limit to 0

### DIFF
--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
@@ -188,6 +188,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
                        .addToRequests("memory", new Quantity(config.getDeploymentMemoryRequestMi() +  "Mi"))
                 .endResources()
             .endStrategy()
+            .withRevisionHistoryLimit(0)
             .withNewTemplate()
             .withNewMetadata().addToLabels("integration", name).endMetadata()
             .withNewSpec()


### PR DESCRIPTION
This ensures that old RCs are cleaned up and that we do not hit limits related to this.

Fixes #739