### PR TITLE
Add API to manage tech extensions

### DIFF
--- a/dao/src/main/java/io/syndesis/dao/ExtensionDao.java
+++ b/dao/src/main/java/io/syndesis/dao/ExtensionDao.java
@@ -13,19 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.rest.v1;
+package io.syndesis.dao;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 
-/**
- * Configured in spring.factories so that this configuration is automatically picked
- * up when included in the classpath.
- */
-@Configuration
-@ComponentScan
-@ConditionalOnProperty(name = "features.api.v1.enabled")
-public class V1Configuration {
+import io.syndesis.dao.manager.DataAccessObject;
+import io.syndesis.model.extension.Extension;
+
+public interface ExtensionDao extends DataAccessObject<Extension> {
+
+    @Override
+    default Class<Extension> getType() {
+        return Extension.class;
+    }
 
 }

--- a/filestore/src/main/java/io/syndesis/filestore/impl/SqlFileStore.java
+++ b/filestore/src/main/java/io/syndesis/filestore/impl/SqlFileStore.java
@@ -18,6 +18,7 @@ package io.syndesis.filestore.impl;
 import io.syndesis.filestore.FileStore;
 import io.syndesis.filestore.FileStoreException;
 import org.apache.commons.io.IOUtils;
+import org.postgresql.PGConnection;
 import org.postgresql.largeobject.LargeObject;
 import org.postgresql.largeobject.LargeObjectManager;
 import org.skife.jdbi.v2.DBI;
@@ -193,7 +194,7 @@ public class SqlFileStore implements FileStore {
     private void doWritePostgres(Handle h, String path, InputStream file) {
         doDelete(h, path);
         try {
-            LargeObjectManager lobj = ((org.postgresql.PGConnection) h.getConnection()).getLargeObjectAPI();
+            LargeObjectManager lobj = h.getConnection().unwrap(PGConnection.class).getLargeObjectAPI();
             long oid = lobj.createLO();
             LargeObject obj = lobj.open(oid, LargeObjectManager.WRITE);
             try (OutputStream lob = obj.getOutputStream()) {
@@ -293,7 +294,7 @@ public class SqlFileStore implements FileStore {
                 .findFirst();
 
             if (oid.isPresent()) {
-                LargeObjectManager lobj = ((org.postgresql.PGConnection) h.getConnection()).getLargeObjectAPI();
+                LargeObjectManager lobj = h.getConnection().unwrap(PGConnection.class).getLargeObjectAPI();
                 LargeObject obj = lobj.open(oid.get(), LargeObjectManager.READ);
                 return new HandleCloserInputStream(h, obj.getInputStream());
             } else {

--- a/filestore/src/test/java/io/syndesis/filestore/impl/SqlFileStoreTest.java
+++ b/filestore/src/test/java/io/syndesis/filestore/impl/SqlFileStoreTest.java
@@ -65,15 +65,15 @@ public class SqlFileStoreTest {
 //        postgresDs.setPassword("password");
 
         return Arrays.asList(new Object[][]{
-            {derbyDs, SqlFileStore.DatabaseKind.DERBY},
-//            {postgresDs, SqlFileStore.DatabaseKind.PostgreSQL},
-            {h2Ds, SqlFileStore.DatabaseKind.H2},
+            {derbyDs},
+//            {postgresDs},
+            {h2Ds}
         });
     }
 
-    public SqlFileStoreTest(DataSource ds, SqlFileStore.DatabaseKind kind) throws Exception {
+    public SqlFileStoreTest(DataSource ds) throws Exception {
         DBI dbi = new DBI(ds);
-        this.fileStore = new SqlFileStore(dbi, kind);
+        this.fileStore = new SqlFileStore(dbi);
         this.fileStore.destroy();
         this.fileStore.init();
     }

--- a/filestore/src/test/java/io/syndesis/filestore/impl/SqlFileStoreTest.java
+++ b/filestore/src/test/java/io/syndesis/filestore/impl/SqlFileStoreTest.java
@@ -235,6 +235,25 @@ public class SqlFileStoreTest {
         }
     }
 
+    @Test
+    public void testMultipleInitAreIdempotent() throws IOException {
+        fileStore.init();
+        fileStore.init();
+        fileStore.init();
+        fileStore.init();
+        assertNull(fileStore.read("/not-exists"));
+    }
+
+    @Test
+    public void testMultipleDestroyAreIdempotent() throws IOException {
+        fileStore.destroy();
+        fileStore.destroy();
+        fileStore.destroy();
+        fileStore.destroy();
+        fileStore.init();
+        assertNull(fileStore.read("/not-exists"));
+    }
+
     private <T> void expectInvalidPath(Callable<T> callable) {
         assertNotNull(callable);
         try {

--- a/jsondb/src/main/java/io/syndesis/jsondb/dao/ExtensionJsonDbDao.java
+++ b/jsondb/src/main/java/io/syndesis/jsondb/dao/ExtensionJsonDbDao.java
@@ -1,41 +1,36 @@
 /**
  * Copyright (C) 2016 Red Hat, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.runtime;
+package io.syndesis.jsondb.dao;
 
-import io.syndesis.filestore.FileStore;
-import io.syndesis.filestore.impl.SqlFileStore;
-import org.skife.jdbi.v2.DBI;
+import io.syndesis.dao.ExtensionDao;
+import io.syndesis.jsondb.JsonDB;
+import io.syndesis.model.extension.Extension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
 
-/**
- * Creates and configures the file store
- */
+@Service
 @Configuration
-@ConditionalOnProperty(value = "features.filestore.enabled")
-public class FileStoreConfiguration {
+@ConditionalOnProperty(value = "dao.kind", havingValue = "jsondb")
+public class ExtensionJsonDbDao extends JsonDbDao<Extension> implements ExtensionDao {
 
-    @Bean
     @Autowired
-    public FileStore fileStore(DBI dbi) {
-        SqlFileStore fileStore = new SqlFileStore(dbi);
-        fileStore.init();
-        return fileStore;
+    public ExtensionJsonDbDao(JsonDB jsondb) {
+        super(jsondb);
     }
 
 }

--- a/model/src/main/java/io/syndesis/model/Kind.java
+++ b/model/src/main/java/io/syndesis/model/Kind.java
@@ -31,6 +31,7 @@ public enum Kind {
 
     Environment(io.syndesis.model.environment.Environment.class),
     EnvironmentType(io.syndesis.model.environment.EnvironmentType.class),
+    Extension(io.syndesis.model.extension.Extension.class),
     Organization(io.syndesis.model.environment.Organization.class),
 
     Integration(io.syndesis.model.integration.Integration.class),

--- a/model/src/main/java/io/syndesis/model/extension/Extension.java
+++ b/model/src/main/java/io/syndesis/model/extension/Extension.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.extension;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.syndesis.model.Kind;
+import io.syndesis.model.WithConfigurationProperties;
+import io.syndesis.model.WithId;
+import io.syndesis.model.WithName;
+import io.syndesis.model.WithTags;
+import org.immutables.value.Value;
+
+import java.io.Serializable;
+
+@Value.Immutable
+@JsonDeserialize(builder = Extension.Builder.class)
+public interface Extension extends WithId<Extension>, WithName, WithTags, WithConfigurationProperties, Serializable {
+
+    @Override
+    default Kind getKind() {
+        return Kind.Extension;
+    }
+
+    String getDescription();
+
+    @Override
+    default Extension withId(String id) {
+        return new Builder().createFrom(this).id(id).build();
+    }
+
+    class Builder extends ImmutableExtension.Builder {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-multipart-provider</artifactId>
+        <version>${resteasy.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-jaxrs</artifactId>
         <version>${swagger.version}</version>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -49,6 +49,11 @@
 
     <dependency>
       <groupId>io.syndesis</groupId>
+      <artifactId>filestore</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis</groupId>
       <artifactId>project-generator</artifactId>
     </dependency>
 
@@ -141,6 +146,11 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-multipart-provider</artifactId>
     </dependency>
 
     <dependency>

--- a/rest/src/main/java/io/syndesis/rest/v1beta1/V1Beta1Application.java
+++ b/rest/src/main/java/io/syndesis/rest/v1beta1/V1Beta1Application.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1beta1;
+
+import io.swagger.jaxrs.config.BeanConfig;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@Component
+@ApplicationPath("/api/v1beta1")
+public class V1Beta1Application extends Application {
+
+    public V1Beta1Application() {
+        BeanConfig beanConfig = new BeanConfig();
+        beanConfig.setVersion("v1beta1");
+        beanConfig.setTitle("Syndesis Rest API");
+        beanConfig.setSchemes(new String[]{"http", "https"});
+        beanConfig.setBasePath("/api/v1beta1");
+        beanConfig.setResourcePackage(getClass().getPackage().getName());
+        beanConfig.setScan(true);
+    }
+
+}

--- a/rest/src/main/java/io/syndesis/rest/v1beta1/V1Beta1Configuration.java
+++ b/rest/src/main/java/io/syndesis/rest/v1beta1/V1Beta1Configuration.java
@@ -1,41 +1,31 @@
 /**
  * Copyright (C) 2016 Red Hat, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.runtime;
+package io.syndesis.rest.v1beta1;
 
-import io.syndesis.filestore.FileStore;
-import io.syndesis.filestore.impl.SqlFileStore;
-import org.skife.jdbi.v2.DBI;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Creates and configures the file store
+ * Configured in spring.factories so that this configuration is automatically picked
+ * up when included in the classpath.
  */
 @Configuration
-@ConditionalOnProperty(value = "features.filestore.enabled")
-public class FileStoreConfiguration {
-
-    @Bean
-    @Autowired
-    public FileStore fileStore(DBI dbi) {
-        SqlFileStore fileStore = new SqlFileStore(dbi);
-        fileStore.init();
-        return fileStore;
-    }
+@ComponentScan
+@ConditionalOnProperty(name = "features.api.v1beta1.enabled")
+public class V1Beta1Configuration {
 
 }

--- a/rest/src/main/java/io/syndesis/rest/v1beta1/handler/extension/ExtensionHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1beta1/handler/extension/ExtensionHandler.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1beta1.handler.extension;
+
+import io.swagger.annotations.Api;
+import io.syndesis.core.SyndesisServerException;
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.filestore.FileStore;
+import io.syndesis.model.Kind;
+import io.syndesis.model.extension.Extension;
+import io.syndesis.rest.v1.handler.BaseHandler;
+import io.syndesis.rest.v1.operations.Deleter;
+import io.syndesis.rest.v1.operations.Getter;
+import io.syndesis.rest.v1.operations.Lister;
+import io.syndesis.rest.v1beta1.util.ExtensionAnalyzer;
+import org.jboss.resteasy.plugins.providers.multipart.InputPart;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Path("/extensions")
+@Api(value = "extensions")
+@Component
+public class ExtensionHandler extends BaseHandler implements Lister<Extension>, Getter<Extension>, Deleter<Extension> {
+
+    private final FileStore fileStore;
+
+    private final ExtensionAnalyzer extensionAnalyzer;
+
+    public ExtensionHandler(final DataManager dataMgr, final FileStore fileStore,
+                            final ExtensionAnalyzer extensionAnalyzer) {
+        super(dataMgr);
+        this.fileStore = fileStore;
+        this.extensionAnalyzer = extensionAnalyzer;
+    }
+
+    @Override
+    public Kind resourceKind() {
+        return Kind.Extension;
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Extension upload(@Context SecurityContext sec, MultipartFormDataInput dataInput) {
+
+        String tempLocation = storeFile(dataInput);
+        Extension embeddedExtension = getExtension(tempLocation);
+
+        Extension extension = getDataManager().create(embeddedExtension);
+
+        String id = extension.getId().orElseThrow(() -> new IllegalStateException("Id not set"));
+        fileStore.move(tempLocation, "/extensions/" + id);
+        return extension;
+    }
+
+    @Override
+    public void delete(String id) {
+        Deleter.super.delete(id);
+        fileStore.delete("/extensions/" + id);
+    }
+
+    // ===============================================================
+
+    @Nonnull
+    private Extension getExtension(String location) {
+        try (InputStream file = fileStore.read(location)) {
+            return extensionAnalyzer.analyze(file);
+        } catch (IOException ex) {
+            throw SyndesisServerException.
+                launderThrowable("Unable to load extension from filestore location " + location, ex);
+        }
+    }
+
+    private String storeFile(MultipartFormDataInput dataInput) {
+        // Store the artifact into the filestore
+        String tempLocation;
+        try (InputStream file = getBinaryArtifact(dataInput)) {
+            tempLocation = fileStore.writeTemporaryFile(file);
+        } catch (IOException ex) {
+            throw SyndesisServerException.launderThrowable("Unable to store the file into the filestore", ex);
+        }
+        return tempLocation;
+    }
+
+    @Nonnull
+    private InputStream getBinaryArtifact(MultipartFormDataInput input) {
+        if (input == null || input.getParts() == null || input.getParts().isEmpty()) {
+            throw new IllegalArgumentException("Multipart request is empty");
+        }
+
+        try {
+            InputStream result;
+            if (input.getParts().size() == 1) {
+                InputPart filePart = input.getParts().iterator().next();
+                result = filePart.getBody(InputStream.class, null);
+            } else {
+                result = input.getFormDataPart("file", InputStream.class, null);
+            }
+
+            if (result == null) {
+                throw new IllegalArgumentException("Can't find a valid 'file' part in the multipart request");
+            }
+
+            return result;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Error while reading multipart request", e);
+        }
+    }
+
+}

--- a/rest/src/main/java/io/syndesis/rest/v1beta1/util/ExtensionAnalyzer.java
+++ b/rest/src/main/java/io/syndesis/rest/v1beta1/util/ExtensionAnalyzer.java
@@ -1,8 +1,22 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.syndesis.rest.v1beta1.util;
 
 import io.syndesis.core.SyndesisServerException;
 import io.syndesis.model.extension.Extension;
-import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
@@ -20,7 +34,7 @@ public class ExtensionAnalyzer {
     /**
      * Analyze a binary extension to obtain the embedded {@link Extension} object.
      *
-     * TODO: implement it, this is a dummy handle
+     * TODO: implement it, this is a dummy stub
      *
      * @param binaryExtension the binary stream of the extension
      * @return the embedded {@code Extension} object
@@ -28,7 +42,10 @@ public class ExtensionAnalyzer {
     @Nonnull
     public Extension analyze(InputStream binaryExtension) {
         try {
-            IOUtils.toByteArray(binaryExtension); // to simulate reading it
+            if (binaryExtension.read() < 0) {
+                // TODO: remove it from the actual code. This simulates a read from the stream
+                throw new IllegalArgumentException("Empty stream");
+            }
         } catch (IOException ex) {
             throw SyndesisServerException.launderThrowable("Cannot read from binary extension file", ex);
         }

--- a/rest/src/main/java/io/syndesis/rest/v1beta1/util/ExtensionAnalyzer.java
+++ b/rest/src/main/java/io/syndesis/rest/v1beta1/util/ExtensionAnalyzer.java
@@ -1,0 +1,42 @@
+package io.syndesis.rest.v1beta1.util;
+
+import io.syndesis.core.SyndesisServerException;
+import io.syndesis.model.extension.Extension;
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Tools to analyze binary extensions.
+ *
+ * TODO: determine the right place to put this component
+ */
+@Component
+public class ExtensionAnalyzer {
+
+    /**
+     * Analyze a binary extension to obtain the embedded {@link Extension} object.
+     *
+     * TODO: implement it, this is a dummy handle
+     *
+     * @param binaryExtension the binary stream of the extension
+     * @return the embedded {@code Extension} object
+     */
+    @Nonnull
+    public Extension analyze(InputStream binaryExtension) {
+        try {
+            IOUtils.toByteArray(binaryExtension); // to simulate reading it
+        } catch (IOException ex) {
+            throw SyndesisServerException.launderThrowable("Cannot read from binary extension file", ex);
+        }
+
+        return new Extension.Builder()
+            .name("Dummy")
+            .description("Dummy description")
+            .build();
+    }
+
+}

--- a/rest/src/main/resources/META-INF/spring.factories
+++ b/rest/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    io.syndesis.rest.v1.V1Configuration
+    io.syndesis.rest.v1.V1Configuration,\
+    io.syndesis.rest.v1beta1.V1Beta1Configuration

--- a/runtime/src/main/resources/application.yml
+++ b/runtime/src/main/resources/application.yml
@@ -14,6 +14,15 @@
 # limitations under the License.
 #
 
+features:
+  api:
+    v1:
+      enabled: true
+    v1beta1:
+      enabled: false
+  filestore:
+    enabled: false
+
 server:
   useForwardHeaders: true
 

--- a/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
@@ -84,7 +84,7 @@ public abstract class BaseITCase {
 
     @PostConstruct()
     public void resetDB() {
-        get("/api/v1/test-support/reset-db", null, tokenRule.validToken(), HttpStatus.NO_CONTENT);
+        get("/api/v1/test-support/reset-db", Void.class, tokenRule.validToken(), HttpStatus.NO_CONTENT);
     }
 
     protected void clearDB() {
@@ -161,6 +161,10 @@ public abstract class BaseITCase {
         return http(HttpMethod.GET, url, null, responseClass, token, expectedStatus);
     }
 
+    protected <T> ResponseEntity<T> get(String url, ParameterizedTypeReference<T> responseClass, String token, HttpStatus expectedStatus) {
+        return http(HttpMethod.GET, url, null, responseClass, token, new HttpHeaders(), expectedStatus);
+    }
+
     protected <T> ResponseEntity<T> post(String url, Object body,  Class<T> responseClass) {
         return post(url, body, responseClass, tokenRule.validToken(), HttpStatus.OK);
     }
@@ -175,6 +179,10 @@ public abstract class BaseITCase {
 
     protected <T> ResponseEntity<T> post(String url, Object body, ParameterizedTypeReference<T> responseClass, String token, HttpStatus expectedStatus) {
         return http(HttpMethod.POST, url, body, responseClass, token, new HttpHeaders(), expectedStatus);
+    }
+
+    protected <T> ResponseEntity<T> post(String url, Object body, Class<T> responseClass, String token, HttpStatus expectedStatus, HttpHeaders headers) {
+        return http(HttpMethod.POST, url, body, responseClass, token, headers, expectedStatus);
     }
 
     protected <T> ResponseEntity<T> put(String url, Object body, Class<T> responseClass, String token, HttpStatus expectedStatus) {
@@ -209,7 +217,7 @@ public abstract class BaseITCase {
     }
 
     private void prepareHeaders(Object body, HttpHeaders headers, String token) {
-        if( body!=null ) {
+        if( body!=null && !headers.containsKey(HttpHeaders.CONTENT_TYPE) ) {
             headers.set(HttpHeaders.CONTENT_TYPE, "application/json");
         }
         if (token != null) {

--- a/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.runtime;
+
+import io.syndesis.model.ListResult;
+import io.syndesis.model.extension.Extension;
+import org.junit.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.io.ByteArrayInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExtensionsITCase extends BaseITCase {
+
+    @Test
+    public void basicConnectivityTest() {
+        ResponseEntity<ListResult<Extension>> exts = get("/api/v1beta1/extensions",
+            new ParameterizedTypeReference<ListResult<Extension>>() {}, tokenRule.validToken(), HttpStatus.OK);
+        assertThat(exts.getBody().getTotalCount()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    public void createNewExtensionListDeleteTest() {
+        // Dummy data: replace with actual data when the binary format is defined
+        byte[] data = {1, 2, 3, 4};
+
+        // POST
+        ResponseEntity<Extension> created = post("/api/v1beta1/extensions", multipartBody(data), Extension.class,
+            tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
+
+        assertThat(created.getBody().getId()).isNotEmpty();
+        assertThat(created.getBody().getName()).isNotBlank();
+
+        String id = created.getBody().getId().get();
+
+        // GET
+        ResponseEntity<Extension> got = get("/api/v1beta1/extensions/" + id, Extension.class,
+            tokenRule.validToken(), HttpStatus.OK);
+
+        assertThat(got.getBody().getName()).isEqualTo(created.getBody().getName());
+
+        // LIST
+        ResponseEntity<ListResult<Extension>> list = get("/api/v1beta1/extensions",
+            new ParameterizedTypeReference<ListResult<Extension>>() {}, tokenRule.validToken(), HttpStatus.OK);
+
+        assertThat(list.getBody().getTotalCount()).as("extensions size").isGreaterThan(0);
+
+        // DELETE
+        delete("/api/v1beta1/extensions/" + id, Void.class, tokenRule.validToken(), HttpStatus.NO_CONTENT);
+
+        // RE-GET
+        get("/api/v1beta1/extensions/" + id, Void.class,
+            tokenRule.validToken(), HttpStatus.NOT_FOUND);
+    }
+
+    // ===========================================================
+
+    private HttpHeaders multipartHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        return headers;
+    }
+
+    private MultiValueMap<String, Object> multipartBody(byte[] data) {
+        LinkedMultiValueMap<String, Object> multipartData = new LinkedMultiValueMap<>();
+        multipartData.add("file", new InputStreamResource(new ByteArrayInputStream(data)));
+        return multipartData;
+    }
+
+}

--- a/runtime/src/test/java/io/syndesis/runtime/T3stSupportITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/T3stSupportITCase.java
@@ -35,7 +35,7 @@ public class T3stSupportITCase extends BaseITCase {
     public void createAndGetIntegration() {
 
         // Reset to fresh startup state..
-        get("/api/v1/test-support/reset-db", null, tokenRule.validToken(), HttpStatus.NO_CONTENT);
+        get("/api/v1/test-support/reset-db", Void.class, tokenRule.validToken(), HttpStatus.NO_CONTENT);
 
         // We should have some initial data in the snapshot since we start up with deployment.json
         @SuppressWarnings({"unchecked", "rawtypes"})
@@ -61,7 +61,7 @@ public class T3stSupportITCase extends BaseITCase {
         assertThat(r2.getBody().length).isEqualTo(1);
 
         // Reset to fresh startup state..
-        get("/api/v1/test-support/reset-db", null, tokenRule.validToken(), HttpStatus.NO_CONTENT);
+        get("/api/v1/test-support/reset-db", Void.class, tokenRule.validToken(), HttpStatus.NO_CONTENT);
 
         // Verify that the new state has the same number of entities as the original
         ResponseEntity<ModelData<?>[]> r3 = get("/api/v1/test-support/snapshot-db", type);

--- a/runtime/src/test/resources/application-test.yml
+++ b/runtime/src/test/resources/application-test.yml
@@ -14,6 +14,14 @@
 # limitations under the License.
 #
 
+features:
+  api:
+    v1beta1:
+      enabled: true
+  filestore:
+    enabled: true
+
+
 endpoints:
   test_support:
     enabled: true


### PR DESCRIPTION
This adds a API to manage tech extensions.

Supported operations are:
- POST (this accepts a binary artifact and returns the JSON metadata of the extension)
- LIST
- GET
- DELETE

API are published under "/api/v1beta1". Beta api are disabled by default. They can be enabled with toggles (env var on Deployment):
```
FEATURES_API_V1BETA1_ENABLED=true
FEATURES_FILESTORE_ENABLED=true
```

I've put a toggle also for the "v1" api, but it's enabled by default.

When a binary artifact is uploaded, it's stored in "/extensions/[id]" into the filestore (same id of the entity in the jsondb). The artifact can be retrieved later (not implemented yet) by ID or GAV. A retrieval by GAV will require first a lookup into the jsondb.

Fixed some issues found with the filestore now that it's integrated in the loop (initialization on a dirty db was not working, added auto-detection of DB type, fixed PG connection management).

Added also IT tests (and done manual testing on Openshift).