### PR TITLE
fix: set the username as the label when creatin...

### DIFF
--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
@@ -115,7 +115,7 @@ public class ActivateHandler extends BaseHandler implements StatusChangeHandlerP
 
         return DeploymentData.builder()
             .addLabel(OpenShiftService.REVISION_ID_ANNOTATION, revision.getVersion().orElse(0).toString())
-            .addAnnotation(OpenShiftService.USERNAME_LABEL, username)
+            .addLabel(OpenShiftService.USERNAME_LABEL, Names.sanitize(username))
             .addSecretEntry("application.properties", propsToString(applicationProperties))
             .build();
     }

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
@@ -26,7 +26,7 @@ import io.fabric8.openshift.api.model.User;
 public interface OpenShiftService {
 
     String REVISION_ID_ANNOTATION = "syndesis.io/revision-id";
-    String USERNAME_LABEL = "USERNAME";
+    String USERNAME_LABEL = "syndesis.io/username";
 
     /**
      * Start a previously created build with the data from the given directory


### PR DESCRIPTION
...g integration deployment

Username that we use to count the number of deployments was set as
annotation and when counting expected as label. This sets the username
as label when creating integration deployment.

Fixes #769