### PR TITLE
refactor: cleanup integration model

### DIFF
--- a/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -123,6 +123,7 @@ public interface Integration extends WithId<Integration>, WithTags, WithName, Se
     }
 
     class Builder extends ImmutableIntegration.Builder {
+        // allow access to ImmutableIntegration.Builder
     }
 
 }

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
@@ -173,6 +173,7 @@ public abstract class IntegrationRevision {
     }
 
     public static class Builder extends ImmutableIntegrationRevision.Builder {
+        // allow access to ImmutableIntegrationRevision.Builder
     }
 
 }

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionSpec.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionSpec.java
@@ -41,6 +41,7 @@ public interface IntegrationRevisionSpec {
     }
 
     class Builder extends ImmutableIntegrationRevisionSpec.Builder {
+        // allow access to ImmutableIntegrationRevisionSpec.Builder
     }
 
 }

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRuntime.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRuntime.java
@@ -44,6 +44,7 @@ public interface IntegrationRuntime extends WithId<IntegrationRuntime>, Serializ
     }
 
     class Builder extends ImmutableIntegrationRuntime.Builder {
+        // allow access to ImmutableIntegrationRuntime.Builder
     }
 
 }

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationStatus.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationStatus.java
@@ -52,5 +52,6 @@ public interface IntegrationStatus {
 
 
     class Builder extends ImmutableIntegrationStatus.Builder {
+        // allow access to ImmutableIntegrationStatus.Builder
     }
 }

--- a/model/src/main/java/io/syndesis/model/integration/SimpleStep.java
+++ b/model/src/main/java/io/syndesis/model/integration/SimpleStep.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import io.syndesis.core.immutable.SkipNulls;
 import io.syndesis.model.Kind;
 import io.syndesis.model.connection.Action;
 import io.syndesis.model.connection.Connection;
@@ -34,17 +36,23 @@ public interface SimpleStep extends Step {
         return Kind.Step;
     }
 
+    @Override
     Optional<Action> getAction();
 
+    @Override
     Optional<Connection> getConnection();
 
+    @Override
     String getStepKind();
 
+    @Override
     @Value.Default
+    @SkipNulls
     default Map<String, String> getConfiguredProperties() {
         return Collections.emptyMap();
     }
 
+    @Override
     String getName();
 
     @Override
@@ -53,6 +61,7 @@ public interface SimpleStep extends Step {
     }
 
     class Builder extends ImmutableSimpleStep.Builder {
+        // allow access to ImmutableSimpleStep.Builder
     }
 
 }

--- a/model/src/main/java/io/syndesis/model/integration/StepDeserializer.java
+++ b/model/src/main/java/io/syndesis/model/integration/StepDeserializer.java
@@ -53,15 +53,15 @@ public class StepDeserializer extends JsonDeserializer<Step> {
             Class<? extends Step> resourceType = getTypeForName(value);
             if (resourceType == null) {
                 throw ctxt.mappingException("No step type found for kind:" + value);
-            } else {
-                return jp.getCodec().treeToValue(node, resourceType);
             }
+
+            return jp.getCodec().treeToValue(node, resourceType);
         }
         return null;
     }
 
     private static Class<? extends Step> getTypeForName(String name) {
-        Class result = KIND_TO_STEP_MAPPING.get(name);
+        Class<? extends Step> result = KIND_TO_STEP_MAPPING.get(name);
         if (result == null) {
             return DEFAULT_STEP_TYPE;
         }


### PR DESCRIPTION
The only functional difference is addition of `@SkipNulls` annotation
that filters out SimpleStep.configuredProperties that contain `null`
values. Issue that manifests itself when trying to add a mapping step to
an integration and having no mapping defined at that point, in JSON it
looks like:

    {
        "configuredProperties": {
            "atlasmapping": ""
        }
    }

That is converted by `StringTrimmingJsonDeserializer` to
`(atlasmapping, null)`, and in trun results in a NullPointerException
when trying to deserialize the JSON.

Also adds a few `@Override` annotations, comments to empty blocks.