### PR TITLE
refactor: sort Maven repositories

### DIFF
--- a/core/src/main/java/io/syndesis/core/MavenProperties.java
+++ b/core/src/main/java/io/syndesis/core/MavenProperties.java
@@ -16,14 +16,14 @@
 package io.syndesis.core;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("maven")
 public class MavenProperties {
 
-    private final Map<String, String> repositories = new ConcurrentHashMap<>(3);
+    private final Map<String, String> repositories = new ConcurrentSkipListMap<>();
 
     public MavenProperties() {
     }

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-pom.xml
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-pull-push-pom.xml
@@ -20,12 +20,12 @@
 
   <repositories>
     <repository>
-      <id>maven.central</id>
-      <url>https://repo1.maven.org/maven2</url>
-    </repository>
-    <repository>
       <id>jboss.ea</id>
       <url>https://repository.jboss.org/nexus/content/groups/ea</url>
+    </repository>
+    <repository>
+      <id>maven.central</id>
+      <url>https://repo1.maven.org/maven2</url>
     </repository>
     <repository>
       <id>redhat.ga</id>

--- a/runtime/src/main/resources/application.yml
+++ b/runtime/src/main/resources/application.yml
@@ -87,4 +87,4 @@ controllers:
 
 maven:
   repositories:
-    maven.central: https://repo1.maven.org/maven2
+    01_maven_central: https://repo1.maven.org/maven2


### PR DESCRIPTION
This sorts configured Maven repositories by their keys as a simple
priority mechanism. Now if we specify environment variable like:

    MAVEN_REPOSITORIES_00_some_where=http://over.the.rainbow

The order of generated `pom.xml` of the integration pod and order by
which Grape resolves artifacts of Camel Connectors should be affected.