### PR TITLE
feat: client error exception mapper

### DIFF
--- a/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ClientErrorExceptionMapper.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ClientErrorExceptionMapper.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.exception;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.springframework.stereotype.Component;
+
+@Component
+@Provider
+public class ClientErrorExceptionMapper implements ExceptionMapper<ClientErrorException> {
+
+    @Override
+    public Response toResponse(final ClientErrorException exception) {
+        final Response response = exception.getResponse();
+
+        final RestError error = new RestError(exception.getMessage(), "Given request is not acceptable", null,
+            response.getStatus());
+
+        return Response.fromResponse(response).type(MediaType.APPLICATION_JSON_TYPE).entity(error).build();
+    }
+
+}


### PR DESCRIPTION
Adds exception mapper to better handle client errors. Previously client
errors were equated with 500 internal server error, for JAX-RS client
errors have appropriate status codes and messages this surfaces those.