### PR TITLE
Fixes #141: Add validation to tech extension API

### DIFF
--- a/dao/src/main/java/io/syndesis/dao/validation/extension/NoDuplicateExtensionValidator.java
+++ b/dao/src/main/java/io/syndesis/dao/validation/extension/NoDuplicateExtensionValidator.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.dao.validation.extension;
+
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.model.extension.Extension;
+import io.syndesis.model.validation.extension.NoDuplicateExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Set;
+
+public class NoDuplicateExtensionValidator implements ConstraintValidator<NoDuplicateExtension, Extension> {
+
+    @Autowired
+    private DataManager dataManager;
+
+    @Override
+    public void initialize(final NoDuplicateExtension validExtension) {
+        // The annotation has no useful values
+    }
+
+    @Override
+    public boolean isValid(final Extension value, final ConstraintValidatorContext context) {
+        if (value.getExtensionId() == null) {
+            return true;
+        }
+
+        Set<String> ids = dataManager.fetchIdsByPropertyValue(Extension.class, "extensionId", value.getExtensionId());
+        if (value.getId().isPresent()) {
+            ids.remove(value.getId().get());
+        }
+
+        for (String id : ids) {
+            Extension other = dataManager.fetch(Extension.class, id);
+            boolean installed = other.getStatus().isPresent() && other.getStatus().get() == Extension.Status.Installed;
+            if (installed) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/dao/src/main/resources/META-INF/validation/extension-constraint.xml
+++ b/dao/src/main/resources/META-INF/validation/extension-constraint.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<constraint-mappings xmlns="http://jboss.org/xml/ns/javax/validation/mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://jboss.org/xml/ns/javax/validation/mapping validation-mapping-1.1.xsd" version="1.1">
+
+  <constraint-definition annotation="io.syndesis.model.validation.extension.NoDuplicateExtension">
+    <validated-by include-existing-validators="true">
+      <value>io.syndesis.dao.validation.extension.NoDuplicateExtensionValidator</value>
+    </validated-by>
+  </constraint-definition>
+
+</constraint-mappings>
+

--- a/model/src/main/java/io/syndesis/model/extension/Extension.java
+++ b/model/src/main/java/io/syndesis/model/extension/Extension.java
@@ -21,19 +21,32 @@ import io.syndesis.model.WithConfigurationProperties;
 import io.syndesis.model.WithId;
 import io.syndesis.model.WithName;
 import io.syndesis.model.WithTags;
+import io.syndesis.model.validation.NonBlockingValidations;
+import io.syndesis.model.validation.extension.NoDuplicateExtension;
 import org.immutables.value.Value;
 
+import javax.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.util.Optional;
 
 @Value.Immutable
 @JsonDeserialize(builder = Extension.Builder.class)
+@NoDuplicateExtension(groups = NonBlockingValidations.class)
 public interface Extension extends WithId<Extension>, WithName, WithTags, WithConfigurationProperties, Serializable {
+
+    enum Status { Draft, Installed, Deleted}
 
     @Override
     default Kind getKind() {
         return Kind.Extension;
     }
 
+    Optional<Status> getStatus();
+
+    @NotNull
+    String getExtensionId();
+
+    @NotNull
     String getDescription();
 
     @Override

--- a/model/src/main/java/io/syndesis/model/validation/NonBlockingValidations.java
+++ b/model/src/main/java/io/syndesis/model/validation/NonBlockingValidations.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.validation;
+
+/**
+ * Group of non-blocking validations, such as warnings for the user.
+ */
+public interface NonBlockingValidations {
+    // tag interface
+}

--- a/model/src/main/java/io/syndesis/model/validation/extension/NoDuplicateExtension.java
+++ b/model/src/main/java/io/syndesis/model/validation/extension/NoDuplicateExtension.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.validation.extension;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Constraint(validatedBy = {})
+@Target(TYPE)
+@Retention(RUNTIME)
+@Documented
+public @interface NoDuplicateExtension {
+
+    String message() default "{io.syndesis.model.validation.NoDuplicateExtension.message}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+}

--- a/rest/src/main/java/io/syndesis/rest/v1beta1/util/ExtensionAnalyzer.java
+++ b/rest/src/main/java/io/syndesis/rest/v1beta1/util/ExtensionAnalyzer.java
@@ -51,6 +51,8 @@ public class ExtensionAnalyzer {
         }
 
         return new Extension.Builder()
+            .extensionId("dummy-extension")
+            .status(Extension.Status.Draft)
             .name("Dummy")
             .description("Dummy description")
             .build();

--- a/runtime/src/main/resources/messages.properties
+++ b/runtime/src/main/resources/messages.properties
@@ -20,3 +20,8 @@ io.syndesis.model.validation.UniqueProperty.message = Value '${nonUnique}' is no
 javax.validation.constraints.NotNull.message = Value is required
 
 org.hibernate.validator.constraints.NotEmpty.message = Value is required
+
+
+
+# Tech Extensions
+io.syndesis.model.validation.NoDuplicateExtension.message = The tech extension already exists and will be upgraded


### PR DESCRIPTION
This adds services to validate the tech extension in order to detect blocking/non-blocking errors (the HTTP status code determines the kind of errors). Both kind of alerts are computed using bean validation. I've used the `NonBlockingValidation` group for checking non-blocking errors.