### PR TITLE
fix: redeclare commons-io as compile dependency

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -744,6 +744,11 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
@@ -778,12 +783,6 @@
     <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock-standalone</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>test</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
HTTP Components we use via Resteasy JAX-RS client require `commons-io`,
this adds `commons-io` as compile dependency.

Fixes #806