### PR TITLE
feat: disable security in `development` profile

### DIFF
--- a/runtime/src/main/java/io/syndesis/runtime/SecurityConfiguration.java
+++ b/runtime/src/main/java/io/syndesis/runtime/SecurityConfiguration.java
@@ -19,6 +19,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -36,6 +37,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedG
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails;
 import org.springframework.security.web.authentication.preauth.RequestHeaderAuthenticationFilter;
 
+@Profile("!development")
 @Configuration
 @EnableWebSecurity
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {


### PR DESCRIPTION
This allows specifying Spring profile to be `development`, for instance
via Java property `spring.profiles.active` (i.e.
`-Dspring.profiles.active=development`) to disable pre-authenticated
security and the ACLs defined within `SpringConfiguration`. This allows
local development and invoking REST API via HTTP client (e.g. `curl`)
without specifying any Cookies or other authentication headers.