### PR TITLE
refactor: Use separate version number for the Maven runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <assertj-core.version>3.6.2</assertj-core.version>
     <caffeine.version>2.4.0</caffeine.version>
     <camel.version>2.20.0</camel.version>
+    <camel.runtime.version>2.20.0</camel.runtime.version>
     <jdbi.version>2.78</jdbi.version>
     <hibernate.validator.version>5.3.5.Final</hibernate.validator.version>
     <immutables.version>2.5.1</immutables.version>

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/pom.xml.mustache
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/pom.xml.mustache
@@ -13,7 +13,7 @@
 
   <properties>
     <spring-boot.version>@spring-boot.version@</spring-boot.version>
-    <camel.version>@camel.version@</camel.version>
+    <camel.version>@camel.runtime.version@</camel.version>
     <syndesis-integration-runtime.version>@syndesis-integration-runtime.version@</syndesis-integration-runtime.version>
     <camel-atlasmap.version>@camel-atlasmap.version@</camel-atlasmap.version>
   </properties>


### PR DESCRIPTION
This must not be replaced by the pipeline builds as the Fuse Repo is not added in the runtime pom.xml