### PR TITLE
refactor: use the image provided m2 repository.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ node {
                     containerEnvVar(key:'GITHUB_OAUTH_CLIENT_ID', value: "${env.GITHUB_OAUTH_CLIENT_ID}"),
                     containerEnvVar(key:'GITHUB_OAUTH_CLIENT_SECRET', value: "${env.GITHUB_OAUTH_CLIENT_SECRET}")
                 ],
-                serviceAccount: "jenkins", mavenSettingsXmlSecret: 'm2-settings') {
+                serviceAccount: "jenkins", mavenSettingsXmlSecret: 'm2-settings', mavenLocalRepositoryPath: '/home/jenkins/mvnrepo/') {
                 inside {
                     def testingNamespace = generateProjectName()
 


### PR DESCRIPTION
So, as of openshift 3.6.0 our approach of mounting m2 settings under ~/.m2 and local maven repo under ~/.m2/repository ( a mount within a mount ) does no longer work.

We need to use different paths.